### PR TITLE
Fix server log output and add test

### DIFF
--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -18,6 +18,17 @@
     - client/.env.example
   tests: []
 
+- id: LOG-0001
+  title: Log test servers to files only
+  description: Servers started by codex-setp.sh log output exclusively to files to keep console output clean
+  category: developer-experience
+  status: implemented
+  components:
+    - scripts/common-functions.sh
+    - scripts/codex-setp.sh
+  tests:
+    - server/tests/server-log-file.test.js
+
 - id: FTR-0014
   title: Configurable host and port via environment variables
   description: Default service hosts and ports are configurable through environment variables with fallbacks.
@@ -1207,3 +1218,14 @@
   status: implemented
   components: []
   tests: []
+
+- id: LOG-0001
+  title: Log test servers to files only
+  description: Servers started by codex-setp.sh log output exclusively to files to keep console output clean
+  category: developer-experience
+  status: implemented
+  components:
+    - scripts/common-functions.sh
+    - scripts/codex-setp.sh
+  tests:
+    - server/tests/server-log-file.test.js

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -169,7 +169,7 @@ start_firebase_emulator() {
 
   echo "Starting Firebase emulator..."
   cd "${ROOT_DIR}"
-  firebase emulators:start --project ${FIREBASE_PROJECT_ID} 2>&1 | tee "${ROOT_DIR}/server/logs/firebase-emulator.log" &
+  firebase emulators:start --project ${FIREBASE_PROJECT_ID} > "${ROOT_DIR}/server/logs/firebase-emulator.log" 2>&1 &
   cd "${ROOT_DIR}"
 }
 
@@ -177,7 +177,7 @@ start_firebase_emulator() {
 start_tinylicious() {
   echo "Starting Tinylicious server on port ${TEST_FLUID_PORT}..."
   cd "${ROOT_DIR}/client"
-  PORT=${TEST_FLUID_PORT} npx tinylicious 2>&1 | tee "${ROOT_DIR}/server/logs/tinylicious.log" &
+  PORT=${TEST_FLUID_PORT} npx tinylicious > "${ROOT_DIR}/server/logs/tinylicious.log" 2>&1 &
   cd "${ROOT_DIR}"
 }
 
@@ -185,7 +185,7 @@ start_tinylicious() {
 start_api_server() {
   echo "Starting API server on port ${TEST_API_PORT}..."
   cd "${ROOT_DIR}/server"
-  npx dotenvx run --env-file=.env.test -- npm --experimental-network-inspection run dev -- --host 0.0.0.0 --port ${TEST_API_PORT} </dev/null 2>&1 | tee "${ROOT_DIR}/server/logs/test-auth-service-tee.log" &
+  npx dotenvx run --env-file=.env.test -- npm --experimental-network-inspection run dev -- --host 0.0.0.0 --port ${TEST_API_PORT} </dev/null > "${ROOT_DIR}/server/logs/test-auth-service-tee.log" 2>&1 &
   cd "${ROOT_DIR}"
 }
 
@@ -193,7 +193,7 @@ start_api_server() {
 start_sveltekit_server() {
   echo "Starting SvelteKit server on port ${VITE_PORT}..."
   cd "${ROOT_DIR}/client"
-  npx dotenvx run --env-file=.env.test -- npm --experimental-network-inspection run dev -- --host 0.0.0.0 --port ${VITE_PORT} </dev/null 2>&1 | tee "${ROOT_DIR}/server/logs/test-svelte-kit.log" &
+  npx dotenvx run --env-file=.env.test -- npm --experimental-network-inspection run dev -- --host 0.0.0.0 --port ${VITE_PORT} </dev/null > "${ROOT_DIR}/server/logs/test-svelte-kit.log" 2>&1 &
   cd "${ROOT_DIR}"
 }
 

--- a/server/tests/server-log-file.test.js
+++ b/server/tests/server-log-file.test.js
@@ -1,0 +1,40 @@
+const { describe, it } = require("mocha");
+const { expect } = require("chai");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+describe("Server logs redirected to file (LOG-0001)", function () {
+  this.timeout(600000); // setup can take time
+
+  it("writes server output only to log files", function () {
+    const root = path.resolve(__dirname, "..", "..");
+    const logFiles = [
+      path.join(root, "server/logs/test-svelte-kit.log"),
+      path.join(root, "server/logs/test-auth-service-tee.log"),
+      path.join(root, "server/logs/tinylicious.log"),
+      path.join(root, "server/logs/firebase-emulator.log"),
+    ];
+    // clean previous logs
+    logFiles.forEach((f) => {
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+    });
+
+    const result = spawnSync("bash", ["scripts/codex-setp.sh"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(result.status).to.equal(0);
+    expect(result.stdout).to.not.match(/Local server:/);
+    expect(result.stdout).to.not.match(/SvelteKit v/);
+
+    logFiles.forEach((f) => {
+      expect(fs.existsSync(f)).to.be.true;
+      const content = fs.readFileSync(f, "utf8");
+      expect(content).to.not.equal("");
+    });
+
+    spawnSync("node", ["scripts/kill-tinylicious.js"], { cwd: root, encoding: "utf8" });
+  });
+});


### PR DESCRIPTION
## Summary
- log server processes to files instead of console
- document feature LOG-0001
- add mocha test to verify logs are written to files

## Testing
- `npx mocha tests/server-log-file.test.js --timeout 600000`

------
https://chatgpt.com/codex/tasks/task_e_6850f9145664832fb0c74d2ecc9cbad7