### PR TITLE
Add extended port env var test

### DIFF
--- a/client/e2e/new/FTR-0016.spec.ts
+++ b/client/e2e/new/FTR-0016.spec.ts
@@ -13,4 +13,15 @@ test.describe("FTR-0016: PORT environment variable", () => {
         await expect(page).toHaveURL(new RegExp(`${expectedPort}`));
         await expect(page.locator("h1")).toContainText("Fluid Outliner App");
     });
+
+    test("baseURL port matches window location", async ({ page, baseURL }) => {
+        const expectedPort = process.env.PORT ?? "7090";
+        await page.goto("/");
+        const locationPort = await page.evaluate(() => window.location.port);
+        expect(locationPort).toBe(String(expectedPort));
+
+        const response = await page.request.get(`${baseURL}/api/telemetry-logs`);
+        expect(response.status()).toBeGreaterThanOrEqual(200);
+        expect(response.status()).toBeLessThan(500);
+    });
 });


### PR DESCRIPTION
## Summary
- extend FTR-0016 spec with port verification and API endpoint check

## Testing
- `npm --prefix client run test:e2e:single e2e/new/FTR-0016.spec.ts` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_6851501d3bbc832f9b896f1fcaff417c