### PR TITLE
Fix compile error in BacklinkPanel

### DIFF
--- a/client/src/components/BacklinkPanel.svelte
+++ b/client/src/components/BacklinkPanel.svelte
@@ -293,7 +293,7 @@ onDestroy(() => {
 }
 </style>
 
-<script context="module">
+<script lang="ts" context="module">
 // コンテキスト内のリンクをハイライトする
 function highlightLinkInContext(context: string, pageName: string): string {
     if (!context || !pageName) return context;


### PR DESCRIPTION
## Summary
- enable TypeScript parsing for BacklinkPanel module script

## Testing
- `npm run test:unit` *(fails: fluidService > getContainer test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684654b05b18832f9537d4c485c60dbc