### PR TITLE
Improve test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,14 @@ scripts/run-tests.sh client/e2e/your-spec-file.spec.ts
 PORT=7100 scripts/run-tests.sh client/e2e/your-spec-file.spec.ts
 ```
 テスト実行前に必ず `scripts/codex-setp.sh` を実行してローカルのエミュレータ群を起動してください。
+This script must run **before every test** to ensure all services are available.
 
 自動化されたテストにより、主要機能の回帰を防ぎます。CI環境でも同じコマンドが実行されます。
+
+### E2E テストのガイドライン
+
+- `.nth()` などの位置指定は使わず、必ず `data-item-id` 属性を用いて要素を取得します。
+- DOM へアクセスする場合は `TestHelpers` 経由で実行し、`page.evaluate` を直接書かないようにします。
 
 ### Feature Map の更新
 

--- a/client/docs/clipboard-test-guide.md
+++ b/client/docs/clipboard-test-guide.md
@@ -36,7 +36,13 @@ npm run test:e2e:localhost:debug e2e/core/FMT-0004.spec.ts
 npm run test:e2e:localhost:ui e2e/core/FMT-0004.spec.ts
 ```
 テストを実行する前に必ず `scripts/codex-setp.sh` を実行してください。
+This sets up Firebase emulators and other services required for the tests.
 Playwright テストは `scripts/run-tests.sh <spec>` を利用して 1 ファイルずつ実行します。
+
+### Test Guidelines
+
+- 要素取得には `data-item-id` 属性を利用し、`.nth()` の使用は避けます。
+- 画面状態の取得や DOM 操作は `TestHelpers` を介して行い、`page.evaluate` を直接書かないようにします。
 
 ## テストの内容
 

--- a/docs/join-table/README.md
+++ b/docs/join-table/README.md
@@ -6,6 +6,7 @@ This feature introduces a SQL powered table component that syncs data through th
 
 1. `npm --prefix client install`
 2. Run services: `./scripts/codex-setp.sh`
+   - Always execute this script before running any tests so that the emulators are available.
 3. Run unit tests: `npm --prefix client run test:unit`
 4. Run E2E tests:
    ```bash
@@ -13,6 +14,11 @@ This feature introduces a SQL powered table component that syncs data through th
    npx playwright test e2e/core/basic.spec.ts --project=core --reporter=list
    npx playwright test e2e/new/TBL-0001.spec.ts --project=new --reporter=list
    ```
+
+### Test Guidelines
+
+- Select elements via `data-item-id` attributes instead of using `.nth()`.
+- Call DOM code through helper utilities (e.g., `TestHelpers`) rather than writing `page.evaluate` inline.
 
 ## Extending
 


### PR DESCRIPTION
## Summary
- stress the need to run `scripts/codex-setp.sh` before tests
- document preferred selectors and helper functions

## Testing
- `./scripts/codex-setp.sh` *(fails: `sudo: npm: command not found`)*
- `./scripts/run-tests.sh client/e2e/core/ALS-0001.spec.ts` *(fails: `sudo: npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685137c5faa8832f8e9eba76a127e58d