### PR TITLE
Add encrypted env file test

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -1206,4 +1206,5 @@
   category: security
   status: implemented
   components: []
-  tests: []
+  tests:
+    - server/tests/sec-0001-env.test.js

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -34,10 +34,11 @@
 | FMT-0007 | 内部リンク機能の表示 | — | implemented |
 | FTR-0012 | User can reset forgotten password | — | implemented |
 | FTR-0013 | Use environment variables in min page | — | implemented |
+| FTR-0014 | Configurable host and port via environment variables | — | implemented |
 | GRF-001 | Graph View | — | implemented |
 | GVI-0001 | Graph View | — | implemented |
 | IME-0001 | IMEを使用した日本語入力 | client/e2e/core/IME-0001.spec.ts | implemented |
-| ITM-0001 | Enterで新規アイテム追加 | client/e2e/core/ITM-0001-title.spec.ts<br>client/e2e/core/ITM-0001.spec.ts | implemented |
+| ITM-0001 | Enterで新規アイテム追加 | client/e2e/core/ITM-0001.spec.ts<br>client/e2e/core/ITM-0001-title.spec.ts | implemented |
 | LNK-0001 | 内部リンクのURL生成機能 | — | implemented |
 | LNK-0002 | 内部リンクの機能検証 | — | implemented |
 | LNK-0003 | 内部リンクのナビゲーション機能 | — | implemented |

--- a/server/tests/sec-0001-env.test.js
+++ b/server/tests/sec-0001-env.test.js
@@ -1,0 +1,22 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+
+/** @feature SEC-0001 */
+describe('Dotenvx encrypted env files (SEC-0001)', function () {
+  it('all environment variables are encrypted', function () {
+    const envPath = path.resolve(__dirname, '../.env.development');
+    const lines = fs.readFileSync(envPath, 'utf-8').split(/\r?\n/);
+    const envLines = lines.filter(
+      (line) => line.trim() && !line.startsWith('#') && !line.startsWith('DOTENV_PUBLIC_KEY')
+    );
+    envLines.forEach((line) => {
+      const idx = line.indexOf('=');
+      expect(idx).to.be.greaterThan(-1);
+      const value = line.slice(idx + 1).replace(/^"|"$/g, '');
+      expect(value.startsWith('encrypted:'), `${line} should start with encrypted:`).to.be
+        .true;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha test to check `.env.development` for `encrypted:` prefixes
- record the test in the feature list
- regenerate `feature-map.md`

## Testing
- `npx mocha tests/sec-0001-env.test.js --timeout 10000`

------
https://chatgpt.com/codex/tasks/task_e_6850fb480c98832fb09c0d35de5f6e5d