### PR TITLE
Add FTR-0013 e2e test

### DIFF
--- a/client/e2e/core/FTR-0013.spec.ts
+++ b/client/e2e/core/FTR-0013.spec.ts
@@ -1,0 +1,25 @@
+/** @feature FTR-0013
+ *  Title   : Use environment variables in min page
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("Min page environment variables", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo, [], false, true);
+    });
+
+    test("uses values from import.meta.env", async ({ page }) => {
+        await page.goto("/min");
+        await expect(page.locator("button")).toBeVisible();
+        const envValues = await page.evaluate(() => {
+            return {
+                apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+                verifyUrl: import.meta.env.VITE_TOKEN_VERIFY_URL,
+            };
+        });
+        expect(envValues.apiKey).toBe(process.env.VITE_FIREBASE_API_KEY);
+        expect(envValues.verifyUrl).toBe(process.env.VITE_TOKEN_VERIFY_URL);
+    });
+});

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -16,7 +16,8 @@
   components:
     - client/src/routes/min/+page.svelte
     - client/.env.example
-  tests: []
+  tests:
+    - client/e2e/core/FTR-0013.spec.ts
 
 - id: FTR-0014
   title: Configurable host and port via environment variables

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -33,7 +33,7 @@
 | FMT-0006 | カーソル移動時のフォーマット表示の一貫性 | client/e2e/core/FMT-0006.spec.ts | implemented |
 | FMT-0007 | 内部リンク機能の表示 | — | implemented |
 | FTR-0012 | User can reset forgotten password | — | implemented |
-| FTR-0013 | Use environment variables in min page | — | implemented |
+| FTR-0013 | Use environment variables in min page | client/e2e/core/FTR-0013.spec.ts | implemented |
 | GRF-001 | Graph View | — | implemented |
 | GVI-0001 | Graph View | — | implemented |
 | IME-0001 | IMEを使用した日本語入力 | client/e2e/core/IME-0001.spec.ts | implemented |


### PR DESCRIPTION
## Summary
- add e2e test for FTR-0013 to check env values on `/min`
- document FTR-0013 test in feature files

## Testing
- `bash scripts/codex-setp.sh` *(fails: npm proxy config warnings)*
- `bash scripts/run-tests.sh client/e2e/core/FTR-0013.spec.ts` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850fb3741f8832fb4b4745b8324afad