### PR TITLE
Separate environment tests and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # 📄 Documentation & Specifications
 
-Record every feature in docs\client-features.yaml. Document intentionally omitted features in docs/unimplemented-features.md.
+Record end-user features in docs\client-features.yaml.
+List development and environment maintenance features (the ENV-* series) in docs/dev-features.yaml.
+Document intentionally omitted features in docs/unimplemented-features.md.
 
 - While multiple AIs may code in parallel, review documents frequently to avoid overlapping features or contradictory explanations.
 - Continuously reference and update past best practices so they remain current.
@@ -15,6 +17,8 @@ Do not embed code that skips tests.
 Do not use mocks in tests.
 Run tests in headless mode.
 Fix one test file at a time and run tests after each fix to confirm.
+Run environment maintenance tests (ENV-*) separately from unit and e2e suites.
+These tests use Vitest while e2e tests use Playwright.
 
 # 🔍 How to deal with test failures
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ npm run test:unit
 
 # E2E テスト (dotenvxで復号化して実行)
 dotenvx run -- npm run test:e2e
+
+# 環境維持テスト (Vitest)
+dotenvx run -- npm run test:env
 ```
 
 テストの前には `scripts/codex-setup.sh` を実行してローカルのエミュレータ群を起動してください。

--- a/client/e2e/new/GRF-001.spec.ts
+++ b/client/e2e/new/GRF-001.spec.ts
@@ -1,0 +1,23 @@
+/** @feature GRF-001
+ *  Title   : Graph View
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("GRF-001: Graph View", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("graph page is accessible", async ({ page }) => {
+        await page.goto("/graph");
+        await page.waitForLoadState("domcontentloaded");
+        await expect(page.locator("body")).toBeVisible();
+
+        const hasGraph = await page.evaluate(() => {
+            return document.querySelector("#graph, .graph-container, svg") !== null;
+        });
+        expect(hasGraph).toBe(true);
+    });
+});

--- a/client/e2e/new/SRE-001.spec.ts
+++ b/client/e2e/new/SRE-001.spec.ts
@@ -1,0 +1,20 @@
+/** @feature SRE-001
+ *  Title   : Advanced Search & Replace
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("SRE-001: Advanced Search & Replace", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("search panel should be visible", async ({ page }) => {
+        const openButton = page.locator(".search-btn");
+        if (await openButton.count()) {
+            await openButton.click();
+        }
+        await expect(page.locator(".search-panel")).toBeVisible();
+    });
+});

--- a/client/e2e/utils/ENV-0001.spec.ts
+++ b/client/e2e/utils/ENV-0001.spec.ts
@@ -1,11 +1,8 @@
 /** @feature ENV-0001
  *  Title   : Codex setup script is executable
- *  Source  : docs/client-features.yaml
- */
-import {
-    expect,
-    test,
-} from "@playwright/test";
+ *  Source  : docs/dev-features.yaml
+*/
+import { expect, test } from "vitest";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";

--- a/client/e2e/utils/ENV-0002.spec.ts
+++ b/client/e2e/utils/ENV-0002.spec.ts
@@ -1,11 +1,8 @@
 /** @feature ENV-0002
  *  Title   : Setup script starts all test services
- *  Source  : docs/client-features.yaml
- */
-import {
-    expect,
-    test,
-} from "@playwright/test";
+ *  Source  : docs/dev-features.yaml
+*/
+import { expect, test } from "vitest";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";

--- a/client/e2e/utils/ENV-0003.spec.ts
+++ b/client/e2e/utils/ENV-0003.spec.ts
@@ -1,11 +1,8 @@
 /** @feature ENV-0003
  *  Title   : Setup script caches installation
- *  Source  : docs/client-features.yaml
- */
-import {
-    expect,
-    test,
-} from "@playwright/test";
+ *  Source  : docs/dev-features.yaml
+*/
+import { expect, test } from "vitest";
 import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";

--- a/client/e2e/utils/feature-map-removal.spec.ts
+++ b/client/e2e/utils/feature-map-removal.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, describe, beforeEach, afterEach } from "vitest";
 import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
@@ -9,14 +9,14 @@ import { fileURLToPath } from "url";
  *  Source  : docs/dev-features.yaml
  */
 
-test.describe("TST-0006: feature-map削除スクリプト", () => {
+describe("TST-0006: feature-map削除スクリプト", () => {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
     const repoRoot = path.resolve(__dirname, "../../.." );
     const docsPath = path.join(repoRoot, "docs", "feature-map.md");
     const scriptPath = path.join(repoRoot, "scripts", "remove_feature_map.sh");
 
-    test.beforeEach(() => {
+    beforeEach(() => {
         if (!fs.existsSync(path.dirname(docsPath))) {
             fs.mkdirSync(path.dirname(docsPath), { recursive: true });
         }
@@ -24,7 +24,7 @@ test.describe("TST-0006: feature-map削除スクリプト", () => {
         execSync(`git add ${docsPath}`);
     });
 
-    test.afterEach(() => {
+    afterEach(() => {
         try { execSync(`git restore --staged ${docsPath}`); } catch { /* ignore */ }
         try { fs.unlinkSync(docsPath); } catch { /* ignore */ }
     });

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,7 @@
         "test:e2e:xvfb": "cross-env NODE_ENV=test TEST_ENV=localhost dotenvx run --env-file=.env.test -- xvfb-run --auto-servernum --server-args=\"-screen 0 1280x960x24\" playwright test --reporter=list",
         "test:e2e:single": "cross-env NODE_ENV=test TEST_ENV=localhost dotenvx run --env-file=.env.test -- playwright test --reporter=list",
         "test:e2e:clipboard": "cross-env NODE_ENV=test TEST_ENV=localhost dotenvx run --env-file=.env.test -- playwright test --reporter=list e2e/core/FMT-0004.spec.ts",
+        "test:env": "cross-env NODE_ENV=test TEST_ENV=localhost dotenvx run --env-file=.env.test -- vitest run e2e/utils/ENV-*.spec.ts",
         "ci:test:e2e": "playwright test --reporter=list --workers=1",
         "ci:test:e2e:ui": "playwright test --ui --reporter=list",
         "ci:test:e2e:xvfb": "xvfb-run --auto-servernum --server-args=\"-screen 0 1280x960x24\" npm run ci:test:e2e --reporter=list"

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -1074,31 +1074,3 @@
   components: []
   tests: []
 
-- id: ENV-0001
-  title: Codex setup script is executable
-  description: Ensure scripts/codex-setup.sh has execute permission and is referenced consistently.
-  category: environment
-  status: implemented
-  components: []
-  tests:
-    - client/e2e/utils/ENV-0001.spec.ts
-
-- id: ENV-0002
-  title: Setup script starts all services
-  description: Verify scripts/codex-setup.sh contains commands to start Firebase emulator, Tinylicious, API server, and SvelteKit server.
-  category: environment
-  status: implemented
-  components: []
-  tests:
-    - client/e2e/utils/ENV-0002.spec.ts
-
-- id: ENV-0003
-  title: Setup script caches installation
-  description: >-
-    scripts/codex-setup.sh creates a sentinel file after running once and skips
-    dependency installation on subsequent runs, making repeat executions faster.
-  category: environment
-  status: implemented
-  components: []
-  tests:
-    - client/e2e/utils/ENV-0003.spec.ts

--- a/docs/dev-features.yaml
+++ b/docs/dev-features.yaml
@@ -10,3 +10,32 @@
     - インデックスに登録されていても自動的に削除される
   tests:
     - client/e2e/utils/feature-map-removal.spec.ts
+
+- id: ENV-0001
+  title: Codex setup script is executable
+  description: Ensure scripts/codex-setup.sh has execute permission and is referenced consistently.
+  category: environment
+  status: implemented
+  components: []
+  tests:
+    - client/e2e/utils/ENV-0001.spec.ts
+
+- id: ENV-0002
+  title: Setup script starts all services
+  description: Verify scripts/codex-setup.sh contains commands to start Firebase emulator, Tinylicious, API server, and SvelteKit server.
+  category: environment
+  status: implemented
+  components: []
+  tests:
+    - client/e2e/utils/ENV-0002.spec.ts
+
+- id: ENV-0003
+  title: Setup script caches installation
+  description: >-
+    scripts/codex-setup.sh creates a sentinel file after running once and skips
+    dependency installation on subsequent runs, making repeat executions faster.
+  category: environment
+  status: implemented
+  components: []
+  tests:
+    - client/e2e/utils/ENV-0003.spec.ts


### PR DESCRIPTION
## Summary
- document environment features in docs/dev-features.yaml
- explain env feature docs and separate execution in `AGENTS.md`
- use vitest for environment tests and update `test:env` script
- clarify environment test command in README
- add graph view and search E2E tests under `client/e2e/new`

## Testing
- ❌ `npx vitest run client/e2e/utils/ENV-0001.spec.ts` *(fails: Need to install the following packages)*
- ❌ `npx playwright test client/e2e/new/GRF-001.spec.ts` *(fails: Need to install the following packages)*

------
https://chatgpt.com/codex/tasks/task_e_6859e2ded4e0832fa1ff544d75e38ffd