### PR TITLE
Fix Node EIO error when starting dev servers

### DIFF
--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -176,7 +176,7 @@ start_tinylicious() {
 start_api_server() {
   echo "Starting API server on port ${TEST_API_PORT}..."
   cd "${ROOT_DIR}/server"
-  npx dotenvx run --env-file=.env.test -- npm --experimental-network-inspection run dev -- --host 0.0.0.0 --port ${TEST_API_PORT} 2>&1 | tee "${ROOT_DIR}/server/logs/test-auth-service-tee.log" &
+  npx dotenvx run --env-file=.env.test -- npm --experimental-network-inspection run dev -- --host 0.0.0.0 --port ${TEST_API_PORT} </dev/null 2>&1 | tee "${ROOT_DIR}/server/logs/test-auth-service-tee.log" &
   cd "${ROOT_DIR}"
 }
 
@@ -184,7 +184,7 @@ start_api_server() {
 start_sveltekit_server() {
   echo "Starting SvelteKit server on port ${VITE_PORT}..."
   cd "${ROOT_DIR}/client"
-  npx dotenvx run --env-file=.env.test -- npm --experimental-network-inspection run dev -- --host 0.0.0.0 --port ${VITE_PORT} 2>&1 | tee "${ROOT_DIR}/server/logs/test-svelte-kit.log" &
+  npx dotenvx run --env-file=.env.test -- npm --experimental-network-inspection run dev -- --host 0.0.0.0 --port ${VITE_PORT} </dev/null 2>&1 | tee "${ROOT_DIR}/server/logs/test-svelte-kit.log" &
   cd "${ROOT_DIR}"
 }
 


### PR DESCRIPTION
## Summary
- redirect stdin when starting API and SvelteKit servers

## Testing
- `bash scripts/start-localhost-sveltekit-server.sh > /tmp/svelte.log &`

------
https://chatgpt.com/codex/tasks/task_e_6850cb0b0014832fa0a70144eab88e25