### PR TITLE
Refactor e2e selectors and helper usage

### DIFF
--- a/client/e2e/core/CHT-001.spec.ts
+++ b/client/e2e/core/CHT-001.spec.ts
@@ -22,7 +22,7 @@ test.describe('CHT-001 - ChartComponent E2E Tests', () => {
 
         // Verify Bars
         // D3 usually renders bars as <rect> elements
-        const bars = chartSvg.locator('rect.bar'); // Assuming bars have a class 'bar'
+        const bars = chartSvg.locator('rect[data-label]');
         await expect(bars).toHaveCount(3); // Based on sampleData length
 
         // Verify Axes (basic check)
@@ -56,17 +56,15 @@ test.describe('CHT-001 - ChartComponent E2E Tests', () => {
 
         // Check if the 'Banana' bar (expected to be the tallest) has the largest height.
         // This requires getting all bar heights and comparing.
-        let maxHeight = 0;
-        for (let i = 0; i < 3; i++) {
-            const barHeight = await bars.nth(i).getAttribute('height');
-            const height = parseFloat(barHeight || '0');
-            if (height > maxHeight) {
-                maxHeight = height;
-            }
+        const heights: number[] = [];
+        for (const bar of await bars.all()) {
+            const h = parseFloat((await bar.getAttribute('height')) || '0');
+            heights.push(h);
         }
+        const maxHeight = Math.max(...heights);
 
-        const bananaBarIndex = 1; // Banana is the second item in sampleData
-        const bananaBarHeight = parseFloat(await bars.nth(bananaBarIndex).getAttribute('height') || '0');
+        const bananaBar = chartSvg.locator('rect[data-label="Banana"]');
+        const bananaBarHeight = parseFloat(await bananaBar.getAttribute('height') || '0');
         expect(bananaBarHeight).toBe(maxHeight);
 
     });

--- a/client/e2e/new/CHT-001.spec.ts
+++ b/client/e2e/new/CHT-001.spec.ts
@@ -8,10 +8,7 @@ test.describe("CHT-001: Chart Component", () => {
     });
 
     test("chart renders page item counts", async ({ page }) => {
-        const pageCount = await page.evaluate(() => {
-            const store = (window as any).appStore;
-            return store.pages.current.length;
-        });
+        const pageCount = await TestHelpers.getPageCount(page);
         await expect(page.locator("svg#chart-svg rect")).toHaveCount(pageCount);
     });
 
@@ -19,7 +16,7 @@ test.describe("CHT-001: Chart Component", () => {
         const newPageName = `p-${Date.now()}`;
         await TestHelpers.createTestPageViaAPI(page, newPageName, []);
         await page.goto("/graph", { waitUntil: "domcontentloaded" });
-        const pageCount = await page.evaluate(() => (window as any).appStore.pages.current.length);
+        const pageCount = await TestHelpers.getPageCount(page);
         await expect(page.locator("svg#chart-svg rect")).toHaveCount(pageCount);
     });
 });

--- a/client/e2e/new/DBW-001.spec.ts
+++ b/client/e2e/new/DBW-001.spec.ts
@@ -11,18 +11,7 @@ test.describe("DBW-001: Client-Side SQL Database", () => {
     });
 
     test("basic CRUD operations", async ({ page }) => {
-        const result = await page.evaluate(async () => {
-            const db = window.__DB_SERVICE__;
-            await db.init();
-            const id = "p1";
-            await db.addPage({ id, title: "First", content: "Hello" });
-            const added = await db.getPage(id);
-            await db.updatePage({ id, title: "Updated", content: "World" });
-            const updated = await db.getPage(id);
-            await db.deletePage(id);
-            const remaining = await db.getAllPages();
-            return { added, updated, remainingCount: remaining.length };
-        });
+        const result = await TestHelpers.runClientDbCrud(page);
 
         expect(result.added.title).toBe("First");
         expect(result.updated.title).toBe("Updated");

--- a/client/e2e/new/TBL-0001.spec.ts
+++ b/client/e2e/new/TBL-0001.spec.ts
@@ -42,24 +42,7 @@ test.describe("TBL-0001: Editable JOIN Table", () => {
         await page.waitForTimeout(2000); // グリッドの描画完了を待つ
 
         // wx-svelte-gridの実際のセル構造を確認（.wx-cellクラス使用）
-        const cellInfo = await page.evaluate(() => {
-            const container = document.querySelector('[data-testid="editable-grid"]');
-            if (!container) return null;
-
-            const cells = container.querySelectorAll(".wx-cell");
-            const dataCells = Array.from(cells).filter(cell => {
-                const role = cell.getAttribute("role");
-                const text = cell.textContent?.trim() || "";
-                // ヘッダーセルではなく、かつヘッダーテキストでもないセルを選択
-                return role !== "columnheader" && !["tbl_pk", "value", "num"].includes(text);
-            });
-
-            return {
-                cellCount: cells.length,
-                dataCellCount: dataCells.length,
-                firstDataCellText: dataCells[0]?.textContent?.trim() || null,
-            };
-        });
+        const cellInfo = await TestHelpers.getEditableGridCellInfo(page);
 
         console.log("Cell info:", cellInfo);
         expect(cellInfo).toBeDefined();
@@ -76,7 +59,7 @@ test.describe("TBL-0001: Editable JOIN Table", () => {
             return (window as any).__JOIN_TABLE__ && (window as any).__JOIN_TABLE__.chartOption;
         }, { timeout: 5000 });
 
-        const chartOption = await page.evaluate(() => (window as any).__JOIN_TABLE__.chartOption);
+        const chartOption = await TestHelpers.getJoinTableChartOption(page);
         expect(chartOption).toBeDefined();
         expect(chartOption.xAxis).toBeDefined();
         expect(chartOption.yAxis).toBeDefined();

--- a/client/src/components/ChartComponent.svelte
+++ b/client/src/components/ChartComponent.svelte
@@ -49,7 +49,8 @@ function render() {
         .attr("y", d => y(d.value))
         .attr("width", x.bandwidth())
         .attr("height", d => height - y(d.value))
-        .attr("fill", "#4caf50");
+        .attr("fill", "#4caf50")
+        .attr("data-label", d => d.label);
 
     svg.append("g")
         .attr("transform", `translate(0,${height})`)


### PR DESCRIPTION
## Summary
- expose bar labels in `ChartComponent` for reliable selection
- use `data-label` in chart spec instead of `.nth()`
- wrap DB CRUD and JOIN table helpers in `TestHelpers`
- use `TestHelpers` in DBW-001, TBL-0001 and chart specs

## Testing
- `scripts/run-tests.sh client/e2e/core/CHT-001.spec.ts` *(fails: `playwright: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685137ce53e4832fa2b10695ededfe69