### PR TITLE
Update test runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,12 @@ npm run test:unit
 # まず `scripts/codex-setp.sh` を実行し、Firebase Emulator などのローカルサービスを
 # 起動します。その後、Playwright のテストファイルを個別に実行します。
 
-# Playwright テストを 1 ファイルずつ実行する場合
+# Playwright テストを複数指定した場合、それぞれ順番に実行されます
 scripts/run-tests.sh client/e2e/your-spec-file.spec.ts
 # Example: run the collaboration cursor test
 scripts/run-tests.sh client/e2e/collaboration/COL-0001.spec.ts
+# 複数ファイルを一度に実行する例
+scripts/run-tests.sh client/e2e/spec-a.spec.ts client/e2e/spec-b.spec.ts
 # 環境変数 `PORT` を指定して別ポートで実行する例
 PORT=7100 scripts/run-tests.sh client/e2e/your-spec-file.spec.ts
 ```

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -8,4 +8,6 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 bash "$ROOT_DIR/scripts/codex-setp.sh"
 
 cd "$ROOT_DIR/client"
-xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test:e2e -- "$@"
+for spec in "$@"; do
+    xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test:e2e -- "$spec"
+done


### PR DESCRIPTION
## Summary
- run Playwright tests sequentially in `run-tests.sh`
- document sequential spec execution in README

## Testing
- `bash scripts/codex-setp.sh` *(failed: sudo npm not found)*
- `bash scripts/run-tests.sh client/e2e/core/minimal.spec.ts` *(failed: sudo npm not found)*
- `npx dprint@0.50.0 check` *(failed: could not download plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6851d66a4628832f9e15dd06466b3225