### PR TITLE
Disable proxy in setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Prioritize performance.
 - Always use environment variables for emulator host configuration instead of hardcoding IP addresses like 192.168.50.13, as CI environments will have different host values.
 - User prefers fixing import.meta environment variable loading issues at the root cause rather than using error handling workarounds.
 - Always run `scripts/codex-setp.sh` when the container starts to set up local test services.
+- The setup script temporarily unsets HTTP_PROXY and HTTPS_PROXY and sets `npm_config_http-proxy=''` so npm ignores proxy settings.
 
 # Cursor and Selection Management
 - Key files: Cursor.ts, EditorOverlay.svelte, EditorOverlayStore.svelte.ts, OutlinerItem.svelte.

--- a/scripts/codex-setp.sh
+++ b/scripts/codex-setp.sh
@@ -3,6 +3,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 set -euo pipefail
 
+# Disable proxy settings for npm and related tools
+unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy || true
+export npm_config_http-proxy=''
+export npm_config_https-proxy=''
+
 wait_for_port() {
   local port="$1"
   local retry=60


### PR DESCRIPTION
## Summary
- disable HTTP proxy settings in `scripts/codex-setp.sh`
- document proxy reset step in `AGENTS.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bd8cbd4b4832fb5cf53510ba785cf