### PR TITLE
Refactor evaluate blocks

### DIFF
--- a/client/e2e/core/CLM-0001.spec.ts
+++ b/client/e2e/core/CLM-0001.spec.ts
@@ -18,13 +18,7 @@ test.describe("CLM-0001: クリックで編集モードに入る", () => {
         console.log("Current URL:", url);
 
         // ページ内の要素を確認
-        const elements = await page.evaluate(() => {
-            return {
-                outlinerItems: document.querySelectorAll(".outliner-item").length,
-                pageTitle: document.querySelector(".outliner-item.page-title") ? true : false,
-                firstItem: document.querySelector(".outliner-item") ? true : false,
-            };
-        });
+        const elements = await TestHelpers.getPageElementsInfo(page);
         console.log("Page elements:", elements);
     });
 
@@ -48,10 +42,7 @@ test.describe("CLM-0001: クリックで編集モードに入る", () => {
         await page.screenshot({ path: "client/test-results/CLM-0001-after-click.png" });
 
         // 隠し textarea がフォーカスされているか確認
-        const isFocused = await page.evaluate(() => {
-            const active = document.activeElement;
-            return active?.classList.contains("global-textarea");
-        });
+        const isFocused = await TestHelpers.isGlobalTextareaFocused(page);
         console.log("Global textarea focused:", isFocused);
         expect(isFocused).toBe(true);
 

--- a/client/e2e/core/LNK-0005.spec.ts
+++ b/client/e2e/core/LNK-0005.spec.ts
@@ -30,39 +30,7 @@ test.describe("LNK-0005: リンクプレビュー機能", () => {
      */
     test("内部リンクにマウスオーバーするとプレビューが表示される", async ({ page }) => {
         // 内部リンクのフォーマットを強制的に適用
-        await page.evaluate(pageName => {
-            // 全てのアウトライナーアイテムを取得
-            const items = document.querySelectorAll(".outliner-item");
-            console.log(`Found ${items.length} outliner items for formatting`);
-
-            // 各アイテムのテキストを確認
-            items.forEach(item => {
-                const textElement = item.querySelector(".item-text");
-                if (textElement) {
-                    const text = textElement.textContent || "";
-                    console.log(`Item text: "${text}"`);
-
-                    // 内部リンクのパターンを検出
-                    if (text.includes(`[${pageName}]`)) {
-                        console.log(`Found internal link to ${pageName}`);
-
-                        // HTMLを直接設定
-                        const html = text.replace(
-                            `[${pageName}]`,
-                            `<span class="link-preview-wrapper">
-                                <a href="/${pageName}" class="internal-link" data-page="${pageName}">${pageName}</a>
-                            </span>`,
-                        );
-
-                        // HTMLを設定
-                        textElement.innerHTML = html;
-
-                        // フォーマット済みクラスを追加
-                        textElement.classList.add("formatted");
-                    }
-                }
-            });
-        }, testPageName);
+        await TestHelpers.applyInternalLinkFormat(page, testPageName);
 
         // リンク要素を特定
         const linkSelector = `a.internal-link:has-text("${testPageName}")`;

--- a/client/e2e/utils/testHelpers.ts
+++ b/client/e2e/utils/testHelpers.ts
@@ -694,6 +694,46 @@ export class TestHelpers {
         }, index);
     }
 
+    /** Get basic info about current page elements */
+    public static async getPageElementsInfo(page: Page): Promise<{ outlinerItems: number; pageTitle: boolean; firstItem: boolean; }> {
+        return await page.evaluate(() => {
+            return {
+                outlinerItems: document.querySelectorAll(".outliner-item").length,
+                pageTitle: document.querySelector(".outliner-item.page-title") ? true : false,
+                firstItem: document.querySelector(".outliner-item") ? true : false,
+            };
+        });
+    }
+
+    /** Determine if the hidden textarea currently has focus */
+    public static async isGlobalTextareaFocused(page: Page): Promise<boolean> {
+        return await page.evaluate(() => {
+            const active = document.activeElement;
+            return active?.classList.contains("global-textarea") ?? false;
+        });
+    }
+
+    /** Apply internal link formatting to all outliner items */
+    public static async applyInternalLinkFormat(page: Page, pageName: string): Promise<void> {
+        await page.evaluate(name => {
+            const items = document.querySelectorAll(".outliner-item");
+            items.forEach(item => {
+                const textElement = item.querySelector(".item-text");
+                if (textElement) {
+                    const text = textElement.textContent || "";
+                    if (text.includes(`[${name}]`)) {
+                        const html = text.replace(
+                            `[${name}]`,
+                            `<span class="link-preview-wrapper"><a href="/${name}" class="internal-link" data-page="${name}">${name}</a></span>`,
+                        );
+                        textElement.innerHTML = html;
+                        textElement.classList.add("formatted");
+                    }
+                }
+            });
+        }, pageName);
+    }
+
     /**
      * アイテムをクリックして編集モードに入る
      * @param page Playwrightのページオブジェクト


### PR DESCRIPTION
## Summary
- move common page.evaluate code to helper functions
- use helpers in CLM-0001 and LNK-0005 tests

## Testing
- `scripts/codex-setp.sh` *(fails: `sudo: npm: command not found`)*
- `npx playwright test client/e2e/core/CLM-0001.spec.ts --reporter=list` *(fails: Cannot find package '@playwright/test')*
- `npx playwright test client/e2e/core/LNK-0005.spec.ts --reporter=list` *(fails: Cannot find package '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68514ff7ddf4832f8901dfacad4a5796