### PR TITLE
Add autogenerated note for feature map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@ Record every feature in docs\client-features.yaml.
 - While multiple AIs may code in parallel, review documents frequently to avoid overlapping features or contradictory explanations.
 - Continuously reference and update past best practices so they remain current.
 - Keep the implementation plan documentation updated whenever changes occur.
+docs/feature-map.md is automatically generated; do not edit it.
 
 # 🧪 Test implementation and execution policy
 For every feature, create a corresponding test.


### PR DESCRIPTION
## Summary
- clarify that `docs/feature-map.md` is autogenerated in AGENTS guidelines

## Testing
- `bash scripts/codex-setp.sh` *(fails: npm not found)*
- `npm run test:e2e:single e2e/core/CLM-0001.spec.ts` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68564d854a08832f87796012d416ff71