### PR TITLE
Fix auth service test environment

### DIFF
--- a/server/tests/auth-service.test.js
+++ b/server/tests/auth-service.test.js
@@ -1,6 +1,10 @@
 const { describe, it, before } = require("mocha");
 const { expect } = require("chai");
-const request = require("supertest")(`http://localhost:${process.env.TEST_API_PORT || 7091}`);
+const apiPort = process.env.TEST_API_PORT;
+if (!apiPort) {
+  throw new Error("TEST_API_PORT env var is required");
+}
+const request = require("supertest")(`http://localhost:${apiPort}`);
 
 describe("Auth service integration", function () {
   this.timeout(10000);


### PR DESCRIPTION
## Summary
- rename `auth-service.test.js.skip` to `auth-service.test.js`
- require `TEST_API_PORT` environment variable in the auth service test

## Testing
- `./scripts/codex-setp.sh`
- `cd server && npm test` *(fails: Cannot find module '../firebase-adminsdk.json')*
- `npx mocha tests/auth-service.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6850fb26a314832fb5f1e6d59bbff501