### PR TITLE
Expand authentication E2E coverage

### DIFF
--- a/client/e2e/auth/FTR-0012-forgot-password.spec.ts
+++ b/client/e2e/auth/FTR-0012-forgot-password.spec.ts
@@ -73,7 +73,16 @@ test.describe('FTR-0012 - Forgot Password UI Flow', () => {
         await page.goto(`${resetPasswordRoute}?oobCode=testtoken123`);
 
         // Add basic UI verification for reset password page
-        // This test can be expanded based on the actual reset password implementation
         await expect(page.locator('h1')).toBeVisible();
+    });
+
+    test('Reset link shows success for valid token', async ({ page }) => {
+        await page.goto(`${forgotPasswordRoute}?oobCode=valid-token`);
+        await expect(page.locator('.token-valid')).toBeVisible();
+    });
+
+    test('Reset link shows error for invalid token', async ({ page }) => {
+        await page.goto(`${forgotPasswordRoute}?oobCode=invalid-token`);
+        await expect(page.locator('.error')).toBeVisible();
     });
 });

--- a/client/e2e/auth/auth-login-flow.spec.ts
+++ b/client/e2e/auth/auth-login-flow.spec.ts
@@ -1,0 +1,44 @@
+/** @feature FTR-0015 */
+import { test, expect } from '@playwright/test';
+import { TestHelpers } from '../utils/testHelpers';
+
+test.describe('FTR-0015 - Authentication Login Flow', () => {
+    test('User can login and logout', async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo, [], false, true);
+        await page.waitForSelector('.auth-container');
+
+        const devToggle = page.locator('button.dev-toggle');
+        await devToggle.click();
+        await page.waitForSelector('.dev-login-form');
+
+        await page.locator('#email').fill('test@example.com');
+        await page.locator('#password').fill('password');
+        await page.locator('button.dev-login-btn').click();
+
+        await expect(page.locator('button.logout-btn')).toBeVisible({ timeout: 10000 });
+
+        await page.locator('button.logout-btn').click();
+        await expect(page.locator('button.dev-toggle')).toBeVisible({ timeout: 10000 });
+    });
+
+    test('Login session persists after reload', async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo, [], false, true);
+        await page.waitForSelector('.auth-container');
+
+        const devToggle = page.locator('button.dev-toggle');
+        await devToggle.click();
+        await page.waitForSelector('.dev-login-form');
+
+        await page.locator('#email').fill('test@example.com');
+        await page.locator('#password').fill('password');
+        await page.locator('button.dev-login-btn').click();
+
+        await expect(page.locator('button.logout-btn')).toBeVisible({ timeout: 10000 });
+
+        await page.reload();
+        await page.waitForSelector('.auth-container');
+        await expect(page.locator('button.logout-btn')).toBeVisible({ timeout: 10000 });
+
+        await page.locator('button.logout-btn').click();
+    });
+});

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -66,6 +66,14 @@
     - client/e2e/core/USR-0002.spec.ts
     - client/e2e/core/FTR-0014.spec.ts
     - client/e2e/new/FTR-0014.spec.ts
+- id: FTR-0015
+  title: User login, logout and session persistence
+  status: implemented
+  components:
+    - client/src/components/AuthComponent.svelte
+    - client/src/auth/UserManager.ts
+  tests:
+    - client/e2e/auth/auth-login-flow.spec.ts
 - id: FTR-0016
   title: Playwright config supports PORT env variable
   description: The E2E test server port can be set via PORT environment variable with fallback to 7090.


### PR DESCRIPTION
## Summary
- add login/logout/session persistence test
- extend password reset E2E test for valid and invalid token cases
- record feature FTR-0015 for new authentication flow tests

## Testing
- `python3 scripts/gen_feature_map.py`
- `npx playwright test client/e2e/auth/auth-login-flow.spec.ts` *(fails: Process from config.webServer exited early)*
- `npx playwright test client/e2e/auth/FTR-0012-forgot-password.spec.ts` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_6851d66cac14832f815c3398de467e48