### PR TITLE
Add TestHelpers unit tests

### DIFF
--- a/client/e2e/utils/linkTestHelpers.spec.ts
+++ b/client/e2e/utils/linkTestHelpers.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+import { LinkTestHelpers } from "./linkTestHelpers";
+
+test.describe('LinkTestHelpers unit tests', () => {
+    test('forceRenderInternalLinks converts bracket link to anchor', async ({ page }) => {
+        await page.setContent('<div class="outliner-item"><div class="item-text">Example [page]</div></div>');
+        await LinkTestHelpers.forceRenderInternalLinks(page);
+        const link = page.locator('a.internal-link');
+        await expect(link).toHaveCount(1);
+        await expect(link).toHaveAttribute('href', '/page');
+    });
+
+    test('detectInternalLink finds rendered link', async ({ page }) => {
+        await page.setContent('<div class="outliner-item"><div class="item-text">Check [page]</div></div>');
+        await LinkTestHelpers.forceRenderInternalLinks(page);
+        const exists = await LinkTestHelpers.detectInternalLink(page, 'page');
+        expect(exists).toBe(true);
+    });
+
+    test('forceLinkPreview shows preview popup', async ({ page }) => {
+        await page.setContent('<a href="/preview" class="internal-link" data-page="preview">preview</a>');
+        await LinkTestHelpers.forceLinkPreview(page, 'preview');
+        const popup = page.locator('.link-preview-popup');
+        await expect(popup).toBeVisible();
+    });
+});

--- a/client/e2e/utils/testHelpers.spec.ts
+++ b/client/e2e/utils/testHelpers.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import { TestHelpers } from "./testHelpers";
+
+test.describe('TestHelpers unit tests', () => {
+    test('getItemIdByIndex returns dataset id', async ({ page }) => {
+        await page.setContent('<div class="outliner-item" data-item-id="a1"></div>');
+        const id = await TestHelpers.getItemIdByIndex(page, 0);
+        expect(id).toBe('a1');
+    });
+
+    test('forceHoverEvent triggers mouseenter', async ({ page }) => {
+        await page.setContent('<div id="el">hover me</div>');
+        await page.evaluate(() => {
+            window.hovered = false;
+            const el = document.getElementById('el')!;
+            el.addEventListener('mouseenter', () => { window.hovered = true; });
+        });
+        await TestHelpers.forceHoverEvent(page, '#el');
+        const result = await page.evaluate(() => window.hovered);
+        expect(result).toBe(true);
+    });
+
+    test('forceMouseOutEvent triggers mouseleave', async ({ page }) => {
+        await page.setContent('<div id="el">out</div>');
+        await page.evaluate(() => {
+            window.left = false;
+            const el = document.getElementById('el')!;
+            el.addEventListener('mouseleave', () => { window.left = true; });
+        });
+        await TestHelpers.forceMouseOutEvent(page, '#el');
+        const result = await page.evaluate(() => window.left);
+        expect(result).toBe(true);
+    });
+
+    test('forceCheckVisibility returns true for visible and false for hidden', async ({ page }) => {
+        await page.setContent('<div id="v" style="display:block;width:100px;height:100px;"></div><div id="h" style="display:none"></div>');
+        const visible = await TestHelpers.forceCheckVisibility('#v', page, 0, 1);
+        const hidden = await TestHelpers.forceCheckVisibility('#h', page, 0, 1);
+        expect(visible).toBe(true);
+        expect(hidden).toBe(false);
+    });
+});

--- a/client/playwright.unit.config.ts
+++ b/client/playwright.unit.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './e2e/utils',
+    testMatch: '*.spec.ts',
+    fullyParallel: false,
+    reporter: [['list']],
+    use: { ...devices['Desktop Chrome'] },
+});

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -679,6 +679,8 @@
     - client/e2e/core/add-text.spec.ts
     - client/e2e/core/tinylicious.spec.ts
     - client/e2e/auth/auth.spec.ts
+    - client/e2e/utils/testHelpers.spec.ts
+    - client/e2e/utils/linkTestHelpers.spec.ts
   examples:
     - client/e2e/utils/testHelpers.ts
 


### PR DESCRIPTION
## Summary
- add unit tests for TestHelpers helper class
- add unit tests for LinkTestHelpers helper class
- allow running all util specs with minimal Playwright config
- document the new spec in the feature list

## Testing
- `npx playwright test e2e/utils/testHelpers.spec.ts --config=playwright.unit.config.ts`
- `npx playwright test e2e/utils/linkTestHelpers.spec.ts --config=playwright.unit.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_685121fc3b7c832f9f76263674d8483f