### PR TITLE
Add unimplemented features doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # 📄 Documentation & Specifications
-Record every feature in docs\client-features.yaml.
+Record every feature in docs\client-features.yaml. Document intentionally omitted features in docs/unimplemented-features.md.
 - While multiple AIs may code in parallel, review documents frequently to avoid overlapping features or contradictory explanations.
 - Continuously reference and update past best practices so they remain current.
 - Keep the implementation plan documentation updated whenever changes occur.

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -929,3 +929,14 @@
   status: implemented
   components: []
   tests: []
+
+- id: SEC-0002
+  title: "Two-Factor Authentication (2FA)"
+  description: >-
+    This project intentionally omits two-factor authentication.
+    Firebase Authentication handles user sign-in, and email link
+    authentication is used only during testing.
+  category: security
+  status: deprecated
+  components: []
+  tests: []

--- a/docs/unimplemented-features.md
+++ b/docs/unimplemented-features.md
@@ -1,0 +1,9 @@
+# Features Explicitly Not Implemented
+
+This document records features that are intentionally omitted from the project. Their absence is by design and pull requests adding these features will be rejected.
+
+## Two-Factor Authentication (2FA)
+- We rely on Firebase Authentication for sign‑in.
+- Only email link authentication is used for testing purposes.
+- No additional verification steps such as SMS or authenticator apps are planned.
+


### PR DESCRIPTION
## Summary
- document features that will not be implemented
- record 2FA omission in client feature matrix
- mention unimplemented features doc in AGENTS guidance

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685647ae1140832f98df605717b851c6