### PR TITLE
Update feature map script test roots

### DIFF
--- a/scripts/gen_feature_map.py
+++ b/scripts/gen_feature_map.py
@@ -15,9 +15,10 @@ ROOT        = Path(__file__).resolve().parent.parent
 YAML_SRC    = ROOT / "docs" / "client-features.yaml"
 # ★ 複数ディレクトリをリストで指定
 TEST_ROOTS  = [                                   # 任意で追記 / 上書き
-    ROOT / "client/e2e",                              # default
-    ROOT / "client/src/tests",                              # default
-    # ROOT / "server/tests",                    # 例: 追加したいときはアンコメント
+    ROOT / "client/e2e",                         # default
+    ROOT / "client/src/tests",                   # default
+    ROOT / "functions/test",                     # new: Cloud Functions tests
+    ROOT / "server/tests",                       # new: server unit tests
 ]
 MD_OUTFILE  = ROOT / "docs" / "feature-map.md"        # 出力先
 # Accept any capitalized prefix like CLM-0001 or API-0123


### PR DESCRIPTION
## Summary
- include `functions/test` and `server/tests` in `scripts/gen_feature_map.py`
- run feature map generation script

## Testing
- `python3 scripts/gen_feature_map.py`
- `npx playwright test e2e/core/CLM-0001.spec.ts --reporter=line` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68576956a7e4832f9840040d26471305