### PR TITLE
Enable auto setup on container start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,6 +38,7 @@
         57070,
         57000
     ],
+    "postStartCommand": "bash /workspace/outliner/scripts/codex-setp.sh",
     // node ユーザーとして接続
     "remoteUser": "node"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Prioritize performance.
 - User has set up test users in server/auth-service.js and wants to clear all Firestore emulator data during development.
 - Always use environment variables for emulator host configuration instead of hardcoding IP addresses like 192.168.50.13, as CI environments will have different host values.
 - User prefers fixing import.meta environment variable loading issues at the root cause rather than using error handling workarounds.
+- Always run `scripts/codex-setp.sh` when the container starts to set up local test services.
 
 # Cursor and Selection Management
 - Key files: Cursor.ts, EditorOverlay.svelte, EditorOverlayStore.svelte.ts, OutlinerItem.svelte.

--- a/scripts/codex-setp.sh
+++ b/scripts/codex-setp.sh
@@ -1,5 +1,11 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+set -euo pipefail
+
+# ポート番号のデフォルト値
+: "${TEST_FLUID_PORT:=7092}"
+: "${TEST_API_PORT:=7091}"
+: "${VITE_PORT:=7090}"
 
 chmod +x ${ROOT_DIR}/scripts/setup-local-env.sh
 ${ROOT_DIR}/scripts/setup-local-env.sh
@@ -9,7 +15,7 @@ source ${ROOT_DIR}/server/.env
 source ${ROOT_DIR}/client/.env
 set +a
 
-npm install -g firebase-tools tinylicious dotenv-cli
+npm install -g firebase-tools tinylicious dotenv-cli cross-env
 curl -fsSL https://dprint.dev/install.sh | sh
 
 pwd
@@ -21,8 +27,12 @@ mkdir -p ${ROOT_DIR}/logs/
 mkdir -p client/logs/
 mkdir -p client/e2e/logs/
 mkdir -p server/logs/
+mkdir -p functions/logs/
     # サーバーサイドの準備
 cd ${ROOT_DIR}/server
+npm ci
+    # Firebase Functionsの準備
+cd ${ROOT_DIR}/functions
 npm ci
     # クライアントの準備
 cd ${ROOT_DIR}/client


### PR DESCRIPTION
## Summary
- ensure codex setup script installs dependencies and sets default ports
- run setup script automatically when container starts
- document required setup in AGENTS.md

## Testing
- `bash ./scripts/run-tests.sh` *(fails: xvfb-run: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684296ea4004832fa800092f01d9e432