### PR TITLE
docs: add requirements for feature map script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ npm install
 # Firebase Functions側の依存関係
 cd ../functions
 npm install
+
+# Python依存関係 (feature-map スクリプト用)
+cd ..
+pip install -r scripts/requirements.txt
 ```
 
 2. 環境変数を設定:

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -15,6 +15,7 @@
 | CLM-0101 | アイテム間移動時のカーソル重複と入力分散問題 | — | implemented |
 | CLM-0102 | 空のテキストアイテムでのカーソル移動と複数回のキーボード操作 | — | implemented |
 | CLM-0103 | フォーマット文字列でのカーソル操作 | — | implemented |
+| COL-0001 | 他ユーザーのカーソル表示 | — | implemented |
 | FLD-0001 | プロジェクトタイトルからFluidClientを取得する機能 | — | implemented |
 | FMT-0001 | フォーマット表示 | — | implemented |
 | FMT-0002 | フォーマット組み合わせ | — | implemented |

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+loguru


### PR DESCRIPTION
## Summary
- add Python requirements file in scripts
- document how to install Python deps when setting up the dev environment
- update auto-generated feature map

## Testing
- `pre-commit run --files README.md scripts/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684bfd2faa08832f9e9a2c8e4dc85212