### PR TITLE
fix: add telemetry log path import in auth service

### DIFF
--- a/server/auth-service.js
+++ b/server/auth-service.js
@@ -10,6 +10,7 @@ const {
     serverLogger: logger,
     clientLogger,
     telemetryLogger,
+    telemetryLogPath,
     rotateClientLogs,
     rotateTelemetryLogs,
     rotateServerLogs,


### PR DESCRIPTION
## Summary
- import `telemetryLogPath` in `server/auth-service.js`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe1849098832fa6e987f465460c12