### PR TITLE
Introduce LOCAL_HOST variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ cp .env.example .env
 cd ../server
 cp .env.example .env
 
+# ネットワーク経由でアクセスする場合は .env の `LOCAL_HOST` にローカル IP を設定
+
 # Firebase Functions側
 cd ../functions
 cp .env.example .env

--- a/client/.env.example
+++ b/client/.env.example
@@ -2,6 +2,9 @@
 VITE_IS_TEST=false
 VITE_IS_TEST_MODE_FORCE_E2E=false
 
+# Local network host used by development scripts
+LOCAL_HOST=localhost
+
 # サーバー設定
 VITE_HOST=localhost
 VITE_PORT=7070

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -5,6 +5,9 @@ AZURE_PRIMARY_KEY=your-primary-key
 AZURE_SECONDARY_KEY=your-secondary-key
 AZURE_ACTIVE_KEY=primary
 
+# Local network host used by development scripts
+LOCAL_HOST=localhost
+
 # Firebase設定
 # firebase-adminsdk.jsonファイルをサーバーディレクトリに配置してください
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,6 @@
 # 環境設定
 NODE_ENV=development
+LOCAL_HOST=localhost
 
 # サーバー設定
 PORT=7071

--- a/server/README.md
+++ b/server/README.md
@@ -24,6 +24,7 @@ cp .env.example .env
 3. 環境変数を設定:
    - Azure Fluid Relay設定（テナントID、エンドポイント、プライマリキー）
    - サーバー設定（ポート、CORS設定など）
+   - `LOCAL_HOST` をローカルネットワークのIPアドレスに設定（デフォルトは`localhost`）
 
 4. Firebase Admin SDK JSONファイルをダウンロードして配置:
    - `firebase-adminsdk.json` をこのディレクトリに配置

--- a/server/scripts/test-dev-auth.js
+++ b/server/scripts/test-dev-auth.js
@@ -3,7 +3,8 @@ require("dotenv").config();
 const fetch = require("node-fetch");
 
 // APIサーバーのURL
-const API_BASE_URL = process.env.API_BASE_URL || "http://192.168.50.16:7071";
+const LOCAL_HOST = process.env.LOCAL_HOST || "localhost";
+const API_BASE_URL = process.env.API_BASE_URL || `http://${LOCAL_HOST}:7071`;
 
 // テスト用認証情報
 const testCredentials = {

--- a/server/start-with-ngrok.js
+++ b/server/start-with-ngrok.js
@@ -3,6 +3,9 @@ const { spawn } = require("child_process");
 const path = require("path");
 const { setupNgrokUrl } = require("./utils/ngrok-helper");
 
+// Local host configuration
+const LOCAL_HOST = process.env.LOCAL_HOST || "localhost";
+
 // サーバーとngrokのプロセスを格納するオブジェクト
 const processes = {
     ngrok: null,
@@ -163,7 +166,7 @@ async function start() {
 
         console.log("\n=====================================================");
         console.log("アプリケーションが正常に起動しました！");
-        console.log(`バックエンドサーバー: http://192.168.50.13:${port}`);
+        console.log(`バックエンドサーバー: http://${LOCAL_HOST}:${port}`);
         if (ngrokUrl) {
             console.log(`パブリックURL: ${ngrokUrl}`);
         }

--- a/server/utils/ngrok-helper.js
+++ b/server/utils/ngrok-helper.js
@@ -3,6 +3,9 @@ const fs = require("fs");
 const path = require("path");
 const dotenv = require("dotenv");
 
+// Local host configuration
+const LOCAL_HOST = process.env.LOCAL_HOST || "localhost";
+
 // .envファイルのパス
 const envPath = path.join(__dirname, "..", ".env");
 
@@ -13,7 +16,7 @@ const envPath = path.join(__dirname, "..", ".env");
 async function getNgrokPublicUrl() {
     try {
         // ngrokのAPIからトンネル情報を取得
-        const response = await axios.get("http://192.168.50.13:4040/api/tunnels");
+        const response = await axios.get(`http://${LOCAL_HOST}:4040/api/tunnels`);
         const tunnels = response.data.tunnels;
 
         // HTTPS URLを探す


### PR DESCRIPTION
## Summary
- add `LOCAL_HOST` variable to `.env.example` files
- use `LOCAL_HOST` in server scripts instead of hardcoded IPs
- document `LOCAL_HOST` usage in server README and main README

## Testing
- `npm test` *(fails: request to http://169.254.169.254/computeMetadata/v1/instance failed)*

------
https://chatgpt.com/codex/tasks/task_e_68500b0bfe44832fbb60362a61bd4159