### PR TITLE
Add custom port E2E test

### DIFF
--- a/client/e2e/new/FTR-0014.spec.ts
+++ b/client/e2e/new/FTR-0014.spec.ts
@@ -1,0 +1,18 @@
+/** @feature FTR-0014 */
+import { expect, test } from "@playwright/test";
+
+/**
+ * FTR-0014: Verify custom PORT and VITE_PORT environment variables
+ */
+
+test.describe("FTR-0014: custom environment ports", () => {
+    test("uses provided PORT and VITE_PORT for server", async ({ page, baseURL }) => {
+        const port = process.env.PORT ?? "7090";
+        const vitePort = process.env.VITE_PORT ?? port;
+
+        await expect(baseURL).toContain(port);
+        await page.goto("/");
+        await expect(page).toHaveURL(new RegExp(`${vitePort}`));
+        await expect(page.locator("h1")).toContainText("Fluid Outliner App");
+    });
+});

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -51,6 +51,7 @@
     - client/e2e/core/USR-0001.spec.ts
     - client/e2e/core/USR-0002.spec.ts
     - client/e2e/core/FTR-0014.spec.ts
+    - client/e2e/new/FTR-0014.spec.ts
 - id: FTR-0016
   title: Playwright config supports PORT env variable
   description: The E2E test server port can be set via PORT environment variable with fallback to 7090.


### PR DESCRIPTION
## Summary
- add FTR-0014 test to check custom PORT and VITE_PORT
- document test in feature list

## Testing
- `PORT=5200 VITE_PORT=5200 npx playwright test e2e/new/FTR-0014.spec.ts --reporter=list`


------
https://chatgpt.com/codex/tasks/task_e_68514fe3ca98832f9b27854fdb119d59