### PR TITLE
Update playwright localhost setting

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -11,10 +11,9 @@ const __dirname = path.dirname(__filename);
 
 // テスト環境の設定
 // 環境変数TEST_ENVが'localhost'の場合はlocalhost環境、それ以外はデフォルト環境
-// VSCode Playwright拡張から実行する場合は環境変数が正しく渡らないため、直接trueに設定
-// 元の設定に戻す場合はこちらのコメントを外してください
-// const isLocalhostEnv = process.env.TEST_ENV === 'localhost';
-const isLocalhostEnv = true; // localhostを強制的に使用
+// VSCode Playwright拡張から実行する場合は環境変数が正しく渡らないことがあるため、
+// 必要に応じて直接trueに設定してください
+const isLocalhostEnv = process.env.TEST_ENV === 'localhost';
 
 // テスト用ポートを定義 - これを明示的に指定
 const TEST_PORT = isLocalhostEnv ? "7090" : "7080";


### PR DESCRIPTION
## Summary
- check TEST_ENV variable instead of forcing localhost

## Testing
- `./scripts/codex-setp.sh` *(fails: `sudo: npm: command not found`)*
- `npx playwright test client/e2e/basic.spec.ts` *(fails to install playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6856458b4940832f8e2685c3ac24298f