### PR TITLE
Add log cleanup to setup script

### DIFF
--- a/scripts/codex-setp.sh
+++ b/scripts/codex-setp.sh
@@ -18,6 +18,8 @@ echo "Loading NVM..."
 load_nvm
 echo "Creating log directories..."
 create_log_directories
+echo "Clearing old log files..."
+clear_log_files
 echo "Setting up environment files..."
 setup_environment_files
 

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -72,6 +72,15 @@ create_log_directories() {
   done
 }
 
+# Remove all files in log directories
+clear_log_files() {
+  for dir in "${LOG_DIRS[@]}"; do
+    if [ -d "${dir}" ]; then
+      rm -rf "${dir}"/* 2>/dev/null || true
+    fi
+  done
+}
+
 # Install npm dependencies if needed
 npm_ci_if_needed() {
   if [ ! -d node_modules ]; then


### PR DESCRIPTION
## Summary
- clear log files before environment setup
- add `clear_log_files` helper

## Testing
- `bash scripts/codex-setp.sh` *(fails: port wait/timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6850cb729a10832f8639aeef55f50d97