### PR TITLE
Refactor e2e selectors

### DIFF
--- a/client/e2e/core/CLM-0103.spec.ts
+++ b/client/e2e/core/CLM-0103.spec.ts
@@ -58,7 +58,9 @@ test.describe("フォーマット文字列でのカーソル操作", () => {
 
     test("複数のフォーマットが混在する文字列でのカーソル移動", async ({ page }) => {
         // ページタイトル以外のアイテムを選択（2番目のアイテム）
-        const item = page.locator(".outliner-item").nth(1);
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(secondItemId).not.toBeNull();
+        const item = page.locator(`.outliner-item[data-item-id="${secondItemId}"]`);
         await item.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 
@@ -132,7 +134,9 @@ test.describe("フォーマット文字列でのカーソル操作", () => {
 
     test("Home/Endキーがフォーマット文字列で正しく機能する", async ({ page }) => {
         // ページタイトル以外のアイテムを選択（2番目のアイテム）
-        const item = page.locator(".outliner-item").nth(1);
+        const secondItemId2 = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(secondItemId2).not.toBeNull();
+        const item = page.locator(`.outliner-item[data-item-id="${secondItemId2}"]`);
         await item.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 
@@ -161,7 +165,9 @@ test.describe("フォーマット文字列でのカーソル操作", () => {
 
     test("Shift+矢印キーによる選択がフォーマット文字列で正しく機能する", async ({ page }) => {
         // 既存のアイテム（2番目のアイテム）を使用
-        const item = page.locator(".outliner-item").nth(1);
+        const secondItemId3 = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(secondItemId3).not.toBeNull();
+        const item = page.locator(`.outliner-item[data-item-id="${secondItemId3}"]`);
         await item.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 
@@ -233,7 +239,9 @@ test.describe("フォーマット文字列でのカーソル操作", () => {
 
     test("フォーマット文字列内での単語単位の移動（Ctrl+矢印）", async ({ page }) => {
         // ページタイトル以外のアイテムを選択（2番目のアイテム）
-        const item = page.locator(".outliner-item").nth(1);
+        const secondItemId4 = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(secondItemId4).not.toBeNull();
+        const item = page.locator(`.outliner-item[data-item-id="${secondItemId4}"]`);
         await item.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 

--- a/client/e2e/core/FMT-0003.spec.ts
+++ b/client/e2e/core/FMT-0003.spec.ts
@@ -27,7 +27,9 @@ test.describe("拡張フォーマット", () => {
         await page.keyboard.type("別のアイテム");
 
         // 別のアイテムをクリックしてフォーカスを移動（フォーマットを適用させるため）
-        await page.locator(".outliner-item").nth(1).locator(".item-content").click();
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(secondItemId).not.toBeNull();
+        await page.locator(`.outliner-item[data-item-id="${secondItemId}"]`).locator(".item-content").click();
 
         // フォーマットが適用されるのを待つ
         await page.waitForTimeout(500);
@@ -52,7 +54,9 @@ test.describe("拡張フォーマット", () => {
         await page.keyboard.type("別のアイテム");
 
         // 別のアイテムをクリックしてフォーカスを移動（フォーマットを適用させるため）
-        await page.locator(".outliner-item").nth(1).locator(".item-content").click();
+        const secondItemId2 = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(secondItemId2).not.toBeNull();
+        await page.locator(`.outliner-item[data-item-id="${secondItemId2}"]`).locator(".item-content").click();
 
         // フォーマットが適用されるのを待つ
         await page.waitForTimeout(500);
@@ -78,7 +82,9 @@ test.describe("拡張フォーマット", () => {
         await page.keyboard.type("別のアイテム");
 
         // 別のアイテムをクリックしてフォーカスを移動（フォーマットを適用させるため）
-        await page.locator(".outliner-item").nth(1).locator(".item-content").click();
+        const secondItemId3 = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(secondItemId3).not.toBeNull();
+        await page.locator(`.outliner-item[data-item-id="${secondItemId3}"]`).locator(".item-content").click();
 
         // フォーマットが適用されるのを待つ
         await page.waitForTimeout(500);


### PR DESCRIPTION
## Summary
- use `data-item-id` selectors instead of `.nth()` in CLM-0103 and FMT-0003 e2e tests

## Testing
- `npx playwright test e2e/core/CLM-0103.spec.ts --project=core --config=playwright.config.ts` *(fails: Error Context)*
- `npx playwright test e2e/core/FMT-0003.spec.ts --project=core --config=playwright.config.ts` *(fails: Error Context)*

------
https://chatgpt.com/codex/tasks/task_e_68576963a4c0832fbb9f2d46728dcbbb