### PR TITLE
Attempt to prepare E2E test env

### DIFF
--- a/client/e2e/utils/testHelpers.ts
+++ b/client/e2e/utils/testHelpers.ts
@@ -20,8 +20,16 @@ export class TestHelpers {
         testInfo: any,
         lines: string[] = [],
     ): Promise<{ projectName: string; pageName: string; }> {
-        // ホームページにアクセス
+        // ホームページにアクセスしてアプリの初期化を待つ
         await page.goto("/");
+
+        // ページが完全に初期化されるのを待機
+        await page.waitForFunction(() => {
+            return (
+                (window as any).__FLUID_STORE__ !== undefined &&
+                (window as any).__SVELTE_GOTO__ !== undefined
+            );
+        });
 
         page.goto = async (
             url: string,
@@ -114,6 +122,11 @@ export class TestHelpers {
                 }
             }
         }, { projectName, pageName, lines });
+
+        // FluidClient が設定されるまで待機
+        await page.waitForFunction(() => {
+            return (window as any).__FLUID_STORE__?.fluidClient !== undefined;
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- install dependencies, install Playwright browsers
- adjust `prepareTestEnvironment` helper to wait for Fluid store and goto to exist
- ensure created container is ready before proceeding

## Testing
- `npm run ci:test:e2e:xvfb -- e2e/core/add-text.spec.ts` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_68475e0b53bc832fb32b8df515e93d7b