### PR TITLE
Implement admin check for user listing

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -803,6 +803,19 @@
   components:
     - server/auth-service.js
 
+- id: API-0003
+  title: 'コンテナユーザー一覧取得の管理者チェック'
+  description: '/api/get-container-users で管理者権限を検証する機能'
+  category: api-server
+  status: implemented
+  acceptance:
+    - '管理者ロールを持つトークンでユーザー一覧を取得できる'
+    - '管理者でない場合は 403 エラーが返る'
+  tests:
+    - server/tests/get-container-users-admin.test.js
+  components:
+    - server/auth-service.js
+
 - id: COL-0001
   title: '他ユーザーのカーソル表示'
   description: '複数ユーザーが同じページを編集しているとき、他ユーザーのカーソル位置をリアルタイムに表示する'

--- a/server/auth-service.js
+++ b/server/auth-service.js
@@ -350,7 +350,11 @@ app.post("/api/get-container-users", async (req, res) => {
         const decodedToken = await admin.auth().verifyIdToken(idToken);
         const userId = decodedToken.uid;
 
-        // TODO: 管理者権限チェックを追加する場合はここに実装
+        // 管理者権限チェック
+        const isAdmin = decodedToken.role === "admin";
+        if (!isAdmin) {
+            return res.status(403).json({ error: "Admin privileges required" });
+        }
 
         const containerDoc = await containerUsersCollection.doc(containerId).get();
 

--- a/server/tests/get-container-users-admin.test.js
+++ b/server/tests/get-container-users-admin.test.js
@@ -1,0 +1,73 @@
+const { describe, it, before, beforeEach } = require("mocha");
+const { expect } = require("chai");
+const admin = require("firebase-admin");
+const request = require("supertest");
+
+const API_PORT = process.env.TEST_API_PORT || 7091;
+const API_BASE_URL = `http://localhost:${API_PORT}`;
+const AUTH_HOST = process.env.FIREBASE_AUTH_EMULATOR_HOST || "localhost:59099";
+
+async function signInWithCustomToken(customToken) {
+    const url = `http://${AUTH_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=fake-api-key`;
+    const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: customToken, returnSecureToken: true }),
+    });
+    const data = await res.json();
+    return data.idToken;
+}
+
+async function createUser(role) {
+    const email = `user-${role}-${Date.now()}@example.com`;
+    const userRecord = await admin.auth().createUser({ email, password: "pw12345" });
+    await admin.auth().setCustomUserClaims(userRecord.uid, { role });
+    const customToken = await admin.auth().createCustomToken(userRecord.uid, { role });
+    const idToken = await signInWithCustomToken(customToken);
+    return { userRecord, idToken };
+}
+
+let adminUser;
+let normalUser;
+let containerId;
+
+before(async function () {
+    process.env.FIREBASE_AUTH_EMULATOR_HOST = process.env.FIREBASE_AUTH_EMULATOR_HOST || "localhost:59099";
+    process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || "localhost:58080";
+    if (admin.apps.length === 0) {
+        const serviceAccount = require("../firebase-adminsdk.json");
+        admin.initializeApp({
+            credential: admin.credential.cert(serviceAccount),
+            projectId: serviceAccount.project_id,
+        });
+    }
+    adminUser = await createUser("admin");
+    normalUser = await createUser("user");
+});
+
+beforeEach(async function () {
+    containerId = `container-${Date.now()}`;
+    await admin.firestore().collection("containerUsers").doc(containerId).set({
+        accessibleUserIds: [adminUser.userRecord.uid, normalUser.userRecord.uid],
+    });
+});
+
+describe("/api/get-container-users admin check (API-0003)", function () {
+    it("admin can list users", async function () {
+        const res = await request(API_BASE_URL)
+            .post("/api/get-container-users")
+            .send({ idToken: adminUser.idToken, containerId })
+            .expect(200);
+
+        expect(res.body).to.have.property("users");
+        expect(res.body.users).to.include(adminUser.userRecord.uid);
+        expect(res.body.users).to.include(normalUser.userRecord.uid);
+    });
+
+    it("non-admin user is forbidden", async function () {
+        await request(API_BASE_URL)
+            .post("/api/get-container-users")
+            .send({ idToken: normalUser.idToken, containerId })
+            .expect(403);
+    });
+});


### PR DESCRIPTION
## Summary
- verify admin role before returning container user list
- document new API-0003 feature
- add Firebase emulator test for admin-only listing

## Testing
- `scripts/codex-setp.sh` *(fails: Error: read EIO)*
- `npx mocha tests/get-container-users-admin.test.js tests/simple-test.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68500b1c30cc832f8f8217d6a44ed7b7