### PR TITLE
Extend EMB-0001 test

### DIFF
--- a/client/e2e/new/EMB-0001.spec.ts
+++ b/client/e2e/new/EMB-0001.spec.ts
@@ -22,4 +22,27 @@ test.describe("EMB-0001: Table embed in outliner", () => {
         await expect(page.locator('[data-testid="editable-grid"]')).toBeVisible();
         await expect(page.locator('[data-testid="chart-panel"]')).toBeVisible();
     });
+
+    test('editable grid has expected data', async ({ page }) => {
+        await page.waitForSelector('[data-testid="editable-grid"] .wx-grid', { timeout: 10000 });
+        await page.waitForTimeout(2000);
+
+        const info = await TestHelpers.getEditableGridCellInfo(page);
+        expect(info).toBeDefined();
+        expect(info?.cellCount).toBe(9);
+        expect(info?.dataCellCount).toBe(6);
+        expect(info?.firstDataCellText).toBe('1');
+    });
+
+    test('chart option exposes series data', async ({ page }) => {
+        await page.waitForFunction(() => {
+            return (window as any).__JOIN_TABLE__ && (window as any).__JOIN_TABLE__.chartOption;
+        }, { timeout: 5000 });
+
+        const option = await TestHelpers.getJoinTableChartOption(page);
+        expect(option).toBeDefined();
+        expect(option.series?.[0]?.type).toBe('bar');
+        expect(option.series?.[0]?.data).toEqual([1, 2]);
+        expect(option.xAxis?.data).toEqual(['a', 'b']);
+    });
 });

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -75,6 +75,8 @@
   acceptance:
     - "Firebase config values come from VITE_FIREBASE_* variables"
     - "Token verification URL uses VITE_TOKEN_VERIFY_URL"
+    - "Editable grid shows 6 data cells and first cell text is '1'"
+    - "Chart option includes bar series with values [1,2]"
 - id: IME-0001
   title: IMEを使用した日本語入力
   status: implemented # draft / implemented / deprecated


### PR DESCRIPTION
## Summary
- add editable grid and chart config checks in `EMB-0001` test
- document new behaviour in `client-features.yaml`

## Testing
- `bash scripts/run-tests.sh client/e2e/new/EMB-0001.spec.ts` *(fails: waiting for port 7091)*

------
https://chatgpt.com/codex/tasks/task_e_6851c66ae258832f8c8ecf9c184f7960