### PR TITLE
Add PORT env validation test

### DIFF
--- a/client/e2e/new/config-port.spec.ts
+++ b/client/e2e/new/config-port.spec.ts
@@ -1,0 +1,24 @@
+/** @feature FTR-0017 */
+import {
+    expect,
+    test,
+} from "@playwright/test";
+
+/**
+ * FTR-0017: Ensure server and API use the configured PORT
+ */
+
+test.describe("FTR-0017: PORT configuration", () => {
+    const expectedPort = process.env.PORT ?? "7090";
+
+    test("server responds on configured port", async ({ page, baseURL }) => {
+        await page.goto("/");
+        const locationPort = await page.evaluate(() => window.location.port);
+        expect(locationPort).toBe(String(expectedPort));
+
+        expect(baseURL).toContain(expectedPort);
+        const response = await page.request.get(`${baseURL}/api/telemetry-logs`);
+        expect(response.status()).toBeGreaterThanOrEqual(200);
+        expect(response.status()).toBeLessThan(500);
+    });
+});

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -75,6 +75,15 @@
     - playwright.config.ts
   tests:
     - client/e2e/new/FTR-0016.spec.ts
+- id: FTR-0017
+  title: Server respects PORT environment variable
+  description: Running server and API endpoints use process.env.PORT or default 7090
+  category: configuration
+  status: implemented
+  components:
+    - playwright.config.ts
+  tests:
+    - client/e2e/new/config-port.spec.ts
 - id: EMB-0001
   title: Outliner Table & Chart Embedding
   description: Notion-like table and chart blocks can be embedded in any outliner item


### PR DESCRIPTION
## Summary
- verify server uses the PORT env var with a new Playwright spec
- document the feature in `client-features.yaml`

## Testing
- `npx playwright test client/e2e/new/config-port.spec.ts --reporter=line` *(fails: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_6851d66f637c832f9d3c522afc465fa9