### PR TITLE
Fix codex setup cross-env check

### DIFF
--- a/scripts/codex-setup.sh
+++ b/scripts/codex-setup.sh
@@ -25,6 +25,10 @@ echo "ROOT_DIR: ${ROOT_DIR}"
 # Initialize environment
 echo "Loading NVM..."
 load_nvm
+NPM_GLOBAL_BIN="$(npm bin -g 2>/dev/null || true)"
+if [ -n "$NPM_GLOBAL_BIN" ] && [[ ":$PATH:" != *":$NPM_GLOBAL_BIN:"* ]]; then
+  export PATH="$NPM_GLOBAL_BIN:$PATH"
+fi
 echo "Creating log directories..."
 create_log_directories
 echo "Clearing old log files..."


### PR DESCRIPTION
## Summary
- ensure `cross-env` is installed even when dependencies are skipped

## Testing
- `bash scripts/codex-setup.sh`
- `(cd client && npm run test:e2e -- e2e/core/tst-test-helper-utility-2020b233.spec.ts)`

------
https://chatgpt.com/codex/tasks/task_e_685b9b05511c832f8705c80d89a0e08a