### PR TITLE
Add FTR-0014 env port test

### DIFF
--- a/client/e2e/core/FTR-0014.spec.ts
+++ b/client/e2e/core/FTR-0014.spec.ts
@@ -1,0 +1,21 @@
+/** @feature FTR-0014
+ *  Title   : Configurable host and port via environment variables
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("FTR-0014: Host and port configuration", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("app uses VITE_PORT and PORT environment variables", async ({ page, baseURL }) => {
+        const vitePort = process.env.VITE_PORT ?? "7090";
+        const port = process.env.PORT ?? "7090";
+
+        await expect(baseURL).toContain(port);
+        await page.goto("/");
+        await expect(page).toHaveURL(new RegExp(`${vitePort}`));
+    });
+});

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -50,6 +50,7 @@
     - client/e2e/core/DFT-0003.spec.ts
     - client/e2e/core/USR-0001.spec.ts
     - client/e2e/core/USR-0002.spec.ts
+    - client/e2e/core/FTR-0014.spec.ts
 - id: FTR-0016
   title: Playwright config supports PORT env variable
   description: The E2E test server port can be set via PORT environment variable with fallback to 7090.


### PR DESCRIPTION
## Summary
- add playwright test to verify VITE_PORT and PORT vars
- document new test in client-features.yaml
- update feature map

## Testing
- `bash scripts/codex-setp.sh` *(failed: `sudo: npm: command not found`)*
- `npx playwright test client/e2e/core/FTR-0014.spec.ts` *(failed: playwright not installed)*
- `python scripts/gen_feature_map.py`

------
https://chatgpt.com/codex/tasks/task_e_6851381caa30832faa30f4d21c0b79ad