### PR TITLE
Use localhost defaults and env vars

### DIFF
--- a/.cursor/rules/test.mdc
+++ b/.cursor/rules/test.mdc
@@ -24,7 +24,7 @@ alwaysApply: true
   e2e testの実行: cd /workspace/client && npm run test:e2e:xvfb
 6. 実行状況の確認が有効であれば、playwright MCP経由で実行状況を確認してください。
   テスト用のサーバー
-    http://192.168.50.13:7080/
+    http://localhost:7080/
   クライアントのログがここにあります。必要であれば、アクセス後にこちらを確認して下さい。
     /workspace/client/logs/test-browser.log
   テスト用のSveltKit serverのログがここにあります。必要であれば、アクセス後にこちらを確認して下さい。

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,7 +72,7 @@ dotenv は node版を使っているので、npx dotenv。
 
 コード修正後の確認作業
 テスト用のサーバー
-http://192.168.50.13:7080/
+http://localhost:7080/
 へアクセスして、正常に動作していることを確認して。
 クライアントのログがここにあるので、アクセス後にこちらを確認して。
 /workspace/client/logs/browser.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,19 +33,19 @@
             "type": "chrome",
             "request": "launch",
             "name": "Launch Chrome against dev server",
-            "url": "http://192.168.50.13:7070",
+            "url": "http://localhost:7070",
             "webRoot": "${workspaceFolder}/client",
             "sourceMaps": true,
             "sourceMapPathOverrides": {
                 "webpack:///src/*": "${webRoot}/src/*",
-                "http://192.168.50.13:7070/src/*": "${webRoot}/src/*",
-                "http://192.168.50.13:7080/src/*": "${webRoot}/src/*",
+                "http://localhost:7070/src/*": "${webRoot}/src/*",
+                "http://localhost:7080/src/*": "${webRoot}/src/*",
                 "webpack:///./*": "${webRoot}/*",
                 "/./*": "${webRoot}/*",
                 "/*": "*",
                 "/src/*": "${webRoot}/src/*",
-                "192.168.50.13꞉7070/src/*": "${webRoot}/src/*",
-                "192.168.50.13꞉7080/src/*": "${webRoot}/src/*"
+                "localhost꞉7070/src/*": "${webRoot}/src/*",
+                "localhost꞉7080/src/*": "${webRoot}/src/*"
             },
             "skipFiles": [
                 "**/lib/logger.*",
@@ -53,25 +53,25 @@
                 "**/node_modules/**"
             ],
             "port": 9876,
-            "urlFilter": "*192.168.50.13:7070*"
+            "urlFilter": "*localhost:7070*"
         },
         {
             "type": "chrome",
             "request": "launch",
             "name": "Launch Chrome against test server",
-            "url": "http://192.168.50.13:7080",
+            "url": "http://localhost:7080",
             "webRoot": "${workspaceFolder}/client",
             "sourceMaps": true,
             "sourceMapPathOverrides": {
                 "webpack:///src/*": "${webRoot}/src/*",
-                "http://192.168.50.13:7070/src/*": "${webRoot}/src/*",
-                "http://192.168.50.13:7080/src/*": "${webRoot}/src/*",
+                "http://localhost:7070/src/*": "${webRoot}/src/*",
+                "http://localhost:7080/src/*": "${webRoot}/src/*",
                 "webpack:///./*": "${webRoot}/*",
                 "/./*": "${webRoot}/*",
                 "/*": "*",
                 "/src/*": "${webRoot}/src/*",
-                "192.168.50.13꞉7070/src/*": "${webRoot}/src/*",
-                "192.168.50.13꞉7080/src/*": "${webRoot}/src/*"
+                "localhost꞉7070/src/*": "${webRoot}/src/*",
+                "localhost꞉7080/src/*": "${webRoot}/src/*"
             },
             "skipFiles": [
                 "**/lib/logger.*",
@@ -79,7 +79,7 @@
                 "**/node_modules/**"
             ],
             // "port": 9877,
-            "urlFilter": "*192.168.50.13:7080*"
+            "urlFilter": "*localhost:7080*"
             // "runtimeExecutable": "powershell.exe",
             // "runtimeArgs": [
             //     "-NoProfile",

--- a/chat.txt
+++ b/chat.txt
@@ -49,7 +49,7 @@ cd /workspace/client && npm run test:e2e:xvfb
 
 
 
-http://192.168.50.13:7080/
+http://localhost:7080/
 はテスト用のサーバー
 
 
@@ -69,7 +69,7 @@ cd /workspace/client && npx playwright test {test file path}
 　エラーがなければそれで終了です。
 　エラーがある場合は続けて下さい。
 　このテストファイルを分析して、各テストケースの目的と確認すべき挙動を確認してください
-　playwright-mcpを使用して、headedブラウザでテスト環境（http://192.168.50.13:7080/）にアクセスしてください
+　playwright-mcpを使用して、headedブラウザでテスト環境（http://localhost:7080/）にアクセスしてください
 　テストコードをトレースして、実際にブラウザで手動でテストコードの内容を行って下さい。
 　期待通りに動作するか確認してください。
 　異常があれば原因の説明をしてください。
@@ -78,7 +78,7 @@ cd /workspace/client && npx playwright test {test file path}
 　テストの修正をするか、コードの修正をするかは私が決めます。
 
 テスト用のサーバー
-　http://192.168.50.13:7080/
+　http://localhost:7080/
 クライアントのログがここにあります。必要であれば、アクセス後にこちらを確認して下さい。
 　/workspace/client/logs/test-browser.log
 テスト用のSveltKit serverのログがここにあります。必要であれば、アクセス後にこちらを確認して下さい。
@@ -94,7 +94,7 @@ API serverのログがここにあります。必要であれば、アクセス�
 
 
 開発用のサーバー
-http://192.168.50.13:7070/
+http://localhost:7070/
 へアクセスして、正常に動作していることを確認して。
 クライアントのログがここにある。必要であれば、アクセス後にこちらを確認して。
 /workspace/client/logs/browser.log

--- a/client/.vscode/settings.json
+++ b/client/.vscode/settings.json
@@ -16,9 +16,9 @@
     "playwright.env.TEST_ENV": "localhost",
     "playwright.env.PLAYWRIGHT_TEST_BASE_URL": "http://localhost:7090",
     "playwright.use.dotenv": true
-    // 192.168.50.13環境用の設定
-    // 以下のコメントを解除してTEST_ENVを削除することで、192.168.50.13環境でのテスト実行に戻せます
+    // リモートホスト環境用の設定例
+    // 以下のコメントを解除してTEST_ENVを削除することで、別ホスト環境でのテスト実行に戻せます
     // "playwright.env.DOTENV_CONFIG_PATH": ".env.test",
-    // "playwright.env.PLAYWRIGHT_TEST_BASE_URL": "http://192.168.50.13:7080",
+    // "playwright.env.PLAYWRIGHT_TEST_BASE_URL": "http://your.remote.host:7080",
     // // "playwright.env.TEST_ENV": "localhost", // この行を削除または無効化
 }

