### PR TITLE
Implement WASM DB and Graph View

### DIFF
--- a/client/e2e/new/DBW-0001.spec.ts
+++ b/client/e2e/new/DBW-0001.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+// E2E test for Client-Side WASM DB
+
+test.describe("DBW-0001: WASM DB container meta", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo, [], true, true);
+    });
+
+    test("creates container meta and lists it", async ({ page }) => {
+        const id = await page.evaluate(async () => {
+            const svc = window.__FLUID_SERVICE__;
+            const client = await svc.createNewContainer("WASM Test");
+            return client.containerId;
+        });
+
+        const list = await page.evaluate(async () => {
+            const svc = window.__FLUID_SERVICE__;
+            return await svc.listContainers();
+        });
+
+        const found = list.find((c: any) => c.id === id);
+        expect(found).toBeTruthy();
+        expect(found.title).toBe("WASM Test");
+    });
+});
+

--- a/client/e2e/new/GVI-0001.spec.ts
+++ b/client/e2e/new/GVI-0001.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("GVI-0001: Graph View", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+        await page.goto("/graph");
+    });
+
+    test("renders graph nodes and links", async ({ page }) => {
+        await expect(page.locator("svg#graph-svg circle").first()).toBeVisible();
+        await expect(page.locator("svg#graph-svg line").first()).toBeVisible();
+    });
+});
+

--- a/client/src/components/GraphView.svelte
+++ b/client/src/components/GraphView.svelte
@@ -3,34 +3,19 @@ import { onMount } from 'svelte';
 import { goto } from '$app/navigation';
 import * as d3 from 'd3';
 import { store } from '../stores/store.svelte';
+import { buildGraphData, type GraphNode, type GraphLink } from '../lib/graph';
 
-interface NodeData {
-    id: string;
-    title: string;
-}
-interface LinkData {
-    source: string;
-    target: string;
-}
+type NodeData = GraphNode;
+type LinkData = GraphLink;
 
 let nodes: NodeData[] = [];
 let links: LinkData[] = [];
 
