### PR TITLE
Document dotenvx key file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ cp .env.example .env
 npx @dotenvx/dotenvx encrypt --env-file server/.env.development
 ```
 
+暗号化キーは `.env.keys` に保存されます。このファイルはリポジトリに含めないよう
+`.gitignore` にエントリがあることを確認してください。
+
 復号化が必要な場合は `decrypt` サブコマンドを使用します。
 
 ## 開発サーバーの起動


### PR DESCRIPTION
## Summary
- note that encryption keys are stored in `.env.keys`
- remind users that `.env.keys` should stay gitignored

## Testing
- `npx @dotenvx/dotenvx encrypt --env-file server/.env.development --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6850cef9bd10832f8c9a3b2044370303