### PR TITLE
Refactor: use undefined

### DIFF
--- a/client/src/fluid/fluidClient.ts
+++ b/client/src/fluid/fluidClient.ts
@@ -46,10 +46,10 @@ export class FluidClient {
     public readonly project: Project;
 
     // 接続ステータスの追跡
-    private connectionListenerCleanup: (() => void) | null = null;
+    private connectionListenerCleanup: (() => void) | undefined = undefined;
     private connectionRetryCount = 0;
     private readonly MAX_RETRY_COUNT = 3;
-    currentUser: { id: string; } | null = null;
+    currentUser: { id: string; } | undefined = undefined;
 
     /**
      * コンストラクタ - 必要なパラメータを全て受け取る
@@ -247,7 +247,7 @@ export class FluidClient {
             containerId: this.containerId,
             treeData: this.appData?.root ? this.getAllData() : {},
             treeCount: rootItems?.length || 0,
-            treeFirstItem: hasItems ? rootItems[0]?.text || null : null,
+            treeFirstItem: hasItems ? rootItems[0]?.text || undefined : undefined,
             timeStamp: new Date().toISOString(),
             currentUser: userManager.getCurrentUser(),
         };
@@ -279,7 +279,7 @@ export class FluidClient {
         const parts = path.split(".");
         let result = treeData as any;
         for (const part of parts) {
-            if (result === undefined || result === null) return null;
+            if (result === undefined) return undefined;
             result = result[part];
         }
         return result;
@@ -321,7 +321,7 @@ export class FluidClient {
     public dispose() {
         if (this.connectionListenerCleanup) {
             this.connectionListenerCleanup();
-            this.connectionListenerCleanup = null;
+            this.connectionListenerCleanup = undefined;
         }
 
         this.appData.dispose();

--- a/client/src/stores/EditorOverlayStore.svelte.ts
+++ b/client/src/stores/EditorOverlayStore.svelte.ts
@@ -55,33 +55,33 @@ export class EditorOverlayStore {
     // Cursor インスタンスを保持する Map
     cursorInstances = new Map<string, Cursor>();
     selections = $state<Record<string, SelectionRange>>({});
-    activeItemId = $state<string | null>(null);
+    activeItemId = $state<string | undefined>(undefined);
     cursorVisible = $state<boolean>(true);
     animationPaused = $state<boolean>(false);
     // GlobalTextArea の textarea 要素を保持
-    textareaRef = $state<HTMLTextAreaElement | null>(null);
+    textareaRef = $state<HTMLTextAreaElement | undefined>(undefined);
     // onEdit コールバック
-    onEditCallback: (() => void) | null = null;
+    onEditCallback: (() => void) | undefined = undefined;
 
     private timerId!: ReturnType<typeof setTimeout>;
 
     // テキストエリア参照を設定
-    setTextareaRef(el: HTMLTextAreaElement | null) {
+    setTextareaRef(el: HTMLTextAreaElement | undefined) {
         this.textareaRef = el;
     }
 
     // テキストエリア参照を取得
-    getTextareaRef(): HTMLTextAreaElement | null {
+    getTextareaRef(): HTMLTextAreaElement | undefined {
         return this.textareaRef;
     }
 
     // onEdit コールバックを設定
-    setOnEditCallback(callback: (() => void) | null) {
+    setOnEditCallback(callback: (() => void) | undefined) {
         this.onEditCallback = callback;
     }
 
     // onEdit コールバックを取得
-    getOnEditCallback(): (() => void) | null {
+    getOnEditCallback(): (() => void) | undefined {
         return this.onEditCallback;
     }
 
@@ -96,7 +96,7 @@ export class EditorOverlayStore {
         if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
             return crypto.randomUUID();
         }
-        const bytes = (typeof crypto !== "undefined" ? crypto.getRandomValues(new Uint8Array(16)) : null) ||
+        const bytes = (typeof crypto !== "undefined" ? crypto.getRandomValues(new Uint8Array(16)) : undefined) ||
             new Uint8Array(16);
         bytes[6] = (bytes[6] & 0x0f) | 0x40;
         bytes[8] = (bytes[8] & 0x3f) | 0x80;
@@ -416,11 +416,11 @@ export class EditorOverlayStore {
         }
     }
 
-    setActiveItem(itemId: string | null) {
+    setActiveItem(itemId: string | undefined) {
         this.activeItemId = itemId;
     }
 
-    getActiveItem(): string | null {
+    getActiveItem(): string | undefined {
         return this.activeItemId;
     }
 
@@ -551,7 +551,7 @@ export class EditorOverlayStore {
     reset() {
         this.cursors = {};
         this.selections = {};
-        this.activeItemId = null;
+        this.activeItemId = undefined;
         this.cursorVisible = true;
         this.animationPaused = false;
         clearTimeout(this.timerId);
@@ -1014,7 +1014,7 @@ export class EditorOverlayStore {
         itemIdToIndex: Map<string, number>;
         allItems: HTMLElement[];
         timestamp: number;
-    } | null = null;
+    } | undefined = undefined;
 
     /**
      * アイテムIDとインデックスのマッピングを取得する（キャッシュ付き）

--- a/client/src/stores/firestoreStore.svelte.ts
+++ b/client/src/stores/firestoreStore.svelte.ts
@@ -35,7 +35,7 @@ export interface UserContainer {
 
 class GeneralStore {
     // ユーザーコンテナのストア
-    userContainer: UserContainer | null = $state(null);
+    userContainer: UserContainer | undefined = $state(undefined);
 }
 export const firestoreStore = new GeneralStore();
 
@@ -100,14 +100,14 @@ catch (error) {
 }
 
 // リスナーの解除関数
-let unsubscribe: (() => void) | null = null;
+let unsubscribe: (() => void) | undefined = undefined;
 
 // Firestoreとの同期を開始する関数
 function initFirestoreSync(): () => void {
     // 以前のリスナーがあれば解除
     if (unsubscribe) {
         unsubscribe();
-        unsubscribe = null;
+        unsubscribe = undefined;
     }
 
     const currentUser = userManager.getCurrentUser();
@@ -162,7 +162,7 @@ function initFirestoreSync(): () => void {
         return () => {
             if (unsubscribe) {
                 unsubscribe();
-                unsubscribe = null;
+                unsubscribe = undefined;
             }
         };
     }
@@ -369,14 +369,14 @@ if (typeof window !== "undefined") {
         logger.info("Authentication disabled for tests, skipping Firestore sync initialization");
     }
     else {
-        let cleanup: (() => void) | null = null;
+        let cleanup: (() => void) | undefined = undefined;
 
         // 認証状態が変更されたときに Firestore 同期を初期化/クリーンアップ
         const unsubscribeAuth = userManager.addEventListener(authResult => {
             // 前回のクリーンアップがあれば実行
             if (cleanup) {
                 cleanup();
-                cleanup = null;
+                cleanup = undefined;
             }
 
             // 認証されていればリスナーを設定
@@ -385,7 +385,7 @@ if (typeof window !== "undefined") {
             }
             else {
                 // 未認証の場合はコンテナを空にする
-                firestoreStore.userContainer = null;
+                firestoreStore.userContainer = undefined;
             }
         });
 

--- a/server/scripts/test-dev-auth.js
+++ b/server/scripts/test-dev-auth.js
@@ -48,7 +48,7 @@ async function testEmailPasswordLogin() {
 
         const loginData = await loginResponse.json();
         console.log(`${colors.green}ログイン成功!${colors.reset}`);
-        console.log(`ユーザー: ${JSON.stringify(loginData.user, null, 2)}`);
+        console.log(`ユーザー: ${JSON.stringify(loginData.user, undefined, 2)}`);
 
         if (!loginData.customToken) {
             console.error(`${colors.red}カスタムトークンが返されませんでした${colors.reset}`);
@@ -91,7 +91,7 @@ async function testEmailPasswordLogin() {
         const fluidTokenData = await fluidTokenResponse.json();
         console.log(`${colors.green}Fluidトークン取得成功!${colors.reset}`);
         console.log(`テナントID: ${fluidTokenData.tenantId}`);
-        console.log(`ユーザー: ${JSON.stringify(fluidTokenData.user, null, 2)}`);
+        console.log(`ユーザー: ${JSON.stringify(fluidTokenData.user, undefined, 2)}`);
 
         if (fluidTokenData.token) {
             console.log(`${colors.green}トークン検証に成功しました！${colors.reset}`);

--- a/server/start-with-ngrok.js
+++ b/server/start-with-ngrok.js
@@ -8,8 +8,8 @@ const LOCAL_HOST = process.env.LOCAL_HOST || "localhost";
 
 // サーバーとngrokのプロセスを格納するオブジェクト
 const processes = {
-    ngrok: null,
-    server: null,
+    ngrok: undefined,
+    server: undefined,
 };
 
 // 終了時のクリーンアップ
@@ -50,7 +50,7 @@ function startNgrok(port) {
         processes.ngrok = ngrok;
 
         let ngrokOutput = "";
-        let timeout = null;
+        let timeout = undefined;
 
         // 3秒経過してもURL取得できなかったらAPIから取得を試みる
         timeout = setTimeout(async () => {
@@ -68,7 +68,7 @@ function startNgrok(port) {
         });
 
         ngrok.on("close", code => {
-            processes.ngrok = null;
+            processes.ngrok = undefined;
             console.log(`ngrokが終了しました（コード: ${code}）`);
 
             if (code !== 0 && processes.server) {
@@ -108,7 +108,7 @@ function startServer() {
         });
 
         server.on("close", code => {
-            processes.server = null;
+            processes.server = undefined;
             console.log(`サーバーが終了しました（コード: ${code}）`);
 
             if (code !== 0 && processes.ngrok) {

--- a/server/tests/auth-service-test-helper.js
+++ b/server/tests/auth-service-test-helper.js
@@ -192,7 +192,7 @@ function generateAzureFluidToken(user, containerId = undefined) {
             name: user.displayName || "Anonymous",
         },
         tenantId: azureConfig.tenantId,
-        containerId: containerId || null,
+        containerId: containerId || undefined,
     };
 }
 

--- a/server/utils/ngrok-helper.js
+++ b/server/utils/ngrok-helper.js
@@ -11,7 +11,7 @@ const envPath = path.join(__dirname, "..", ".env");
 
 /**
  * ngrokのAPI経由で現在のパブリックURLを取得
- * @returns {Promise<string|null>} ngrokのパブリックURL
+ * @returns {Promise<string | undefined>} ngrokのパブリックURL
  */
 async function getNgrokPublicUrl() {
     try {
@@ -34,12 +34,12 @@ async function getNgrokPublicUrl() {
         }
 
         console.warn("アクティブなngrokトンネルが見つかりません");
-        return null;
+        return undefined;
     }
     catch (error) {
         console.error("ngrok APIにアクセスできません:", error.message);
         console.error("ngrokが起動しているか確認してください");
-        return null;
+        return undefined;
     }
 }
 
@@ -90,7 +90,7 @@ function updateEnvCallbackUrl(ngrokUrl) {
 
 /**
  * ngrokのパブリックURLを取得して.envファイルを更新
- * @returns {Promise<string|null>} 更新されたngrokのURL
+ * @returns {Promise<string | undefined>} 更新されたngrokのURL
  */
 async function setupNgrokUrl() {
     const ngrokUrl = await getNgrokPublicUrl();
@@ -102,7 +102,7 @@ async function setupNgrokUrl() {
         }
     }
 
-    return null;
+    return undefined;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- replace `null` with `undefined` in server utilities
- adjust client stores and fluid client to use `undefined`
- update test scripts accordingly

## Testing
- `npm run test:unit --silent` *(fails: tests hang)*
- `npx playwright test e2e/core/basic.spec.ts` *(fails: assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_6850fb20374c832f8d7cd4a90911a42a