### PR TITLE
Fix integration test cleanup

### DIFF
--- a/client/src/tests/fluidTableClient.integration.test.ts
+++ b/client/src/tests/fluidTableClient.integration.test.ts
@@ -14,7 +14,7 @@ const isFluidAvailable = () => {
     }
 };
 
-describe.skip('FluidTableClient Integration Tests', () => {
+describe('FluidTableClient Integration Tests', () => {
     let client1: FluidTableClient;
     let client2: FluidTableClient;
     let containerId: string;
@@ -26,18 +26,18 @@ describe.skip('FluidTableClient Integration Tests', () => {
 
     afterEach(async () => {
         // クリーンアップ
-        if (client1?.container) {
-            try {
-                client1.container.dispose();
-            } catch (error) {
-                // エラーは無視
-            }
-        }
-        if (client2?.container) {
-            try {
-                client2.container.dispose();
-            } catch (error) {
-                // エラーは無視
+        for (const client of [client1, client2]) {
+            if (client?.container) {
+                try {
+                    client.disconnect();
+                    await client.container.dispose();
+                } catch (error) {
+                    // エラーは無視
+                } finally {
+                    client.container = undefined;
+                    client.tables = undefined as any;
+                    client.containerId = undefined;
+                }
             }
         }
     });


### PR DESCRIPTION
## Summary
- enable FluidTableClient integration tests
- dispose of Fluid containers in afterEach

## Testing
- `npm --prefix client run test:unit client/src/tests/fluidTableClient.integration.test.ts`
- `npm --prefix client run test:e2e:single e2e/core/basic.spec.ts` (fails to parse config)
- `npm --prefix client run test:e2e:single client/e2e/new/TBL-0001.spec.ts` (fails to parse config)


------
https://chatgpt.com/codex/tasks/task_e_6850e3be18f0832fbc5ec8bba66a3a17