### PR TITLE
Adjust setup script for Playwright environment

### DIFF
--- a/scripts/codex-setp.sh
+++ b/scripts/codex-setp.sh
@@ -35,6 +35,7 @@ if [ -f ${ROOT_DIR}/client/.env.test ]; then
 fi
 export NODE_ENV=test
 export TEST_ENV=localhost
+export LIX_SDK_POSTHOG_TOKEN=""
 set +a
 
 FIREBASE_PROJECT_ID="outliner-d57b0"
@@ -92,7 +93,9 @@ if ! command -v lsof >/dev/null || ! command -v xvfb-run >/dev/null; then
     lsof xvfb > /dev/null
 fi
 
-npx -y playwright install --with-deps chromium
+if [ ! -f "$HOME/.cache/ms-playwright/chromium_headless_shell-1176/chrome-linux/headless_shell" ]; then
+  npx -y playwright install --with-deps chromium
+fi
 
 chmod +x ${ROOT_DIR}/scripts/kill_ports.sh
 ${ROOT_DIR}/scripts/kill_ports.sh || true


### PR DESCRIPTION
## Summary
- update `codex-setp.sh` to disable PostHog telemetry
- ensure Playwright browser installation is skipped when already installed

## Testing
- `bash scripts/codex-setp.sh`
- `cd client && npm run ci:test:e2e:xvfb -- e2e/core/basic.spec.ts`
- `npm run ci:test:e2e:xvfb` *(fails: 5 failed, 150 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68490c875c40832faa6c1954b22bfa73