### PR TITLE
Refactor test locators

### DIFF
--- a/client/e2e/core/CLM-0001.spec.ts
+++ b/client/e2e/core/CLM-0001.spec.ts
@@ -273,7 +273,8 @@ test.describe("CLM-0001: クリックで編集モードに入る", () => {
         await page.screenshot({ path: "client/test-results/CLM-0001-last-line-start.png" });
 
         // ページタイトル以外のアイテムを使用（2番目のアイテム）
-        const testItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const testItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         console.log("Using second item (non-page-title) for last line test");
 
         // 折り返しが発生する長いテキストを入力

--- a/client/e2e/core/CLM-0003.spec.ts
+++ b/client/e2e/core/CLM-0003.spec.ts
@@ -83,7 +83,8 @@ test.describe("CLM-0003: 右へ移動", () => {
         await page.keyboard.type("Second item");
 
         // 2つ目のアイテムが存在することを確認
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         await secondItem.waitFor({ state: "visible" });
 
         // 2つ目のアイテムのテキスト内容を確認

--- a/client/e2e/core/CLM-0100.spec.ts
+++ b/client/e2e/core/CLM-0100.spec.ts
@@ -66,7 +66,8 @@ test.describe("カーソル管理テスト", () => {
         expect(cursorCountAfterFirstClick).toBeLessThanOrEqual(initialCursorCount);
 
         // 2番目のアイテムをクリック
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         await secondItem.locator(".item-content").click({ force: true });
 
         // 2番目のアイテムクリック後のカーソル数を確認

--- a/client/e2e/core/CLM-0102.spec.ts
+++ b/client/e2e/core/CLM-0102.spec.ts
@@ -118,7 +118,8 @@ test.describe("空のテキストアイテムでのカーソル移動", () => {
             // 2番目のアイテムが表示されるまで待機（タイムアウトを短くする）
             try {
                 await page.waitForSelector(".outliner-item:nth-child(2)", { timeout: 5000 });
-                const secondItemText = await page.locator(".outliner-item").nth(1).locator(".item-text").textContent();
+                const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+                const secondItemText = await page.locator(`.outliner-item[data-item-id="${secondItemId}"]`).locator(".item-text").textContent();
                 console.log(`2番目のアイテムのテキスト: ${secondItemText}`);
                 expect(secondItemText).toContain("Test text 2"); // 2番目のアイテムに入力したテキストが含まれていることを確認
             }

--- a/client/e2e/core/CLM-0103.spec.ts
+++ b/client/e2e/core/CLM-0103.spec.ts
@@ -58,7 +58,8 @@ test.describe("フォーマット文字列でのカーソル操作", () => {
 
     test("複数のフォーマットが混在する文字列でのカーソル移動", async ({ page }) => {
         // ページタイトル以外のアイテムを選択（2番目のアイテム）
-        const item = page.locator(".outliner-item").nth(1);
+        const itemId2 = await TestHelpers.getItemIdByIndex(page, 1);
+        const item = page.locator(`.outliner-item[data-item-id="${itemId2}"]`);
         await item.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 
@@ -132,7 +133,8 @@ test.describe("フォーマット文字列でのカーソル操作", () => {
 
     test("Home/Endキーがフォーマット文字列で正しく機能する", async ({ page }) => {
         // ページタイトル以外のアイテムを選択（2番目のアイテム）
-        const item = page.locator(".outliner-item").nth(1);
+        const itemId3 = await TestHelpers.getItemIdByIndex(page, 1);
+        const item = page.locator(`.outliner-item[data-item-id="${itemId3}"]`);
         await item.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 
@@ -161,7 +163,8 @@ test.describe("フォーマット文字列でのカーソル操作", () => {
 
     test("Shift+矢印キーによる選択がフォーマット文字列で正しく機能する", async ({ page }) => {
         // 既存のアイテム（2番目のアイテム）を使用
-        const item = page.locator(".outliner-item").nth(1);
+        const itemId4 = await TestHelpers.getItemIdByIndex(page, 1);
+        const item = page.locator(`.outliner-item[data-item-id="${itemId4}"]`);
         await item.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 
@@ -233,7 +236,8 @@ test.describe("フォーマット文字列でのカーソル操作", () => {
 
     test("フォーマット文字列内での単語単位の移動（Ctrl+矢印）", async ({ page }) => {
         // ページタイトル以外のアイテムを選択（2番目のアイテム）
-        const item = page.locator(".outliner-item").nth(1);
+        const itemId5 = await TestHelpers.getItemIdByIndex(page, 1);
+        const item = page.locator(`.outliner-item[data-item-id="${itemId5}"]`);
         await item.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 

--- a/client/e2e/core/FMT-0003.spec.ts
+++ b/client/e2e/core/FMT-0003.spec.ts
@@ -27,7 +27,8 @@ test.describe("拡張フォーマット", () => {
         await page.keyboard.type("別のアイテム");
 
         // 別のアイテムをクリックしてフォーカスを移動（フォーマットを適用させるため）
-        await page.locator(".outliner-item").nth(1).locator(".item-content").click();
+        const secondItemId1 = await TestHelpers.getItemIdByIndex(page, 1);
+        await page.locator(`.outliner-item[data-item-id="${secondItemId1}"]`).locator(".item-content").click();
 
         // フォーマットが適用されるのを待つ
         await page.waitForTimeout(500);
@@ -52,7 +53,8 @@ test.describe("拡張フォーマット", () => {
         await page.keyboard.type("別のアイテム");
 
         // 別のアイテムをクリックしてフォーカスを移動（フォーマットを適用させるため）
-        await page.locator(".outliner-item").nth(1).locator(".item-content").click();
+        const secondItemId2 = await TestHelpers.getItemIdByIndex(page, 1);
+        await page.locator(`.outliner-item[data-item-id="${secondItemId2}"]`).locator(".item-content").click();
 
         // フォーマットが適用されるのを待つ
         await page.waitForTimeout(500);
@@ -78,7 +80,8 @@ test.describe("拡張フォーマット", () => {
         await page.keyboard.type("別のアイテム");
 
         // 別のアイテムをクリックしてフォーカスを移動（フォーマットを適用させるため）
-        await page.locator(".outliner-item").nth(1).locator(".item-content").click();
+        const secondItemId3 = await TestHelpers.getItemIdByIndex(page, 1);
+        await page.locator(`.outliner-item[data-item-id="${secondItemId3}"]`).locator(".item-content").click();
 
         // フォーマットが適用されるのを待つ
         await page.waitForTimeout(500);

--- a/client/e2e/core/FMT-0004.spec.ts
+++ b/client/e2e/core/FMT-0004.spec.ts
@@ -51,7 +51,8 @@ test.describe("フォーマット文字列の入力と表示", () => {
         // フォーカスを外してフォーマットが適用されることを確認
         await page.keyboard.press("Enter");
         await page.keyboard.type("別のアイテム");
-        await page.locator(".outliner-item").nth(1).locator(".item-content").click();
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        await page.locator(`.outliner-item[data-item-id="${secondItemId}"]`).locator(".item-content").click();
 
         // フォーマットが適用されるのを待つ
         await page.waitForTimeout(500);
@@ -105,7 +106,8 @@ test.describe("フォーマット文字列の入力と表示", () => {
 
         if (secondItemExists) {
             // 新しいアイテムが作成された場合
-            const secondItemText = await page.locator(".outliner-item").nth(1).locator(".item-text").textContent();
+            const secondItemIdText = await TestHelpers.getItemIdByIndex(page, 1);
+            const secondItemText = await page.locator(`.outliner-item[data-item-id="${secondItemIdText}"]`).locator(".item-text").textContent();
             expect(secondItemText).toContain("2行目");
         }
         else {
@@ -242,10 +244,9 @@ test.describe("フォーマット文字列の入力と表示", () => {
         console.log("クリップボードテストページが読み込まれました");
 
         // クリップボード権限を確認
-        await clipboardPage.locator(".test-section").nth(2).locator('button:has-text("クリップボード権限を確認")')
-            .click();
+        await clipboardPage.locator('#check-permission-btn').click();
         await clipboardPage.waitForTimeout(1000);
-        const permissionResult = await clipboardPage.locator(".test-section").nth(2).locator(".result").textContent();
+        const permissionResult = await clipboardPage.locator('#permission-result').textContent();
         console.log(`クリップボード権限: ${permissionResult}`);
 
         // Playwrightテスト用セクションにテキストを入力
@@ -253,14 +254,14 @@ test.describe("フォーマット文字列の入力と表示", () => {
         console.log("テキストエリアにテキストを入力しました");
 
         // コピーボタンをクリック
-        await clipboardPage.locator(".test-section").nth(3).locator('button:has-text("コピー")').click();
+        await clipboardPage.locator('#playwright-copy-btn').click();
         console.log("コピーボタンをクリックしました");
 
         // 少し待機してコピー操作が完了するのを待つ
         await clipboardPage.waitForTimeout(2000);
 
         // 結果を確認
-        const resultText = await clipboardPage.locator(".test-section").nth(3).locator(".result").textContent();
+        const resultText = await clipboardPage.locator('#playwright-result').textContent();
         console.log(`コピー結果: ${resultText}`);
 
         // クリップボードの内容を直接確認

--- a/client/e2e/core/FMT-0006.spec.ts
+++ b/client/e2e/core/FMT-0006.spec.ts
@@ -40,7 +40,8 @@ test.describe("カーソル移動時のフォーマット表示の一貫性", ()
         // 空のアイテムを作成
 
         // 3つ目のアイテムをクリック（カーソルを最初のアイテムから離す）
-        const thirdItem = page.locator(".outliner-item").nth(2);
+        const thirdItemId = await TestHelpers.getItemIdByIndex(page, 2);
+        const thirdItem = page.locator(`.outliner-item[data-item-id="${thirdItemId}"]`);
         await thirdItem.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 
@@ -49,7 +50,8 @@ test.describe("カーソル移動時のフォーマット表示の一貫性", ()
         expect(firstItemTextWithoutCursor).toContain("<strong>aasdd</strong>");
 
         // 2つ目のアイテムのテキスト内容を確認（制御文字が非表示で内部リンクが適用されていること）
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         const secondItemTextWithoutCursor = await secondItem.locator(".item-text").innerHTML();
         expect(secondItemTextWithoutCursor).toContain('class="internal-link');
         expect(secondItemTextWithoutCursor).toContain(">asd</a>");
@@ -187,7 +189,8 @@ test.describe("カーソル移動時のフォーマット表示の一貫性", ()
 
     test("SharedTreeデータが正しく保存される", async ({ page }) => {
         // 最初のアイテムを選択
-        const firstItem = page.locator(".outliner-item").nth(1);
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId}"]`);
         await firstItem.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 

--- a/client/e2e/core/FMT-0007.spec.ts
+++ b/client/e2e/core/FMT-0007.spec.ts
@@ -134,7 +134,8 @@ test.describe("FMT-0007: 内部リンク機能", () => {
      */
     test("内部リンクのデータが正しく保存される", async ({ page }) => {
         // ページタイトル以外のアイテムを選択（2番目のアイテム）
-        const firstItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         await firstItem.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 

--- a/client/e2e/core/LNK-0001.spec.ts
+++ b/client/e2e/core/LNK-0001.spec.ts
@@ -53,7 +53,8 @@ test.describe("LNK-0001: 内部リンクのナビゲーション機能", () => {
         expect(firstItemText).toContain('href="/test-page"');
 
         // 2つ目のアイテムのテキスト内容を確認（プロジェクト内部リンクが適用されていること）
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         const secondItemText = await secondItem.locator(".item-text").innerHTML();
 
         // プロジェクト内部リンクが適用されていることを確認
@@ -96,7 +97,8 @@ test.describe("LNK-0001: 内部リンクのナビゲーション機能", () => {
         expect(firstItemHTML).toMatch(/<a href="\/test-page"[^>]*class="[^"]*internal-link[^"]*"[^>]*>test-page<\/a>/);
 
         // 2つ目のアイテムのHTML内容を確認
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         const secondItemHTML = await secondItem.locator(".item-text").innerHTML();
 
         // プロジェクト内部リンクのHTMLが正しく生成されていることを確認

--- a/client/e2e/core/LNK-0003.spec.ts
+++ b/client/e2e/core/LNK-0003.spec.ts
@@ -269,8 +269,10 @@ test.describe("LNK-0003: 内部リンクのナビゲーション機能", () => {
         const itemCount = await allItems.count();
         console.log(`Total items: ${itemCount}`);
 
-        for (let i = 0; i < itemCount; i++) {
-            const item = allItems.nth(i);
+        const itemHandles = await allItems.elementHandles();
+        for (const [i, handle] of itemHandles.entries()) {
+            const itemId = await handle.getAttribute("data-item-id");
+            const item = page.locator(`.outliner-item[data-item-id="${itemId}"]`);
             const itemText = await item.textContent();
             console.log(`Item ${i}: "${itemText}"`);
         }
@@ -280,11 +282,11 @@ test.describe("LNK-0003: 内部リンクのナビゲーション機能", () => {
         const linkCount = await allLinks.count();
         console.log(`Total internal links: ${linkCount}`);
 
-        for (let i = 0; i < linkCount; i++) {
-            const link = allLinks.nth(i);
-            const linkHref = await link.getAttribute("href");
-            const linkText = await link.textContent();
-            const linkClass = await link.getAttribute("class");
+        const linkHandles = await allLinks.elementHandles();
+        for (const [i, handle] of linkHandles.entries()) {
+            const linkHref = await handle.getAttribute("href");
+            const linkText = await handle.textContent();
+            const linkClass = await handle.getAttribute("class");
             console.log(`Link ${i}: href="${linkHref}", text="${linkText}", class="${linkClass}"`);
         }
 
@@ -433,8 +435,10 @@ test.describe("LNK-0003: 内部リンクのナビゲーション機能", () => {
         const itemCount = await allItems.count();
         console.log(`Total items: ${itemCount}`);
 
-        for (let i = 0; i < itemCount; i++) {
-            const item = allItems.nth(i);
+        const itemHandles2 = await allItems.elementHandles();
+        for (const [i, handle] of itemHandles2.entries()) {
+            const itemId = await handle.getAttribute("data-item-id");
+            const item = page.locator(`.outliner-item[data-item-id="${itemId}"]`);
             const itemText = await item.textContent();
             console.log(`Item ${i}: "${itemText}"`);
         }
@@ -444,11 +448,11 @@ test.describe("LNK-0003: 内部リンクのナビゲーション機能", () => {
         const linkCount = await allLinks.count();
         console.log(`Total internal links: ${linkCount}`);
 
-        for (let i = 0; i < linkCount; i++) {
-            const link = allLinks.nth(i);
-            const linkHref = await link.getAttribute("href");
-            const linkText = await link.textContent();
-            const linkClass = await link.getAttribute("class");
+        const linkHandles2 = await allLinks.elementHandles();
+        for (const [i, handle] of linkHandles2.entries()) {
+            const linkHref = await handle.getAttribute("href");
+            const linkText = await handle.textContent();
+            const linkClass = await handle.getAttribute("class");
             console.log(`Link ${i}: href="${linkHref}", text="${linkText}", class="${linkClass}"`);
         }
 
@@ -556,7 +560,8 @@ test.describe("LNK-0003: 内部リンクのナビゲーション機能", () => {
 
         if (itemCount > 1) {
             // 2番目のアイテムが作成された場合
-            const secondItem = page.locator(".outliner-item").nth(1);
+            const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+            const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
             const itemText = await secondItem.textContent();
             console.log("Item text after programmatic creation:", itemText);
             expect(itemText).toContain("これはターゲットページです。");
@@ -697,7 +702,8 @@ test.describe("LNK-0003: 内部リンクのナビゲーション機能", () => {
 
         if (itemCount > 1) {
             // 2番目のアイテムが作成された場合
-            const secondItem = page.locator(".outliner-item").nth(1);
+            const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+            const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
             const itemText = await secondItem.textContent();
             console.log(`Item text after programmatic creation: "${itemText}"`);
             expect(itemText).toContain("これは新しく作成されたページです。");

--- a/client/e2e/core/SLR-0004.spec.ts
+++ b/client/e2e/core/SLR-0004.spec.ts
@@ -151,7 +151,8 @@ test.describe("SLR-0004: マウスドラッグによる選択", () => {
         await page.waitForTimeout(300);
 
         // 新しいアイテムのテキストを取得
-        const newItem = page.locator(".outliner-item").nth(1);
+        const newItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const newItem = page.locator(`.outliner-item[data-item-id="${newItemId}"]`);
         const newItemText = await newItem.locator(".item-text").textContent();
 
         // ペーストされたテキストが存在することを確認

--- a/client/e2e/core/SLR-0005.spec.ts
+++ b/client/e2e/core/SLR-0005.spec.ts
@@ -84,7 +84,8 @@ test.describe("SLR-0005: 複数アイテムにまたがる選択", () => {
         });
 
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -177,7 +178,8 @@ test.describe("SLR-0005: 複数アイテムにまたがる選択", () => {
         await TestHelpers.waitForCursorVisible(page);
 
         // 最初のアイテムを取得
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId2 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId2}"]`);
         const firstItemText = firstItem.locator(".item-text");
 
         // 最初のアイテムをクリックして選択状態をリセット
@@ -265,7 +267,8 @@ test.describe("SLR-0005: 複数アイテムにまたがる選択", () => {
 
     test("複数アイテムにまたがる選択範囲が視覚的に表示される", async ({ page }) => {
         // 最初のアイテムを取得
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId3 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId3}"]`);
 
         // 最初のアイテムをクリックして選択
         await firstItem.locator(".item-content").click({ force: true });

--- a/client/e2e/core/SLR-0006.spec.ts
+++ b/client/e2e/core/SLR-0006.spec.ts
@@ -53,7 +53,8 @@ test.describe("SLR-0006: 複数アイテム選択範囲のコピー＆ペース�
 
     test("複数アイテムにまたがる選択範囲のテキストをコピーできる", async ({ page }) => {
         // 最初のアイテムを取得
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId}"]`);
 
         // 最初のアイテムをクリックして選択
         await firstItem.locator(".item-content").click({ force: true });
@@ -66,7 +67,8 @@ test.describe("SLR-0006: 複数アイテム選択範囲のコピー＆ペース�
         });
 
         // 2つ目のアイテムをクリックして選択
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         await secondItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -186,7 +188,8 @@ test.describe("SLR-0006: 複数アイテム選択範囲のコピー＆ペース�
         });
 
         // 2つ目のアイテムを取得
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId2 = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId2}"]`);
 
         // 2つ目のアイテムをクリックして選択
         await secondItem.locator(".item-content").click({ force: true });
@@ -298,7 +301,8 @@ test.describe("SLR-0006: 複数アイテム選択範囲のコピー＆ペース�
         });
 
         // 3つ目のアイテムをクリック
-        const thirdItem = page.locator(".outliner-item").nth(2);
+        const thirdItemId = await TestHelpers.getItemIdByIndex(page, 2);
+        const thirdItem = page.locator(`.outliner-item[data-item-id="${thirdItemId}"]`);
         await thirdItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -395,7 +399,8 @@ test.describe("SLR-0006: 複数アイテム選択範囲のコピー＆ペース�
         });
 
         // 最初のアイテムを取得
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId2 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId2}"]`);
 
         // 最初のアイテムをクリックして選択
         await firstItem.locator(".item-content").click({ force: true });

--- a/client/e2e/core/SLR-0007.spec.ts
+++ b/client/e2e/core/SLR-0007.spec.ts
@@ -65,7 +65,8 @@ test.describe("SLR-0007: 複数アイテム選択範囲の削除", () => {
         });
 
         // 2つ目のアイテムを取得
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
 
         // 2つ目のアイテムをクリックして選択
         await secondItem.locator(".item-content").click({ force: true });
@@ -122,8 +123,10 @@ test.describe("SLR-0007: 複数アイテム選択範囲の削除", () => {
         expect(afterCount).toBeLessThan(beforeCount);
 
         // 残りのアイテムのテキストを確認
-        const firstItemTextAfter = await page.locator(".outliner-item").nth(0).locator(".item-text").textContent();
-        const secondItemTextAfter = await page.locator(".outliner-item").nth(1).locator(".item-text").textContent();
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 0);
+        const secondItemIdAfterDel = await TestHelpers.getItemIdByIndex(page, 1);
+        const firstItemTextAfter = await page.locator(`.outliner-item[data-item-id="${firstItemId}"]`).locator(".item-text").textContent();
+        const secondItemTextAfter = await page.locator(`.outliner-item[data-item-id="${secondItemIdAfterDel}"]`).locator(".item-text").textContent();
 
         // テキストが存在することを確認
         expect(firstItemTextAfter || "").toBeTruthy();
@@ -138,7 +141,8 @@ test.describe("SLR-0007: 複数アイテム選択範囲の削除", () => {
         });
 
         // 2つ目のアイテムを取得
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId2 = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId2}"]`);
 
         // 2つ目のアイテムをクリックして選択
         await secondItem.locator(".item-content").click({ force: true });
@@ -199,8 +203,10 @@ test.describe("SLR-0007: 複数アイテム選択範囲の削除", () => {
         expect(afterCount).toBeLessThan(beforeCount);
 
         // 残りのアイテムのテキストを確認
-        const firstItemTextAfter = await page.locator(".outliner-item").nth(0).locator(".item-text").textContent();
-        const secondItemTextAfter = await page.locator(".outliner-item").nth(1).locator(".item-text").textContent();
+        const firstItemId2 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItemTextAfter = await page.locator(`.outliner-item[data-item-id="${firstItemId2}"]`).locator(".item-text").textContent();
+        const secondItemIdAfterDel2 = afterCount > 1 ? await TestHelpers.getItemIdByIndex(page, 1) : null;
+        const secondItemTextAfter = secondItemIdAfterDel2 ? await page.locator(`.outliner-item[data-item-id="${secondItemIdAfterDel2}"]`).locator(".item-text").textContent() : null;
 
         // テキストが存在することを確認
         expect(firstItemTextAfter || "").toBeTruthy();
@@ -219,7 +225,8 @@ test.describe("SLR-0007: 複数アイテム選択範囲の削除", () => {
         });
 
         // 2つ目のアイテムを取得
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId3 = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId3}"]`);
 
         // 2つ目のアイテムをクリックして選択
         await secondItem.locator(".item-content").click({ force: true });
@@ -280,7 +287,8 @@ test.describe("SLR-0007: 複数アイテム選択範囲の削除", () => {
         expect(afterCount).toBeLessThan(beforeCount);
 
         // 結合されたアイテムのテキストを確認
-        const secondItemTextAfter = await page.locator(".outliner-item").nth(1).locator(".item-text").textContent();
+        const secondItemIdAfterMerge = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItemTextAfter = await page.locator(`.outliner-item[data-item-id="${secondItemIdAfterMerge}"]`).locator(".item-text").textContent();
 
         // 結合されたテキストが正しいことを確認（前半部分と後半部分が結合されている）
         expect(secondItemTextAfter).toContain("Sec");
@@ -295,7 +303,8 @@ test.describe("SLR-0007: 複数アイテム選択範囲の削除", () => {
         });
 
         // 最初のアイテムを取得
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId3 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId3}"]`);
 
         // 最初のアイテムをクリックして選択
         await firstItem.locator(".item-content").click({ force: true });
@@ -355,7 +364,8 @@ test.describe("SLR-0007: 複数アイテム選択範囲の削除", () => {
         await page.keyboard.type("INSERTED");
 
         // 入力されたテキストが正しい位置に挿入されたことを確認
-        const firstItemTextAfter = await page.locator(".outliner-item").nth(0).locator(".item-text").textContent();
+        const firstItemIdAfterInsert = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItemTextAfter = await page.locator(`.outliner-item[data-item-id="${firstItemIdAfterInsert}"]`).locator(".item-text").textContent();
 
         // 入力されたテキストが正しい位置に挿入されていることを確認
         expect(firstItemTextAfter).toContain("INSERTED");

--- a/client/e2e/core/SLR-0008.spec.ts
+++ b/client/e2e/core/SLR-0008.spec.ts
@@ -53,7 +53,8 @@ test.describe("SLR-0008: 選択範囲のエッジケース", () => {
         });
 
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -159,7 +160,8 @@ test.describe("SLR-0008: 選択範囲のエッジケース", () => {
         });
 
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId2 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId2}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -250,7 +252,8 @@ test.describe("SLR-0008: 選択範囲のエッジケース", () => {
         }, selectionText);
 
         // 2つ目のアイテムをクリックして選択
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         await secondItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -342,7 +345,8 @@ test.describe("SLR-0008: 選択範囲のエッジケース", () => {
         });
 
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId3 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId3}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -374,7 +378,8 @@ test.describe("SLR-0008: 選択範囲のエッジケース", () => {
         await page.waitForTimeout(300);
 
         // 2つ目のアイテムをクリックして選択
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId2 = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId2}"]`);
         await secondItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 

--- a/client/e2e/core/SLR-0009.spec.ts
+++ b/client/e2e/core/SLR-0009.spec.ts
@@ -67,7 +67,8 @@ test.describe("SLR-0009: ドラッグ＆ドロップによるテキスト移動"
         expect(itemCount).toBeGreaterThanOrEqual(3);
 
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -105,7 +106,8 @@ test.describe("SLR-0009: ドラッグ＆ドロップによるテキスト移動"
         await page.waitForTimeout(300);
 
         // 3つ目のアイテムをクリックして選択
-        const thirdItem = page.locator(".outliner-item").nth(2);
+        const thirdItemId = await TestHelpers.getItemIdByIndex(page, 2);
+        const thirdItem = page.locator(`.outliner-item[data-item-id="${thirdItemId}"]`);
         await thirdItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -147,14 +149,15 @@ test.describe("SLR-0009: ドラッグ＆ドロップによるテキスト移動"
         expect(itemCount).toBeGreaterThanOrEqual(3);
 
         // 各アイテムのテキストを取得（最初の3つのアイテムのみ）
-        const firstItemText = await page.locator(".outliner-item").nth(0).locator(".item-text").textContent();
-        const secondItemText = await page.locator(".outliner-item").nth(1).locator(".item-text").textContent();
-        const thirdItemText = await page.locator(".outliner-item").nth(2).locator(".item-text").textContent();
+        const firstItemText = await page.locator(`.outliner-item[data-item-id="${firstItemId}"]`).locator(".item-text").textContent();
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItemText = await page.locator(`.outliner-item[data-item-id="${secondItemId}"]`).locator(".item-text").textContent();
+        const thirdItemText = await page.locator(`.outliner-item[data-item-id="${thirdItemId}"]`).locator(".item-text").textContent();
 
         console.log(`Initial items: 1="${firstItemText}", 2="${secondItemText}", 3="${thirdItemText}"`);
 
         // 2つ目のアイテムを削除
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         await secondItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -167,7 +170,8 @@ test.describe("SLR-0009: ドラッグ＆ドロップによるテキスト移動"
         await page.waitForTimeout(300);
 
         // 3つ目のアイテムをクリックして選択（2つ目が削除されたので、元の3つ目は1番目になる）
-        const thirdItem = page.locator(".outliner-item").nth(1);
+        const thirdItemIdAfterDeletion = await TestHelpers.getItemIdByIndex(page, 1);
+        const thirdItem = page.locator(`.outliner-item[data-item-id="${thirdItemIdAfterDeletion}"]`);
         await thirdItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
@@ -181,18 +185,20 @@ test.describe("SLR-0009: ドラッグ＆ドロップによるテキスト移動"
         await page.waitForTimeout(500);
 
         // 最初の3つのアイテムのテキストを確認
-        const firstItemAfter = await page.locator(".outliner-item").nth(0).locator(".item-text").textContent() || "";
+        const firstItemAfter = await page.locator(`.outliner-item[data-item-id="${firstItemId}"]`).locator(".item-text").textContent() || "";
 
         // 2つ目と3つ目のアイテムが存在する場合のみテキストを取得
         let secondItemAfter = "";
         let thirdItemAfter = "";
 
         if (await page.locator(".outliner-item").count() > 1) {
-            secondItemAfter = await page.locator(".outliner-item").nth(1).locator(".item-text").textContent() || "";
+            const secondItemIdAfter = await TestHelpers.getItemIdByIndex(page, 1);
+            secondItemAfter = await page.locator(`.outliner-item[data-item-id="${secondItemIdAfter}"]`).locator(".item-text").textContent() || "";
         }
 
         if (await page.locator(".outliner-item").count() > 2) {
-            thirdItemAfter = await page.locator(".outliner-item").nth(2).locator(".item-text").textContent() || "";
+            const thirdItemIdAfter = await TestHelpers.getItemIdByIndex(page, 2);
+            thirdItemAfter = await page.locator(`.outliner-item[data-item-id="${thirdItemIdAfter}"]`).locator(".item-text").textContent() || "";
         }
 
         console.log(`Items after: 1="${firstItemAfter}", 2="${secondItemAfter}", 3="${thirdItemAfter}"`);

--- a/client/e2e/core/SLR-0010.spec.ts
+++ b/client/e2e/core/SLR-0010.spec.ts
@@ -50,7 +50,8 @@ test.describe("SLR-0010: 選択範囲のフォーマット変更", () => {
 
     test("単一アイテム内の選択範囲を太字に変更できる", async ({ page }) => {
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await TestHelpers.waitForCursorVisible(page);
 
@@ -80,7 +81,8 @@ test.describe("SLR-0010: 選択範囲のフォーマット変更", () => {
 
     test("単一アイテム内の選択範囲を斜体に変更できる", async ({ page }) => {
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId2 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId2}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await TestHelpers.waitForCursorVisible(page);
 
@@ -109,7 +111,8 @@ test.describe("SLR-0010: 選択範囲のフォーマット変更", () => {
 
     test("単一アイテム内の選択範囲に下線を追加できる", async ({ page }) => {
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId3 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId3}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await TestHelpers.waitForCursorVisible(page);
 
@@ -140,7 +143,8 @@ test.describe("SLR-0010: 選択範囲のフォーマット変更", () => {
 
     test("単一アイテム内の選択範囲を取り消し線に変更できる", async ({ page }) => {
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId4 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId4}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await TestHelpers.waitForCursorVisible(page);
 
@@ -170,7 +174,8 @@ test.describe("SLR-0010: 選択範囲のフォーマット変更", () => {
 
     test("単一アイテム内の選択範囲をコードに変更できる", async ({ page }) => {
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId5 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId5}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await TestHelpers.waitForCursorVisible(page);
 
@@ -200,7 +205,8 @@ test.describe("SLR-0010: 選択範囲のフォーマット変更", () => {
 
     test("複数アイテムにまたがる選択範囲をフォーマット変更できる", async ({ page }) => {
         // 最初のアイテムをクリックして選択
-        const firstItem = page.locator(".outliner-item").nth(0);
+        const firstItemId6 = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstItemId6}"]`);
         await firstItem.locator(".item-content").click({ force: true });
         await TestHelpers.waitForCursorVisible(page);
 
@@ -231,7 +237,8 @@ test.describe("SLR-0010: 選択範囲のフォーマット変更", () => {
         expect(firstItemText).toBeTruthy();
 
         // 2つ目のアイテムのテキストを確認
-        const secondItem = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItem = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         const secondItemText = await secondItem.locator(".item-text").textContent();
         expect(secondItemText).toBeTruthy();
     });

--- a/client/e2e/core/SLR-0101.spec.ts
+++ b/client/e2e/core/SLR-0101.spec.ts
@@ -64,7 +64,8 @@ test.describe("マウスによる矩形選択テスト", () => {
         }
 
         // 2番目のアイテムの位置を取得
-        const secondItemBounds = await page.locator(".outliner-item").nth(1).boundingBox();
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        const secondItemBounds = await page.locator(`.outliner-item[data-item-id="${secondItemId}"]`).boundingBox();
         if (!secondItemBounds) {
             console.log("2番目のアイテムの位置を取得できませんでした。");
             return;


### PR DESCRIPTION
## Summary
- refactor e2e tests to use `data-item-id` and unique ids instead of `.nth()`

## Testing
- `scripts/run-tests.sh client/e2e/core/LNK-0001.spec.ts` *(fails: environment setup blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850e3be3334832fbe8d2bb951238bbe