### PR TITLE
Fix codex setup npm path

### DIFF
--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -99,7 +99,7 @@ kill_ports() {
 # Install global packages if needed
 install_global_packages() {
   if ! command -v firebase >/dev/null || ! command -v tinylicious >/dev/null; then
-    sudo npm --proxy='' --https-proxy='' install -g firebase-tools tinylicious dotenv-cli cross-env @dotenvx/dotenvx || true
+    npm --proxy='' --https-proxy='' install -g firebase-tools tinylicious dotenv-cli cross-env @dotenvx/dotenvx || true
   fi
 
   # if ! command -v dprint >/dev/null; then
@@ -108,7 +108,7 @@ install_global_packages() {
   
   if ! command -v cross-env >/dev/null; then
     echo "cross-env not found after global install; attempting local install"
-    sudo npm install -g cross-env || true
+    npm install -g cross-env || true
   fi
 }
 


### PR DESCRIPTION
## Summary
- fix "sudo: npm: command not found" by removing sudo from npm calls

## Testing
- `./scripts/codex-setup.sh >/tmp/codex-setup.log && tail -n 20 /tmp/codex-setup.log`
- `npm --prefix client run test:e2e:single` *(fails: page.goto net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_e_68592c59d0c0832fb31f588f00578793