### PR TITLE
Remove engine strict from client npmrc

### DIFF
--- a/client/.npmrc
+++ b/client/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
## Summary
- remove engine-strict setting from client/.npmrc to allow installation with Node 22

## Testing
- `npm ci --silent` *(fails: process killed)*


------
https://chatgpt.com/codex/tasks/task_e_68469da11e00832fa48d523da742cd42