### PR TITLE
Remove nth() selectors from e2e tests

### DIFF
--- a/client/e2e/core/FMT-0005-multicursor.spec.ts
+++ b/client/e2e/core/FMT-0005-multicursor.spec.ts
@@ -26,9 +26,10 @@ test.describe("マルチカーソル ペースト", () => {
         await page.keyboard.type("third");
 
         // add multi cursors via Alt+click
-        await items.nth(0).locator(".item-text").click({ modifiers: ["Alt"] });
-        await items.nth(1).locator(".item-text").click({ modifiers: ["Alt"] });
-        await items.nth(2).locator(".item-text").click({ modifiers: ["Alt"] });
+        for (const i of [0, 1, 2]) {
+            const locator = await TestHelpers.getItemLocatorByIndex(page, i);
+            await locator!.locator(".item-text").click({ modifiers: ["Alt"] });
+        }
 
         // dispatch paste event with VSCode metadata
         const lines = ["A", "B", "C"];
@@ -45,9 +46,10 @@ test.describe("マルチカーソル ペースト", () => {
         }, lines);
 
         await page.waitForTimeout(500);
-        await expect(items.nth(0).locator(".item-text")).toHaveText(/A/);
-        await expect(items.nth(1).locator(".item-text")).toHaveText(/B/);
-        await expect(items.nth(2).locator(".item-text")).toHaveText(/C/);
+        for (const [i, ch] of ["A", "B", "C"].entries()) {
+            const locator = await TestHelpers.getItemLocatorByIndex(page, i);
+            await expect(locator!.locator(".item-text")).toHaveText(new RegExp(ch));
+        }
     });
 
     test("シングルカーソルからマルチカーソルへのペースト(full)", async ({ page }) => {
@@ -58,8 +60,10 @@ test.describe("マルチカーソル ペースト", () => {
         await page.keyboard.press("Enter");
         await page.keyboard.type("two");
 
-        await items.nth(0).locator(".item-text").click({ modifiers: ["Alt"] });
-        await items.nth(1).locator(".item-text").click({ modifiers: ["Alt"] });
+        for (const i of [0, 1]) {
+            const locator = await TestHelpers.getItemLocatorByIndex(page, i);
+            await locator!.locator(".item-text").click({ modifiers: ["Alt"] });
+        }
 
         const lines = ["X", "Y"];
         await page.evaluate((lines) => {
@@ -76,7 +80,9 @@ test.describe("マルチカーソル ペースト", () => {
 
         await page.waitForTimeout(500);
         const expected = "X\nY";
-        await expect(items.nth(0).locator(".item-text")).toHaveText(expected);
-        await expect(items.nth(1).locator(".item-text")).toHaveText(expected);
+        for (const i of [0, 1]) {
+            const locator = await TestHelpers.getItemLocatorByIndex(page, i);
+            await expect(locator!.locator(".item-text")).toHaveText(expected);
+        }
     });
 });

--- a/client/e2e/core/FMT-0005.spec.ts
+++ b/client/e2e/core/FMT-0005.spec.ts
@@ -112,9 +112,12 @@ test.describe("Visual Studio Codeのコピー/ペースト仕様", () => {
 
         // 各アイテムのテキストが正しいことを確認（可能な場合）
         if (count >= 3) {
-            const text1 = await items.nth(0).locator(".item-text").textContent();
-            const text2 = await items.nth(1).locator(".item-text").textContent();
-            const text3 = await items.nth(2).locator(".item-text").textContent();
+            const id1 = await TestHelpers.getItemIdByIndex(page, 0);
+            const id2 = await TestHelpers.getItemIdByIndex(page, 1);
+            const id3 = await TestHelpers.getItemIdByIndex(page, 2);
+            const text1 = await page.locator(`[data-item-id="${id1}"] .item-text`).textContent();
+            const text2 = await page.locator(`[data-item-id="${id2}"] .item-text`).textContent();
+            const text3 = await page.locator(`[data-item-id="${id3}"] .item-text`).textContent();
 
             // テキストが含まれていることを確認（完全一致でなくても可）
             expect(text1).toContain("1行目");
@@ -206,8 +209,8 @@ test.describe("Visual Studio Codeのコピー/ペースト仕様", () => {
         // 新しいアイテムを作成してフォーカス
         await page.keyboard.press("Enter"); // Create new item below
         await TestHelpers.waitForOutlinerItems(page, 2); // Wait for the second item
-        const secondItem = page.locator(".outliner-item").nth(1);
-        const secondItemContent = secondItem.locator(".item-content");
+        const secondItemLocator = await TestHelpers.getItemLocatorByIndex(page, 1);
+        const secondItemContent = secondItemLocator!.locator(".item-content");
         await secondItemContent.click(); // Focus the new item
         await TestHelpers.waitForCursorVisible(page); // Ensure cursor is in the new item
 
@@ -215,13 +218,12 @@ test.describe("Visual Studio Codeのコピー/ペースト仕様", () => {
         await page.keyboard.press(isMac ? "Meta+V" : "Control+V");
 
         // 少し待ってからテキスト内容を確認
-        await page.waitForFunction(async (expectedText) => {
-            const secondItemHandle = document.querySelectorAll(".outliner-item")[1];
-            const itemTextElement = secondItemHandle?.querySelector(".item-text");
-            return itemTextElement?.textContent?.includes(expectedText);
-        }, textToCopy, { timeout: 5000 });
+        await page.waitForFunction(async (expectedText, id) => {
+            const el = document.querySelector(`.outliner-item[data-item-id="${id}"] .item-text`);
+            return el?.textContent?.includes(expectedText);
+        }, textToCopy, await TestHelpers.getItemIdByIndex(page, 1), { timeout: 5000 });
 
-        await expect(secondItem.locator(".item-text")).toHaveText(textToCopy);
+        await expect(secondItemLocator!.locator(".item-text")).toHaveText(textToCopy);
     });
 
     /**
@@ -259,9 +261,10 @@ test.describe("Visual Studio Codeのコピー/ペースト仕様", () => {
 
         // 結果を確認
         // 結果を確認
-        const items = page.locator(".outliner-item");
-        const firstItemText = await items.nth(0).locator(".item-text").textContent();
-        const secondItemText = await items.nth(1).locator(".item-text").textContent();
+        const firstId = await TestHelpers.getItemIdByIndex(page, 0);
+        const secondId = await TestHelpers.getItemIdByIndex(page, 1);
+        const firstItemText = await page.locator(`[data-item-id="${firstId}"] .item-text`).textContent();
+        const secondItemText = await page.locator(`[data-item-id="${secondId}"] .item-text`).textContent();
 
         // 各アイテムのテキストが正しいことを確認
         expect(firstItemText).toBe(testText);

--- a/client/e2e/disabled/advanced-indent.spec.ts
+++ b/client/e2e/disabled/advanced-indent.spec.ts
@@ -4,6 +4,7 @@ import {
     expect,
     test,
 } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
 
 /**
  * @file advanced-indent.spec.ts
@@ -139,13 +140,14 @@ test.describe("Advanced indent/unindent functionality", () => {
     test("Should create and manipulate a deeply nested structure", async ({ page }) => {
         // アイテムを5つ追加
         for (let i = 0; i < 5; i++) {
-            const currentItem = page.locator(".outliner-item").nth(i);
-            await currentItem.click(); // Focus or create if it's the first effective click
+            const currentItem = await TestHelpers.getItemLocatorByIndex(page, i);
+            await currentItem!.click(); // Focus or create if it's the first effective click
             await page.keyboard.type(`アイテム ${i + 1}`);
             await page.keyboard.press("Enter");
             // Wait for the next item to be created and visible, except for the last one
             if (i < 4) {
-                await expect(page.locator(".outliner-item").nth(i + 1)).toBeVisible({ timeout: 7000 });
+                const nextLocator = await TestHelpers.getItemLocatorByIndex(page, i + 1);
+                await expect(nextLocator!).toBeVisible({ timeout: 7000 });
             }
         }
 
@@ -153,7 +155,7 @@ test.describe("Advanced indent/unindent functionality", () => {
 
         // ステップ1: 階層構造を作成（2から5までのアイテムを順番に移動）
         // アイテム2をアイテム1の子にする
-        await page.locator(".outliner-item").nth(1).click();
+        await (await TestHelpers.getItemLocatorByIndex(page, 1))!.click();
         await page.keyboard.press("Tab");
         await page.waitForSelector(".outliner-item", { state: "attached", timeout: 7000 });
 
@@ -173,7 +175,7 @@ test.describe("Advanced indent/unindent functionality", () => {
         expect(structure[1].text).toBe("アイテム 2");
 
         // アイテム3をアイテム2の子にする
-        await page.locator(".outliner-item").nth(2).click();
+        await (await TestHelpers.getItemLocatorByIndex(page, 2))!.click();
         await page.keyboard.press("Tab");
         await page.waitForSelector(".outliner-item", { state: "attached", timeout: 7000 });
         await page.keyboard.press("Tab");
@@ -193,7 +195,7 @@ test.describe("Advanced indent/unindent functionality", () => {
         expect(structure[2].text).toBe("アイテム 3");
 
         // アイテム4をアイテム3の子にする
-        await page.locator(".outliner-item").nth(3).click();
+        await (await TestHelpers.getItemLocatorByIndex(page, 3))!.click();
         await page.keyboard.press("Tab");
         await page.waitForSelector(".outliner-item", { state: "attached", timeout: 7000 });
         await page.keyboard.press("Tab");
@@ -221,7 +223,7 @@ test.describe("Advanced indent/unindent functionality", () => {
 
         // ステップ2: 階層構造の変更を検証
         // アイテム4を2レベル上げる（2回のshift+tab）
-        const item4 = page.locator(".outliner-item").nth(3);
+        const item4 = await TestHelpers.getItemLocatorByIndex(page, 3);
         for (let i = 0; i < 2; i++) {
             await item4.click();
             await page.keyboard.press("Shift+Tab");
@@ -271,23 +273,23 @@ test.describe("Advanced indent/unindent functionality", () => {
 
     //     // 2. 子アイテムを追加
     //     await page.click('button:has-text("アイテム追加")');
-    //     await page.locator(".outliner-item").nth(1).click();
+    //     await (await TestHelpers.getItemLocatorByIndex(page, 1))!.click();
     //     await page.keyboard.type("子アイテム1");
     //     await page.keyboard.press("Enter");
 
     //     // 3. 孫アイテムを追加
     //     await page.click('button:has-text("アイテム追加")');
-    //     await page.locator(".outliner-item").nth(2).click();
+    //     await (await TestHelpers.getItemLocatorByIndex(page, 2))!.click();
     //     await page.keyboard.type("子アイテム2");
     //     await page.keyboard.press("Enter");
 
     //     // 子アイテムをインデント
-    //     await page.locator(".outliner-item").nth(1).click();
+    //     await (await TestHelpers.getItemLocatorByIndex(page, 1))!.click();
     //     await page.keyboard.press("Tab");
     //     await page.waitForTimeout(500);
 
     //     // 孫アイテムを更にインデント
-    //     await page.locator(".outliner-item").nth(2).click();
+    //     await (await TestHelpers.getItemLocatorByIndex(page, 2))!.click();
     //     await page.keyboard.press("Tab");
     //     await page.waitForTimeout(500);
 

--- a/client/e2e/disabled/multi-cursor.spec.ts
+++ b/client/e2e/disabled/multi-cursor.spec.ts
@@ -4,6 +4,7 @@ import {
     expect,
     test,
 } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
 
 test.describe("マルチカーソル E2E テスト", () => {
     test.beforeEach(async ({ page }, testInfo) => {
@@ -35,7 +36,8 @@ test.describe("マルチカーソル E2E テスト", () => {
         await expect(page.locator(cursorSelector)).toHaveCount(1, { timeout: 7000 });
 
         // 2番目のアイテムにAlt+Click
-        await items.nth(1).locator(".item-text").click({ modifiers: ["Alt"] });
+        const second = await TestHelpers.getItemLocatorByIndex(page, 1);
+        await second!.locator(".item-text").click({ modifiers: ["Alt"] });
         await expect(page.locator(cursorSelector)).toHaveCount(2, { timeout: 7000 });
 
         // 再度1番目にAlt+Clickしても重複しない (or toggles off, then on if it's a toggle behavior)

--- a/client/e2e/disabled/outliner-tree.spec.ts
+++ b/client/e2e/disabled/outliner-tree.spec.ts
@@ -4,6 +4,7 @@ import {
     expect,
     test,
 } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
 
 test.describe("OutlinerTree E2E", () => {
     test.beforeEach(async ({ page }, testInfo) => {
@@ -38,8 +39,8 @@ test.describe("OutlinerTree E2E", () => {
         // If initialCount could be 0, then nth(0) for first click, nth(1) for second item.
         // Let's assume initialCount >= 1 based on beforeEach.
         // The new item from toolbar usually appears last or based on current focus.
-        // For robustness, let's operate on the newly added item, which should be items.nth(initialCount)
-        const newItem = items.nth(initialCount); // This is the item added by toolbar
+        // For robustness, operate on the newly added item using its item id
+        const newItem = await TestHelpers.getItemLocatorByIndex(page, initialCount)!; // Item added by toolbar
 
         // そのアイテムに対して兄弟追加
         // Hovering might be needed if buttons are not always visible
@@ -47,8 +48,8 @@ test.describe("OutlinerTree E2E", () => {
         await newItem.locator('button[title="新しいアイテムを追加"]').click();
         await expect(items).toHaveCount(initialCount + 2, { timeout: 7000 });
 
-        // 追加された3番目のアイテム (which is now items.nth(initialCount + 1)) を削除
-        const thirdItemOverall = items.nth(initialCount + 1);
+        // 追加された3番目のアイテム (initialCount + 1 番目) を削除
+        const thirdItemOverall = await TestHelpers.getItemLocatorByIndex(page, initialCount + 1)!;
         await thirdItemOverall.hover();
         await thirdItemOverall.locator('button[title="削除"]').click();
         await expect(items).toHaveCount(initialCount + 1, { timeout: 7000 });

--- a/client/e2e/utils/testHelpers.ts
+++ b/client/e2e/utils/testHelpers.ts
@@ -695,6 +695,15 @@ export class TestHelpers {
     }
 
     /**
+     * Get the locator for an item by its index
+     */
+    public static async getItemLocatorByIndex(page: Page, index: number): Promise<any> {
+        const id = await this.getItemIdByIndex(page, index);
+        if (!id) return null;
+        return page.locator(`.outliner-item[data-item-id="${id}"]`);
+    }
+
+    /**
      * アイテムをクリックして編集モードに入る
      * @param page Playwrightのページオブジェクト
      * @param itemSelector アイテムを特定するセレクタ


### PR DESCRIPTION
## Summary
- use deterministic `data-item-id` selectors in e2e tests
- add helper to fetch item locator by index
- update disabled tests to use the new helper

## Testing
- `scripts/codex-setp.sh` *(fails: npm not found)*
- `npx -y playwright test client/e2e/core/FMT-0005.spec.ts` *(fails: cannot find package '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68514feb0d28832fbd72dace7d7eea6c