-function buildGraphData() {
+function updateGraphData() {
     const pages = store.pages.current ?? [];
-    nodes = pages.map(p => ({ id: p.id, title: p.text }));
-    links = [];
-    const internalLinkRegex = /\[([^\[\]\/\-][^\[\]]*?)\]/g;
-    for (const page of pages) {
-        let match;
-        while ((match = internalLinkRegex.exec(page.text))) {
-            const targetTitle = match[1];
-            const target = pages.find(p => p.text === targetTitle);
-            if (target) {
-                links.push({ source: page.id, target: target.id });
-            }
-        }
-    }
+    const result = buildGraphData(pages);
+    nodes = result.nodes;
+    links = result.links;
 }
 
 function renderGraph() {
@@ -112,7 +97,7 @@ function renderGraph() {
 }
 
 function updateGraph() {
-    buildGraphData();
+    updateGraphData();
     renderGraph();
 }
 

--- a/client/src/lib/db/sqliteWorker.ts
+++ b/client/src/lib/db/sqliteWorker.ts
@@ -1,6 +1,6 @@
-// import { createDialect } from 'sqlite-wasm-kysely';
-// import { createInMemoryDatabase } from 'sqlite-wasm-kysely/dist/util';
-// import { Kysely, sql } from 'kysely';
+import { createDialect } from 'sqlite-wasm-kysely';
+import { createInMemoryDatabase } from 'sqlite-wasm-kysely/dist/util';
+import { Kysely } from 'kysely';
 
 interface Page {
     id: string;
@@ -8,22 +8,20 @@ interface Page {
     content: string;
 }
 
-// let db: Kysely<{ pages: Page; }> | undefined;
+let db: Kysely<{ pages: Page }>|undefined;
 
 async function init() {
-    // if (!db) {
-    //     const sqlite = await createInMemoryDatabase({ readOnly: false });
-    //     db = new Kysely<{ pages: Page; }>({
-    //         dialect: createDialect({ database: sqlite }),
-    //     });
-    //     await db.schema
-    //         .createTable("pages")
-    //         .ifNotExists()
-    //         .addColumn("id", "text", col => col.primaryKey())
-    //         .addColumn("title", "text")
-    //         .addColumn("content", "text")
-    //         .execute();
-    // }
+    if (!db) {
+        const sqlite = await createInMemoryDatabase({ readOnly: false });
+        db = new Kysely<{ pages: Page }>({ dialect: createDialect({ database: sqlite }) });
+        await db.schema
+            .createTable('pages')
+            .ifNotExists()
+            .addColumn('id', 'text', col => col.primaryKey())
+            .addColumn('title', 'text')
+            .addColumn('content', 'text')
+            .execute();
+    }
 }
 
 self.onmessage = async (e: MessageEvent) => {
@@ -33,39 +31,44 @@ self.onmessage = async (e: MessageEvent) => {
         // if (!db) throw new Error("DB not initialized");
         let result: any;
         switch (type) {
+            case "init":
+                // initialization handled lazily
+                result = true;
+                break;
             case "addPage":
-                // await db
-                //     .insertInto("pages")
-                //     .values(payload)
-                //     .execute();
+                await db!
+                    .insertInto("pages")
+                    .values(payload)
+                    .execute();
                 result = true;
                 break;
             case "getPage":
-                // result = await db
-                //     .selectFrom("pages")
-                //     .selectAll()
-                //     .where("id", "=", payload.id)
-                //     .executeTakeFirst();
-                result = null;
+                result = await db!
+                    .selectFrom("pages")
+                    .selectAll()
+                    .where("id", "=", payload.id)
+                    .executeTakeFirst();
                 break;
             case "updatePage":
-                // await db
-                //     .updateTable("pages")
-                //     .set(payload)
-                //     .where("id", "=", payload.id)
-                //     .execute();
+                await db!
+                    .updateTable("pages")
+                    .set(payload)
+                    .where("id", "=", payload.id)
+                    .execute();
                 result = true;
                 break;
             case "deletePage":
-                // await db
-                //     .deleteFrom("pages")
-                //     .where("id", "=", payload.id)
-                //     .execute();
+                await db!
+                    .deleteFrom("pages")
+                    .where("id", "=", payload.id)
+                    .execute();
                 result = true;
                 break;
             case "getAllPages":
-                // result = await db.selectFrom("pages").selectAll().execute();
-                result = [];
+                result = await db!
+                    .selectFrom("pages")
+                    .selectAll()
+                    .execute();
                 break;
             default:
                 throw new Error("Unknown type");

--- a/client/src/lib/graph.ts
+++ b/client/src/lib/graph.ts
@@ -1,0 +1,32 @@
+export interface GraphNode {
+    id: string;
+    title: string;
+}
+
+export interface GraphLink {
+    source: string;
+    target: string;
+}
+
+export interface GraphData {
+    nodes: GraphNode[];
+    links: GraphLink[];
+}
+
+export function buildGraphData(pages: Array<{ id: string; text: string }>): GraphData {
+    const nodes: GraphNode[] = pages.map(p => ({ id: p.id, title: p.text }));
+    const links: GraphLink[] = [];
+    const internalLinkRegex = /\[([^\[\]\/\-][^\[\]]*?)\]/g;
+    for (const page of pages) {
+        let match: RegExpExecArray | null;
+        while ((match = internalLinkRegex.exec(page.text))) {
+            const targetTitle = match[1];
+            const target = pages.find(p => p.text === targetTitle);
+            if (target) {
+                links.push({ source: page.id, target: target.id });
+            }
+        }
+    }
+    return { nodes, links };
+}
+

--- a/client/src/tests/graph.test.ts
+++ b/client/src/tests/graph.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { buildGraphData } from '../lib/graph';
+
+describe('graph builder', () => {
+    it('builds nodes and links from pages', () => {
+        const pages = [
+            { id: '1', text: 'home [page2]' },
+            { id: '2', text: 'page2' },
+        ];
+        const result = buildGraphData(pages);
+        expect(result.nodes.length).toBe(2);
+        expect(result.links.length).toBe(1);
+        expect(result.links[0]).toEqual({ source: '1', target: '2' });
+    });
+});
+

--- a/client/src/tests/wasmDb.test.ts
+++ b/client/src/tests/wasmDb.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { saveContainerMeta, getAllContainerMeta } from '../lib/wasmDb';
+
+describe('wasmDb', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('saves and retrieves container metadata', async () => {
+        await saveContainerMeta('c1', 'Test Project');
+        const all = await getAllContainerMeta();
+        expect(all.length).toBe(1);
+        expect(all[0].id).toBe('c1');
+        expect(all[0].title).toBe('Test Project');
+    });
+});
+

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -824,7 +824,14 @@
   title: 'Client-Side WASM DB'
   description: 'オフライン操作と高速検索を実現するWebAssemblyデータベース'
   category: application
-  status: draft
+  status: implemented
+  components:
+    - client/src/lib/wasmDb.ts
+    - client/src/lib/db/dbService.ts
+    - client/src/lib/db/sqliteWorker.ts
+  tests:
+    - client/src/tests/wasmDb.test.ts
+    - client/e2e/new/DBW-0001.spec.ts
 
 - id: FFI-0001
   title: 'Fluid Framework Integration'
@@ -842,7 +849,14 @@
   title: 'Graph View'
   description: 'ページ間のリンクを視覚化するグラフ表示機能'
   category: navigation
-  status: draft
+  status: implemented
+  components:
+    - client/src/components/GraphView.svelte
+    - client/src/routes/graph/+page.svelte
+    - client/src/lib/graph.ts
+  tests:
+    - client/src/tests/graph.test.ts
+    - client/e2e/new/GVI-0001.spec.ts
 
 - id: SRE-001
   title: Advanced Search & Replace


### PR DESCRIPTION
## Summary
- implement client-side WASM DB worker
- add graph builder utility and wire into GraphView
- add unit tests for WASM DB and graph builder
- add e2e tests for WASM DB and Graph View
- mark DBW-0001 and GVI-0001 as implemented

## Testing
- `bash scripts/codex-setp.sh` *(fails: Error: read EIO)*
- `npm run test:unit`
- `npx playwright test client/e2e/new/DBW-0001.spec.ts client/e2e/new/GVI-0001.spec.ts --reporter=list` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68500ae54bbc832fad6e545e40acc543