### PR TITLE
Add table/chart embed blocks

### DIFF
--- a/client/e2e/new/EMB-0001.spec.ts
+++ b/client/e2e/new/EMB-0001.spec.ts
@@ -1,0 +1,25 @@
+/** @feature EMB-0001
+ * Outliner Table & Chart Embedding
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("EMB-0001: Table embed in outliner", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+        // add table item via Fluid API
+        await page.evaluate(() => {
+            const fluidClient = (window as any).__FLUID_STORE__?.fluidClient;
+            if (!fluidClient) throw new Error("FluidClient not available");
+            const project = fluidClient.getProject();
+            const pageItem = project.items[0];
+            const newItem = pageItem.items.addNode("test-user");
+            newItem.embed = { type: 'table', query: 'SELECT id as tbl_pk, value, num FROM tbl' };
+        });
+    });
+
+    test("table embed renders", async ({ page }) => {
+        await expect(page.locator('[data-testid="editable-grid"]')).toBeVisible();
+        await expect(page.locator('[data-testid="chart-panel"]')).toBeVisible();
+    });
+});

--- a/client/src/components/ChartEmbed.svelte
+++ b/client/src/components/ChartEmbed.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+import ChartPanel from "./ChartPanel.svelte";
+
+export let option: any = {
+    xAxis: { type: "category", data: ["A", "B", "C"] },
+    yAxis: { type: "value" },
+    series: [{ type: "bar", data: [1, 2, 3] }],
+};
+</script>
+
+<ChartPanel {option} />

--- a/client/src/components/OutlinerItem.svelte
+++ b/client/src/components/OutlinerItem.svelte
@@ -5,7 +5,9 @@
 	import { editorOverlayStore } from '../stores/EditorOverlayStore.svelte';
 	import type { OutlinerItemViewModel } from "../stores/OutlinerViewModel";
 	import { TreeSubscriber } from "../stores/TreeSubscriber";
-	import { ScrapboxFormatter } from '../utils/ScrapboxFormatter';
+import { ScrapboxFormatter } from '../utils/ScrapboxFormatter';
+import TableEmbed from './TableEmbed.svelte';
+import ChartEmbed from './ChartEmbed.svelte';
 	interface Props {
 		model: OutlinerItemViewModel;
 		depth?: number;
@@ -1366,12 +1368,18 @@
 					<span class="item-text" class:title-text={isPageTitle} class:formatted={ScrapboxFormatter.hasFormatting(text.current)}>
 						{@html ScrapboxFormatter.formatToHtml(text.current)}
 					</span>
-				{/if}
-				{#if !isPageTitle && model.votes.length > 0}
-					<span class="vote-count">{model.votes.length}</span>
-				{/if}
-			</div>
-		</div>
+                                {/if}
+                                {#if !isPageTitle && model.votes.length > 0}
+                                        <span class="vote-count">{model.votes.length}</span>
+                                {/if}
+                        </div>
+
+                        {#if model.embed?.type === 'table'}
+                                <TableEmbed query={model.embed.query} />
+                        {:else if model.embed?.type === 'chart'}
+                                <ChartEmbed option={model.embed.option} />
+                        {/if}
+                </div>
 
 		{#if !isPageTitle}
 			<div class="item-actions">

--- a/client/src/components/TableEmbed.svelte
+++ b/client/src/components/TableEmbed.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+import { onMount } from "svelte";
+import QueryEditor from "./QueryEditor.svelte";
+import EditableQueryGrid from "./EditableQueryGrid.svelte";
+import ChartPanel from "./ChartPanel.svelte";
+import { SqlService } from "../services/sqlService";
+import { FluidTableClient } from "../services/fluidClient";
+import { createQueryStore } from "../services/queryStore";
+import { startSync } from "../services/syncWorker";
+
+export let query: string = "SELECT id as tbl_pk, value, num FROM tbl";
+
+let sql: SqlService;
+let fluid: FluidTableClient;
+let store: ReturnType<typeof createQueryStore>;
+let rows: any[] = $state([]);
+let columns: any[] = $state([]);
+let chartOption: any = $state({});
+
+function refreshChart() {
+    chartOption = {
+        xAxis: { type: "category", data: rows.map(r => r.value) },
+        yAxis: { type: "value" },
+        series: [{ type: "bar", data: rows.map(r => r.num) }],
+    };
+}
+
+function onEdit(e: CustomEvent<any>) {
+    fluid.updateCell({
+        tableId: e.detail.tableId,
+        rowId: e.detail.pk,
+        column: e.detail.column,
+        value: e.detail.value,
+    });
+}
+
+onMount(async () => {
+    sql = new SqlService();
+    fluid = new FluidTableClient();
+    store = createQueryStore(sql, query);
+    store.subscribe(r => {
+        rows = r.rows;
+        columns = r.columnsMeta;
+        refreshChart();
+    });
+    startSync(fluid, sql, () => store.run());
+    await fluid.createContainer();
+    await sql.exec("CREATE TABLE tbl(id TEXT PRIMARY KEY, value TEXT, num INTEGER)");
+    await sql.exec("INSERT INTO tbl VALUES('1','a',1),('2','b',2)");
+    await store.run(query);
+});
+</script>
+
+<div class="table-embed">
+    <QueryEditor {query} onrun={e => store.run(e.query)} />
+    <EditableQueryGrid {rows} {columns} onedit={onEdit} />
+    <ChartPanel option={chartOption} />
+</div>
+
+<style>
+.table-embed {
+    margin-top: 8px;
+}
+</style>

--- a/client/src/schema/app-schema.ts
+++ b/client/src/schema/app-schema.ts
@@ -21,6 +21,7 @@ const sf = new SchemaFactory("fc1db2e8-0a00-11ee-be56-0242ac120003");
 export class Item extends sf.objectRecursive("Item", {
     id: sf.string,
     text: sf.string, // テキスト内容
+    embed: sf.any,
     author: sf.string,
     votes: sf.array(sf.string),
     created: sf.number,
@@ -88,6 +89,7 @@ export class Items extends sf.arrayRecursive("Items", [Item]) {
         const newItem = new Item({
             id: uuid(),
             text: defaultText, // 開発環境ではインデックスを含むテキスト
+            embed: undefined,
             author,
             votes: [],
             created: timeStamp,

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -17,6 +17,19 @@
     - client/src/routes/min/+page.svelte
     - client/.env.example
   tests: []
+
+- id: EMB-0001
+  title: Outliner Table & Chart Embedding
+  description: Notion-like table and chart blocks can be embedded in any outliner item
+  category: table
+  status: implemented
+  components:
+    - client/src/components/TableEmbed.svelte
+    - client/src/components/ChartEmbed.svelte
+    - client/src/components/OutlinerItem.svelte
+    - client/src/schema/app-schema.ts
+  tests:
+    - client/e2e/new/EMB-0001.spec.ts
   acceptance:
     - "Firebase config values come from VITE_FIREBASE_* variables"
     - "Token verification URL uses VITE_TOKEN_VERIFY_URL"

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -1,82 +1,82 @@
 # Feature ↔ Test Matrix
-
-| Feature   | Title                                                                | Test files                                                                 | Status      |
-| --------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------- | ----------- |
-| API-0001  | Firebase Functions APIサーバーの修正                                 | —                                                                          | implemented |
-| API-0002  | Firebase emulator起動待機機能                                        | —                                                                          | implemented |
-| API-0003  | コンテナユーザー一覧取得の管理者チェック                             | —                                                                          | implemented |
-| APP-0001  | プロジェクトページ表示時にグローバルテキストエリアにフォーカスを設定 | —                                                                          | implemented |
-| BRF-0001  | Branch forest item extraction                                        | —                                                                          | implemented |
-| CHT-001   | Chart Component                                                      | —                                                                          | implemented |
-| CLM-0001  | クリックで編集モードに入る                                           | client/e2e/core/CLM-0001.spec.ts                                           | implemented |
-| CLM-0002  | 左へ移動                                                             | client/e2e/core/CLM-0002.spec.ts                                           | implemented |
-| CLM-0003  | 右へ移動                                                             | client/e2e/core/CLM-0003.spec.ts                                           | implemented |
-| CLM-0004  | 上へ移動                                                             | client/e2e/core/CLM-0004.spec.ts                                           | implemented |
-| CLM-0005  | 下へ移動                                                             | client/e2e/core/CLM-0005.spec.ts                                           | implemented |
-| CLM-0007  | 行頭へ移動                                                           | client/e2e/core/CLM-0007.spec.ts                                           | implemented |
-| CLM-0008  | 行末へ移動                                                           | client/e2e/core/CLM-0008.spec.ts                                           | implemented |
-| CLM-0100  | 通常クリックでカーソルが増えないこと                                 | client/e2e/core/CLM-0100.spec.ts                                           | implemented |
-| CLM-0101  | アイテム間移動時のカーソル重複と入力分散問題                         | client/e2e/core/CLM-0101.spec.ts                                           | implemented |
-| CLM-0102  | 空のテキストアイテムでのカーソル移動と複数回のキーボード操作         | client/e2e/core/CLM-0102.spec.ts                                           | implemented |
-| CLM-0103  | フォーマット文字列でのカーソル操作                                   | client/e2e/core/CLM-0103.spec.ts                                           | implemented |
-| COL-0001  | 他ユーザーのカーソル表示                                             | client/e2e/disabled/COL-0001.spec.ts                                       | implemented |
-| DBW-0001  | Client-Side WASM DB                                                  | —                                                                          | implemented |
-| DBW-001   | Client-Side SQL Database                                             | client/e2e/new/DBW-001.spec.ts                                             | implemented |
-| ERR-0001  | エラーハンドリングテスト                                             | client/e2e/new/ERR-0001.spec.ts                                            | implemented |
-| FFI-0001  | Fluid Framework Integration                                          | —                                                                          | implemented |
-| FLD-0001  | プロジェクトタイトルからFluidClientを取得する機能                    | —                                                                          | implemented |
-| FMT-0001  | フォーマット表示                                                     | client/e2e/core/FMT-0001.spec.ts                                           | implemented |
-| FMT-0002  | フォーマット組み合わせ                                               | client/e2e/core/FMT-0002.spec.ts                                           | implemented |
-| FMT-0003  | 拡張フォーマット                                                     | client/e2e/core/FMT-0003.spec.ts                                           | implemented |
-| FMT-0004  | クリップボードからのペーストとフォーマット                           | client/e2e/core/FMT-0004.spec.ts                                           | implemented |
-| FMT-0005  | Visual Studio Codeのコピー/ペースト仕様                              | client/e2e/disabled/FMT-0005.spec.ts                                       | implemented |
-| FMT-0006  | カーソル移動時のフォーマット表示の一貫性                             | client/e2e/core/FMT-0006.spec.ts                                           | implemented |
-| FMT-0007  | 内部リンク機能の表示                                                 | —                                                                          | implemented |
-| FTR-0012  | User can reset forgotten password                                    | —                                                                          | implemented |
-| FTR-0013  | Use environment variables in min page                                | —                                                                          | implemented |
-| GRF-001   | Graph View                                                           | —                                                                          | implemented |
-| GVI-0001  | Graph View                                                           | —                                                                          | implemented |
-| IME-0001  | IMEを使用した日本語入力                                              | client/e2e/core/IME-0001.spec.ts                                           | implemented |
-| ITM-0001  | Enterで新規アイテム追加                                              | client/e2e/core/ITM-0001.spec.ts<br>client/e2e/core/ITM-0001-title.spec.ts | implemented |
-| LNK-0001  | 内部リンクのURL生成機能                                              | —                                                                          | implemented |
-| LNK-0002  | 内部リンクの機能検証                                                 | —                                                                          | implemented |
-| LNK-0003  | 内部リンクのナビゲーション機能                                       | —                                                                          | implemented |
-| LNK-0004  | 仮ページ機能                                                         | —                                                                          | implemented |
-| LNK-0005  | リンクプレビュー機能                                                 | —                                                                          | implemented |
-| LNK-0006  | リンク先ページの存在確認機能                                         | —                                                                          | implemented |
-| LNK-0007  | バックリンク機能                                                     | —                                                                          | implemented |
-| NAV-0001  | プロジェクト選択とページナビゲーション                               | client/e2e/core/NAV-0001.spec.ts                                           | implemented |
-| NAV-0002  | プロジェクトページへのリンク機能                                     | —                                                                          | implemented |
-| PERF-0001 | パフォーマンステスト                                                 | client/e2e/new/PERF-0001.spec.ts                                           | implemented |
-| SEC-0001  | Dotenvx encrypted env files                                          | —                                                                          | implemented |
-| SHR-0001  | プロジェクト共有テスト                                               | client/e2e/new/SHR-0001.spec.ts                                            | implemented |
-| SHR-0002  | リアルタイム共有テスト                                               | client/e2e/new/SHR-0002.spec.ts                                            | implemented |
-| SLR-0001  | Shift + 上下左右                                                     | client/e2e/core/SLR-0001.spec.ts                                           | implemented |
-| SLR-0002  | 行頭まで選択                                                         | client/e2e/core/SLR-0002.spec.ts                                           | implemented |
-| SLR-0003  | 行末まで選択                                                         | client/e2e/core/SLR-0003.spec.ts                                           | implemented |
-| SLR-0004  | マウスドラッグによる選択                                             | client/e2e/core/SLR-0004.spec.ts                                           | implemented |
-| SLR-0005  | 複数アイテムにまたがる選択                                           | client/e2e/core/SLR-0005.spec.ts                                           | implemented |
-| SLR-0006  | 複数アイテム選択範囲のコピー＆ペースト                               | client/e2e/core/SLR-0006.spec.ts                                           | implemented |
-| SLR-0007  | 複数アイテム選択範囲の削除                                           | client/e2e/core/SLR-0007.spec.ts                                           | implemented |
-| SLR-0008  | 選択範囲のエッジケース                                               | client/e2e/core/SLR-0008.spec.ts                                           | implemented |
-| SLR-0009  | ドラッグ＆ドロップによるテキスト移動                                 | client/e2e/core/SLR-0009.spec.ts                                           | implemented |
-| SLR-0010  | 選択範囲のフォーマット変更                                           | client/e2e/core/SLR-0010.spec.ts                                           | implemented |
-| SLR-0100  | ボックス選択（矩形選択）機能 - キーボード                            | —                                                                          | implemented |
-| SLR-0101  | ボックス選択（矩形選択）機能 - マウス                                | —                                                                          | implemented |
-| SRC-0001  | Basic Search Panel                                                   | client/e2e/new/SRC-0001.spec.ts                                            | implemented |
-| SRC-0002  | Replace All via Search Panel                                         | client/e2e/new/SRC-0002.spec.ts                                            | implemented |
-| SRE-001   | Advanced Search & Replace                                            | client/e2e/new/SRE-001.spec.ts                                             | implemented |
-| SRP-0001  | 高度な検索と置換                                                     | —                                                                          | implemented |
-| TBL-0001  | Editable JOIN Table                                                  | client/e2e/new/TBL-0001.spec.ts                                            | implemented |
-| TBL-0002  | EditableQueryGrid 詳細テスト                                         | client/e2e/new/TBL-0002.spec.ts                                            | implemented |
-| TBL-0003  | SQL クエリ実行テスト                                                 | client/e2e/new/TBL-0003.spec.ts                                            | implemented |
-| TBL-0004  | チャート連携テスト                                                   | client/e2e/new/TBL-0004.spec.ts                                            | implemented |
-| TBL-0005  | queryStore.ts の詳細テスト                                           | —                                                                          | implemented |
-| TBL-0006  | FluidTableClient の統合テスト                                        | —                                                                          | implemented |
-| TST-0001  | SharedTreeデータ検証ユーティリティ                                   | client/e2e/utils/tree-validation.spec.ts                                   | implemented |
-| TST-0002  | カーソル情報検証ユーティリティ                                       | client/e2e/utils/cursor-validation.spec.ts                                 | implemented |
-| TST-0003  | テストヘルパーユーティリティ                                         | —                                                                          | implemented |
-| TST-0004  | テスト環境の改善                                                     | —                                                                          | implemented |
-| TST-0005  | テスト環境の初期化と準備                                             | —                                                                          | implemented |
-| USR-0001  | ユーザー削除機能                                                     | —                                                                          | implemented |
-| USR-0002  | コンテナ削除機能                                                     | —                                                                          | implemented |
+| Feature | Title | Test files | Status |
+|---------|-------|------------|--------|
+| API-0001 | Firebase Functions APIサーバーの修正 | — | implemented |
+| API-0002 | Firebase emulator起動待機機能 | — | implemented |
+| API-0003 | コンテナユーザー一覧取得の管理者チェック | — | implemented |
+| APP-0001 | プロジェクトページ表示時にグローバルテキストエリアにフォーカスを設定 | — | implemented |
+| BRF-0001 | Branch forest item extraction | — | implemented |
+| CHT-001 | Chart Component | — | implemented |
+| CLM-0001 | クリックで編集モードに入る | client/e2e/core/CLM-0001.spec.ts | implemented |
+| CLM-0002 | 左へ移動 | client/e2e/core/CLM-0002.spec.ts | implemented |
+| CLM-0003 | 右へ移動 | client/e2e/core/CLM-0003.spec.ts | implemented |
+| CLM-0004 | 上へ移動 | client/e2e/core/CLM-0004.spec.ts | implemented |
+| CLM-0005 | 下へ移動 | client/e2e/core/CLM-0005.spec.ts | implemented |
+| CLM-0007 | 行頭へ移動 | client/e2e/core/CLM-0007.spec.ts | implemented |
+| CLM-0008 | 行末へ移動 | client/e2e/core/CLM-0008.spec.ts | implemented |
+| CLM-0100 | 通常クリックでカーソルが増えないこと | client/e2e/core/CLM-0100.spec.ts | implemented |
+| CLM-0101 | アイテム間移動時のカーソル重複と入力分散問題 | client/e2e/core/CLM-0101.spec.ts | implemented |
+| CLM-0102 | 空のテキストアイテムでのカーソル移動と複数回のキーボード操作 | client/e2e/core/CLM-0102.spec.ts | implemented |
+| CLM-0103 | フォーマット文字列でのカーソル操作 | client/e2e/core/CLM-0103.spec.ts | implemented |
+| COL-0001 | 他ユーザーのカーソル表示 | client/e2e/disabled/COL-0001.spec.ts | implemented |
+| DBW-0001 | Client-Side WASM DB | — | implemented |
+| DBW-001 | Client-Side SQL Database | client/e2e/new/DBW-001.spec.ts | implemented |
+| EMB-0001 | Outliner Table & Chart Embedding | client/e2e/new/EMB-0001.spec.ts | implemented |
+| ERR-0001 | エラーハンドリングテスト | client/e2e/new/ERR-0001.spec.ts | implemented |
+| FFI-0001 | Fluid Framework Integration | — | implemented |
+| FLD-0001 | プロジェクトタイトルからFluidClientを取得する機能 | — | implemented |
+| FMT-0001 | フォーマット表示 | client/e2e/core/FMT-0001.spec.ts | implemented |
+| FMT-0002 | フォーマット組み合わせ | client/e2e/core/FMT-0002.spec.ts | implemented |
+| FMT-0003 | 拡張フォーマット | client/e2e/core/FMT-0003.spec.ts | implemented |
+| FMT-0004 | クリップボードからのペーストとフォーマット | client/e2e/core/FMT-0004.spec.ts | implemented |
+| FMT-0005 | Visual Studio Codeのコピー/ペースト仕様 | client/e2e/disabled/FMT-0005.spec.ts | implemented |
+| FMT-0006 | カーソル移動時のフォーマット表示の一貫性 | client/e2e/core/FMT-0006.spec.ts | implemented |
+| FMT-0007 | 内部リンク機能の表示 | — | implemented |
+| FTR-0012 | User can reset forgotten password | — | implemented |
+| FTR-0013 | Use environment variables in min page | — | implemented |
+| GRF-001 | Graph View | — | implemented |
+| GVI-0001 | Graph View | — | implemented |
+| IME-0001 | IMEを使用した日本語入力 | client/e2e/core/IME-0001.spec.ts | implemented |
+| ITM-0001 | Enterで新規アイテム追加 | client/e2e/core/ITM-0001-title.spec.ts<br>client/e2e/core/ITM-0001.spec.ts | implemented |
+| LNK-0001 | 内部リンクのURL生成機能 | — | implemented |
+| LNK-0002 | 内部リンクの機能検証 | — | implemented |
+| LNK-0003 | 内部リンクのナビゲーション機能 | — | implemented |
+| LNK-0004 | 仮ページ機能 | — | implemented |
+| LNK-0005 | リンクプレビュー機能 | — | implemented |
+| LNK-0006 | リンク先ページの存在確認機能 | — | implemented |
+| LNK-0007 | バックリンク機能 | — | implemented |
+| NAV-0001 | プロジェクト選択とページナビゲーション | client/e2e/core/NAV-0001.spec.ts | implemented |
+| NAV-0002 | プロジェクトページへのリンク機能 | — | implemented |
+| PERF-0001 | パフォーマンステスト | client/e2e/new/PERF-0001.spec.ts | implemented |
+| SEC-0001 | Dotenvx encrypted env files | — | implemented |
+| SHR-0001 | プロジェクト共有テスト | client/e2e/new/SHR-0001.spec.ts | implemented |
+| SHR-0002 | リアルタイム共有テスト | client/e2e/new/SHR-0002.spec.ts | implemented |
+| SLR-0001 | Shift + 上下左右 | client/e2e/core/SLR-0001.spec.ts | implemented |
+| SLR-0002 | 行頭まで選択 | client/e2e/core/SLR-0002.spec.ts | implemented |
+| SLR-0003 | 行末まで選択 | client/e2e/core/SLR-0003.spec.ts | implemented |
+| SLR-0004 | マウスドラッグによる選択 | client/e2e/core/SLR-0004.spec.ts | implemented |
+| SLR-0005 | 複数アイテムにまたがる選択 | client/e2e/core/SLR-0005.spec.ts | implemented |
+| SLR-0006 | 複数アイテム選択範囲のコピー＆ペースト | client/e2e/core/SLR-0006.spec.ts | implemented |
+| SLR-0007 | 複数アイテム選択範囲の削除 | client/e2e/core/SLR-0007.spec.ts | implemented |
+| SLR-0008 | 選択範囲のエッジケース | client/e2e/core/SLR-0008.spec.ts | implemented |
+| SLR-0009 | ドラッグ＆ドロップによるテキスト移動 | client/e2e/core/SLR-0009.spec.ts | implemented |
+| SLR-0010 | 選択範囲のフォーマット変更 | client/e2e/core/SLR-0010.spec.ts | implemented |
+| SLR-0100 | ボックス選択（矩形選択）機能 - キーボード | — | implemented |
+| SLR-0101 | ボックス選択（矩形選択）機能 - マウス | — | implemented |
+| SRC-0001 | Basic Search Panel | client/e2e/new/SRC-0001.spec.ts | implemented |
+| SRC-0002 | Replace All via Search Panel | client/e2e/new/SRC-0002.spec.ts | implemented |
+| SRE-001 | Advanced Search & Replace | client/e2e/new/SRE-001.spec.ts | implemented |
+| SRP-0001 | 高度な検索と置換 | — | implemented |
+| TBL-0001 | Editable JOIN Table | client/e2e/new/TBL-0001.spec.ts | implemented |
+| TBL-0002 | EditableQueryGrid 詳細テスト | client/e2e/new/TBL-0002.spec.ts | implemented |
+| TBL-0003 | SQL クエリ実行テスト | client/e2e/new/TBL-0003.spec.ts | implemented |
+| TBL-0004 | チャート連携テスト | client/e2e/new/TBL-0004.spec.ts | implemented |
+| TBL-0005 | queryStore.ts の詳細テスト | — | implemented |
+| TBL-0006 | FluidTableClient の統合テスト | — | implemented |
+| TST-0001 | SharedTreeデータ検証ユーティリティ | client/e2e/utils/tree-validation.spec.ts | implemented |
+| TST-0002 | カーソル情報検証ユーティリティ | client/e2e/utils/cursor-validation.spec.ts | implemented |
+| TST-0003 | テストヘルパーユーティリティ | — | implemented |
+| TST-0004 | テスト環境の改善 | — | implemented |
+| TST-0005 | テスト環境の初期化と準備 | — | implemented |
+| USR-0001 | ユーザー削除機能 | — | implemented |
+| USR-0002 | コンテナ削除機能 | — | implemented |


### PR DESCRIPTION
## Summary
- support embedding table/chart in Outliner items
- document new EMB feature
- add TableEmbed and ChartEmbed components
- update feature map and add E2E spec

## Testing
- `scripts/codex-setp.sh`
- `npx playwright test e2e/new/EMB-0001.spec.ts --reporter=list` *(fails)*


------
https://chatgpt.com/codex/tasks/task_e_6850ecd0a588832fb6f6834877c4308c