### PR TITLE
Add CHT-001 chart component test

### DIFF
--- a/client/e2e/new/CHT-001.spec.ts
+++ b/client/e2e/new/CHT-001.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("CHT-001: Chart Component", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo, [], true, true);
+        await page.goto("/graph", { waitUntil: "domcontentloaded" });
+    });
+
+    test("chart renders page item counts", async ({ page }) => {
+        const pageCount = await page.evaluate(() => {
+            const store = (window as any).appStore;
+            return store.pages.current.length;
+        });
+        await expect(page.locator("svg#chart-svg rect")).toHaveCount(pageCount);
+    });
+
+    test("chart updates when data changes", async ({ page }) => {
+        const newPageName = `p-${Date.now()}`;
+        await TestHelpers.createTestPageViaAPI(page, newPageName, []);
+        await page.goto("/graph", { waitUntil: "domcontentloaded" });
+        const pageCount = await page.evaluate(() => (window as any).appStore.pages.current.length);
+        await expect(page.locator("svg#chart-svg rect")).toHaveCount(pageCount);
+    });
+});

--- a/client/src/components/ChartComponent.svelte
+++ b/client/src/components/ChartComponent.svelte
@@ -12,9 +12,17 @@ interface Props {
 }
 
 let { data = [] }: Props = $props();
+let mounted = false;
 
 onMount(() => {
+    mounted = true;
     render();
+});
+
+$effect(() => {
+    if (mounted) {
+        render();
+    }
 });
 
 function render() {

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -882,7 +882,8 @@
   status: implemented
   components:
     - src/components/ChartComponent.svelte
-  tests: []
+  tests:
+    - client/e2e/new/CHT-001.spec.ts
 
 - id: TBL-0001
   title: Editable JOIN Table


### PR DESCRIPTION
## Summary
- trigger rerender when ChartComponent data changes
- add CHT-001 Playwright E2E test
- register test in docs/client-features.yaml

## Testing
- `npx playwright test e2e/new/CHT-001.spec.ts --project=new` *(fails: createNewContainer undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68500b34243c832f9d0b8b9e1e105ee7