### PR TITLE
Fix setup script for client tests

### DIFF
--- a/scripts/codex-setp.sh
+++ b/scripts/codex-setp.sh
@@ -51,6 +51,11 @@ if ! command -v lsof >/dev/null; then
   apt-get update && apt-get install -y lsof
 fi
 
+if ! command -v xvfb-run >/dev/null; then
+  echo "Installing xvfb for headless browser tests"
+  apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends xvfb
+fi
+
 chmod +x ${ROOT_DIR}/scripts/kill_ports.sh
 ${ROOT_DIR}/scripts/kill_ports.sh
 


### PR DESCRIPTION
## Summary
- ensure `xvfb` is installed in `codex-setp.sh` so that client E2E tests can run

## Testing
- `bash -n scripts/codex-setp.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842aef8bbc8832f89a7a52b0873560c