### PR TITLE
Update Playwright config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,21 +1,23 @@
 /// <reference types="@playwright/test" />
 import { defineConfig } from "@playwright/test";
 
+const PORT = 7090;
+
 export default defineConfig({
-    testDir: "./tests",
+    testDir: "./client/e2e",
     timeout: 30 * 1000,
     expect: {
         timeout: 5000,
     },
-    // webServer: {
-    //     command: "npm run dev",
-    //     port: 5173,
-    //     reuseExistingServer: true,
-    // },
+    webServer: {
+        command: "npm --prefix client run dev",
+        port: PORT,
+        reuseExistingServer: true,
+    },
     use: {
         headless: true,
         viewport: { width: 1280, height: 720 },
         actionTimeout: 0,
-        baseURL: "http://localhost:5173",
+        baseURL: `http://localhost:${PORT}`,
     },
 });


### PR DESCRIPTION
## Summary
- start client server from Playwright
- point Playwright baseURL to localhost:7090

## Testing
- `npx playwright test client/e2e/basic-simple.spec.ts --config=playwright.config.ts --reporter=line` *(fails: Error: Requiring @playwright/test second time)*

------
https://chatgpt.com/codex/tasks/task_e_6850e3960b54832f9bf8d254adcc5897