### PR TITLE
Move tinylicious test into core suite

### DIFF
--- a/client/e2e/core/tinylicious.spec.ts
+++ b/client/e2e/core/tinylicious.spec.ts
@@ -1,4 +1,7 @@
-/** @feature TIN-0000 */
+/** @feature TIN-0000
+ *  Title   : Tinyliciousリアル接続テスト
+ *  Source  : docs/client-features.yaml
+ */
 // File in disabled/ as it requires a running Tinylicious server and proper test environment config.
 import {
     expect,


### PR DESCRIPTION
## Summary
- move Tinylicious connection test from `disabled` to `core`
- document the feature header

## Testing
- `npx playwright test client/e2e/core/tinylicious.spec.ts --reporter line` *(fails: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_6851c6bcb678832fa9926a5cf3980091