--- a/client/e2e/globals.d.ts
+++ b/client/e2e/globals.d.ts
@@ -51,10 +51,10 @@ export const test = base.extend({
             // Firebase エミュレーターを有効化
             window.localStorage.setItem("VITE_USE_FIREBASE_EMULATOR", "true");
 
-            // エミュレーター接続情報（環境変数から取得、デフォルトは192.168.50.13）
+            // エミュレーター接続情報（環境変数から取得、デフォルトはlocalhost）
             window.localStorage.setItem(
                 "VITE_FIRESTORE_EMULATOR_HOST",
-                process.env.VITE_FIRESTORE_EMULATOR_HOST || "192.168.50.13",
+                process.env.VITE_FIRESTORE_EMULATOR_HOST || "localhost",
             );
             window.localStorage.setItem(
                 "VITE_FIRESTORE_EMULATOR_PORT",
@@ -62,7 +62,7 @@ export const test = base.extend({
             );
             window.localStorage.setItem(
                 "VITE_AUTH_EMULATOR_HOST",
-                process.env.VITE_AUTH_EMULATOR_HOST || "192.168.50.13",
+                process.env.VITE_AUTH_EMULATOR_HOST || "localhost",
             );
             window.localStorage.setItem("VITE_AUTH_EMULATOR_PORT", process.env.VITE_AUTH_EMULATOR_PORT || "59099");
 

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -7,19 +7,16 @@ import {
 // 環境変数TEST_ENVが'localhost'の場合はlocalhost環境、それ以外はデフォルト環境
 // VSCode Playwright拡張から実行する場合は環境変数が正しく渡らないため、直接trueに設定
 // 元の設定に戻す場合はこちらのコメントを外してください
-// const isLocalhostEnv = process.env.TEST_ENV === 'localhost';
-const isLocalhostEnv = true; // localhostを強制的に使用
-
-// テスト用ポートを定義 - これを明示的に指定
-const TEST_PORT = isLocalhostEnv ? "7093" : "7080";
-// Tinylicious サーバーのポートを定義
-const TINYLICIOUS_PORT = isLocalhostEnv ? "7094" : "7082";
-// ホストを定義
-const VITE_HOST = isLocalhostEnv ? "localhost" : "192.168.50.13";
+// テスト用ポートを環境変数から取得（デフォルトは7093）
+const TEST_PORT = process.env.TEST_PORT || "7093";
+// Tinylicious サーバーのポートを環境変数から取得（デフォルトは7094）
+const TINYLICIOUS_PORT = process.env.VITE_TINYLICIOUS_PORT || "7094";
+// ホストを環境変数から取得（デフォルトはlocalhost）
+const VITE_HOST = process.env.VITE_HOST || "localhost";
 // 環境設定ファイルを定義
 const ENV_FILE = ".env.test";
 
-// console.log(`Using test environment: ${isLocalhostEnv ? "localhost" : "default"}`);
+// console.log(`Using test environment: ${VITE_HOST}`);
 // console.log(`Test port: ${TEST_PORT}, Tinylicious port: ${TINYLICIOUS_PORT}, Host: ${VITE_HOST}`);
 // console.log(`Environment file: ${ENV_FILE}`);
 
@@ -83,7 +80,7 @@ export default defineConfig({
     ],
     // webServer: {
     //     command: `npx dotenv -e .env.test -- npm run dev -- --host 0.0.0.0 --port ${TEST_PORT}`,
-    //     url: `http://192.168.50.13:${TEST_PORT}`,
+    //     url: `http://${VITE_HOST}:${TEST_PORT}`,
     //     reuseExistingServer: !process.env.CI,
     //     env: {
     //         NODE_ENV: "test",

--- a/client/src/stores/firestoreStore.svelte.ts
+++ b/client/src/stores/firestoreStore.svelte.ts
@@ -70,8 +70,8 @@ try {
 
     // Firebase Emulatorに接続
     if (useEmulator) {
-        // 環境変数から接続情報を取得（デフォルトは192.168.50.13:58080）
-        const emulatorHost = import.meta.env.VITE_FIRESTORE_EMULATOR_HOST || "192.168.50.13";
+        // 環境変数から接続情報を取得（デフォルトはlocalhost:58080）
+        const emulatorHost = import.meta.env.VITE_FIRESTORE_EMULATOR_HOST || "localhost";
         const emulatorPort = parseInt(import.meta.env.VITE_FIRESTORE_EMULATOR_PORT || "58080", 10);
 
         // エミュレーター接続情報をログに出力

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -39,12 +39,12 @@ export default defineConfig(async ({ mode }) => {
         server: {
             port: parseInt(process.env.VITE_PORT || "7070"),
             strictPort: true,
-            host: process.env.VITE_HOST || "192.168.50.13",
+            host: process.env.VITE_HOST || "localhost",
         },
         preview: {
             port: parseInt(process.env.VITE_PORT || "7070"),
             strictPort: true,
-            host: process.env.VITE_HOST || "192.168.50.13",
+            host: process.env.VITE_HOST || "localhost",
         },
         build: {
             sourcemap: true,

--- a/tips.txt
+++ b/tips.txt
@@ -78,12 +78,12 @@ git grep -n "updateFluidClient" $(git rev-list --all) -- . ':(exclude)*.md'
 & "C:\Program Files Online\mutagen\mutagen.exe" sync monitor --long
 & "C:\Program Files Online\mutagen\mutagen.exe" sync list --long
 & "C:\Program Files Online\mutagen\mutagen.exe" sync terminate sync_JFwY3mVfH7MC40bJuEQK2ZSTqDi41WgKc5HdMvDnmj5
-& "C:\Program Files Online\mutagen\mutagen.exe" sync create --ignore-vcs --ignore node_modules/**,client/node_modules**,server/node_modules**,functions/node_modules/**,.venv/**,client/.svelte-kit/**,client/playwright-report/**,client/logs/**,client/e2e/logs/**,server/logs/** C:\Users\kitam\src\outliner ubuntu@192.168.50.13:~/src/outliner
+& "C:\Program Files Online\mutagen\mutagen.exe" sync create --ignore-vcs --ignore node_modules/**,client/node_modules**,server/node_modules**,functions/node_modules/**,.venv/**,client/.svelte-kit/**,client/playwright-report/**,client/logs/**,client/e2e/logs/**,server/logs/** C:\Users\kitam\src\outliner your-user@your.server.address:~/src/outliner
 
  
  & "C:\Program Files Online\mutagen\mutagen.exe" sync pause sync_Nb1lt2D93LWX7YO7tdNto2vVGQX9yXsnX8yJ89d491q
  & rd /s /q "%USERPROFILE%\.mutagen\synchronization"
- & ssh ubuntu@192.168.50.13 'rm -rf ~/.mutagen/synchronization'
+& ssh your-user@your.server.address 'rm -rf ~/.mutagen/synchronization'
  & "C:\Program Files Online\mutagen\mutagen.exe" sync resume sync_Nb1lt2D93LWX7YO7tdNto2vVGQX9yXsnX8yJ89d491q
 
 


### PR DESCRIPTION
## Summary
- use env vars for emulator host in Svelte store
- update e2e globals to default to localhost
- configure Vite dev server and Playwright to respect `VITE_HOST`
- update VSCode launch config and docs to show localhost examples

## Testing
- `bash scripts/codex-setp.sh` *(fails: still waiting for port 7091)*
- `npm test` *(fails: still waiting for port 7091)*

------
https://chatgpt.com/codex/tasks/task_e_6850cef6c29c832f839d9396b1ca9d67