### PR TITLE
Implement forgot password route

### DIFF
--- a/client/e2e/auth/FTR-0012-forgot-password.spec.ts
+++ b/client/e2e/auth/FTR-0012-forgot-password.spec.ts
@@ -37,10 +37,8 @@ test.describe('FTR-0012 - Forgot Password UI Flow', () => {
     });
 
     test('Reset Password Page - UI and Submission (assumes navigation to reset page)', async ({ page }) => {
-        // This test simulates a user landing on the reset password page,
-        // typically by clicking a link in an email. The token would be part of the URL.
-        // The actual token validation and handling are outside the scope of this UI test.
-        await page.goto(`${resetPasswordRoute}?token=testtoken123`);
+        // Simulate user landing on the reset password page with a token
+        await page.goto(`${resetPasswordRoute}?oobCode=testtoken123`);
 
         // Verify page title/heading (assuming one exists)
         // Example: await expect(page.locator('h1')).toHaveText('Reset Your Password');

--- a/client/src/lib/email/resetPassword.ts
+++ b/client/src/lib/email/resetPassword.ts
@@ -31,3 +31,17 @@ export async function resetPassword(oobCode: string, newPassword: string): Promi
         throw new Error(`Failed to reset password: ${msg}`);
     }
 }
+
+export async function validateResetToken(oobCode: string): Promise<void> {
+    const url = `${getFunctionsBaseUrl()}/api/validate-reset-token`;
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ oobCode })
+    });
+    if (!res.ok) {
+        const msg = await res.text();
+        throw new Error(`Invalid token: ${msg}`);
+    }
+}
+

--- a/client/src/routes/auth/forgot.svelte
+++ b/client/src/routes/auth/forgot.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+import { sendResetLink, validateResetToken } from '$lib/email/resetPassword';
+import { page } from '$app/stores';
+import { onMount } from 'svelte';
+
+let email = $state('');
+let sent = $state(false);
+let error = $state('');
+let tokenValid = $state(false);
+
+onMount(async () => {
+    const token = $page.url.searchParams.get('oobCode');
+    if (token) {
+        try {
+            await validateResetToken(token);
+            tokenValid = true;
+        } catch (e) {
+            error = e instanceof Error ? e.message : 'Invalid or expired token';
+        }
+    }
+});
+
+async function submitForm() {
+    sent = false;
+    error = '';
+    try {
+        await sendResetLink(email);
+        sent = true;
+    } catch (e) {
+        error = e instanceof Error ? e.message : 'Failed to send link';
+    }
+}
+</script>
+
+{#if tokenValid}
+    <p class="token-valid">Token validated. <a href="/auth/reset-password?oobCode={$page.url.searchParams.get('oobCode')}">Reset password</a>.</p>
+{:else}
+    <form on:submit|preventDefault={submitForm} class="space-y-4">
+        <label>
+            <span>Email</span>
+            <input type="email" bind:value={email} required class="border p-2" />
+        </label>
+        <button type="submit" class="border px-4 py-2">Send Reset Link</button>
+    </form>
+{/if}
+
+{#if sent}
+    <p class="reset-link-sent">If an account with this email exists, a password reset link has been sent.</p>
+{:else if error}
+    <p class="error">{error}</p>
+{/if}

--- a/client/src/tests/resetPassword.test.ts
+++ b/client/src/tests/resetPassword.test.ts
@@ -1,0 +1,50 @@
+/** @feature FTR-0012
+ *  Title   : User can reset forgotten password
+ *  Source  : docs/client-features.yaml
+ */
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import { sendResetLink, resetPassword, validateResetToken } from '../lib/email/resetPassword';
+
+const baseUrl = 'http://localhost:57000';
+
+declare global {
+    // eslint-disable-next-line no-var
+    var fetch: typeof fetch;
+}
+
+describe('resetPassword email helpers', () => {
+    beforeEach(() => {
+        process.env.VITE_FIREBASE_FUNCTIONS_URL = baseUrl;
+    });
+
+    afterEach(() => {
+        delete process.env.VITE_FIREBASE_FUNCTIONS_URL;
+        vi.restoreAllMocks();
+    });
+
+    it('sendResetLink posts email', async () => {
+        const mock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' });
+        global.fetch = mock;
+        await sendResetLink('test@example.com');
+        expect(mock).toHaveBeenCalledWith(
+            `${baseUrl}/api/send-reset-password`,
+            expect.objectContaining({ method: 'POST' })
+        );
+    });
+
+    it('resetPassword posts token and password', async () => {
+        const mock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' });
+        global.fetch = mock;
+        await resetPassword('token', 'pass');
+        expect(mock).toHaveBeenCalledWith(
+            `${baseUrl}/api/confirm-reset-password`,
+            expect.objectContaining({ method: 'POST' })
+        );
+    });
+
+    it('validateResetToken throws when invalid', async () => {
+        const mock = vi.fn().mockResolvedValue({ ok: false, text: async () => 'bad' });
+        global.fetch = mock;
+        await expect(validateResetToken('token')).rejects.toThrow('Invalid token: bad');
+    });
+});

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -1,7 +1,8 @@
 - id: FTR-0012
   title: User can reset forgotten password
-  status: implemented # draft / implemented / deprecated
+  status: implemented
   components:
+    - client/src/routes/auth/forgot.svelte
     - client/src/routes/auth/forgot/+page.svelte
     - client/src/routes/auth/reset-password/+page.svelte
     - client/src/lib/email/resetPassword.ts


### PR DESCRIPTION
## Summary
- add forgot password page
- validate reset token with new API helper
- document implemented components in client-features
- test resetPassword email module
- adjust forgot-password e2e flow

## Testing
- `scripts/run-tests.sh client/e2e/auth/FTR-0012-forgot-password.spec.ts` *(fails: npm ci missing packages)*
- `cd client && npm run test:unit -- src/tests/resetPassword.test.ts` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514fb81d8c832fad497a408aa5762d