### PR TITLE
Implement extended navigation commands

### DIFF
--- a/client/e2e/core/clm-extended-navigation-commands-427d145e.spec.ts
+++ b/client/e2e/core/clm-extended-navigation-commands-427d145e.spec.ts
@@ -1,0 +1,53 @@
+/** @feature CLM-0104
+ *  Title   : Extended navigation commands
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+import { CursorValidator } from "../utils/cursorValidation";
+
+// Simplified E2E verifying word jump and bracket jump
+
+test.describe("CLM-0104: Extended navigation commands", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await TestHelpers.prepareTestEnvironment(page, testInfo, [""]);
+    const first = page.locator(".outliner-item").first();
+    await first.locator(".item-content").click({ force: true });
+    await page.keyboard.press("Enter");
+    const item = page.locator(".outliner-item").nth(1);
+    await item.locator(".item-content").click({ force: true });
+    await page.waitForSelector("textarea.global-textarea:focus");
+    await TestHelpers.waitForCursorVisible(page);
+    await page.keyboard.type("Hello [test] world");
+  });
+
+  test("Ctrl+Left/Right move by word", async ({ page }) => {
+    await page.keyboard.press("ArrowLeft");
+    await page.keyboard.down("Control");
+    await page.keyboard.press("ArrowLeft");
+    await page.keyboard.press("ArrowLeft");
+    await page.keyboard.up("Control");
+    const data = await CursorValidator.getCursorData(page);
+    expect(data.cursorInstances[0].offset).toBe(6);
+    await page.keyboard.down("Control");
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.up("Control");
+    const data2 = await CursorValidator.getCursorData(page);
+    expect(data2.cursorInstances[0].offset).toBe(12);
+  });
+
+  test("Ctrl+Shift+\\ jumps between brackets", async ({ page }) => {
+    await page.keyboard.press("Home");
+    await page.keyboard.down("Control");
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.up("Control");
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.down("Control");
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("\\");
+    await page.keyboard.up("Shift");
+    await page.keyboard.up("Control");
+    const data = await CursorValidator.getCursorData(page);
+    expect(data.cursorInstances[0].offset).toBe(12);
+  });
+});

--- a/client/src/lib/Cursor.test.ts
+++ b/client/src/lib/Cursor.test.ts
@@ -324,4 +324,38 @@ describe('Cursor', () => {
     });
   });
 
+  describe('Extended navigation', () => {
+    let mockItem: Item;
+
+    beforeEach(async () => {
+      mockItem = createMockItem('item1', 'Hello World');
+      const { store: generalStore } = await import('../stores/store.svelte');
+      mockCurrentPage = createMockItem('page1', 'Page Title', [mockItem]);
+      generalStore.currentPage = mockCurrentPage;
+      cursor.itemId = 'item1';
+      vi.spyOn(cursor as any, 'findTarget').mockReturnValue(mockItem);
+    });
+
+    it('moveWordLeft and moveWordRight work correctly', () => {
+      cursor.offset = mockItem.text.length;
+      cursor.moveWordLeft();
+      expect(cursor.offset).toBe(6);
+      cursor.moveWordLeft();
+      expect(cursor.offset).toBe(0);
+      cursor.moveWordRight();
+      expect(cursor.offset).toBe(5);
+    });
+
+    it('moveToDocumentStart and moveToDocumentEnd', () => {
+      const other = createMockItem('item2', 'Second');
+      (mockCurrentPage!.items as any).push(other);
+      cursor.moveToDocumentEnd();
+      expect(cursor.itemId).toBe('item2');
+      expect(cursor.offset).toBe(other.text.length);
+      cursor.moveToDocumentStart();
+      expect(cursor.itemId).toBe('item1');
+      expect(cursor.offset).toBe(0);
+    });
+  });
+
 });

--- a/client/src/lib/KeyEventHandler.ts
+++ b/client/src/lib/KeyEventHandler.ts
@@ -93,6 +93,17 @@ export class KeyEventHandler {
             }
         }
 
+        // Alt+PageUp/PageDown スクロール
+        if (event.altKey && ["PageUp", "PageDown"].includes(event.key)) {
+            cursorInstances.forEach(cursor => {
+                if (event.key === "PageUp") cursor.altPageUp();
+                else cursor.altPageDown();
+            });
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+        }
+
         // フォーマットショートカットを処理
         if (event.ctrlKey) {
             // Ctrl+B: 太字

--- a/docs/client-features.yaml
+++ b/docs/client-features.yaml
@@ -1,0 +1,1002 @@
+- id: API-0001
+  title: Fixing Firebase Functions API Server
+  description: Firebase Functions APIサーバーのローカルテスト時のエラーを修正し、正常に動作するようにする機能
+  category: api-server
+  status: implemented
+  acceptance:
+  - CORS設定が正しく構成され、クロスオリジンリクエストが正常に処理される
+  - Firebase Functions エミュレーターが正常に起動する
+  - Firebase Hosting経由でのリクエストが正しくFunctionsにルーティングされる
+  - deleteContainerエンドポイント（/api/deleteContainer）が認証エラーを適切に処理する
+  - deleteUserエンドポイント（/api/deleteUser）が認証エラーを適切に処理する
+  - fluid-tokenエンドポイント（/api/fluid-token）が認証エラーを適切に処理する
+  - getUserContainersエンドポイント（/api/getUserContainers）が認証エラーを適切に処理する
+  - save-containerエンドポイント（/api/save-container）が認証エラーを適切に処理する
+  - ヘルスチェックエンドポイント（/health）が正常に応答する
+  - 'ポート設定が正しく構成される（Hosting: 57000, Functions: 57070）'
+  - 必須パラメータが不足している場合に400エラーが返される
+  - 無効なHTTPメソッドに対して405エラーが返される
+  - 環境変数が正しく読み込まれ、Azure Fluid Relay設定が適用される
+  - 認証に失敗した場合に401または500エラーが返される
+  tests:
+  - client/e2e/core/api-fixing-firebase-functions-api-server-9e65d78b.spec.ts
+  - functions/test/firebase-functions.test.js
+  components:
+  - client/.env.localhost.test
+  - firebase.json
+  - functions/.env
+  - functions/index.js
+  title-ja: Firebase Functions APIサーバーの修正
+- id: API-0002
+  title: Firebase emulator startup standby function
+  description: Firebase emulatorの起動を待つリトライ機能により、ECONNREFUSED エラーを回避する機能
+  category: api-server
+  status: implemented
+  acceptance:
+  - ECONNREFUSED エラーが発生した場合、指数バックオフでリトライする
+  - ECONNREFUSED以外のエラーは即座に失敗とする
+  - Firebase Auth emulatorへの接続テストを行い、成功するまで待機する
+  - Firebase emulator環境変数が設定されている場合、emulatorの起動を待機する
+  - emulator環境でない場合は待機をスキップする
+  - リトライ回数と遅延時間をログに出力する
+  - 接続成功時にユーザー数とユーザー情報をログに出力する
+  - 最大30回のリトライを行い、初期遅延1秒、最大遅延10秒で待機する
+  tests:
+  - client/e2e/core/api-firebase-emulator-startup-standby-function-c9fa9c85.spec.ts
+  - server/tests/log-service-emulator-wait.test.js
+  components:
+  - server/log-service.js
+  title-ja: Firebase emulator起動待機機能
+- id: API-0003
+  title: Admin check for container user listing
+  description: /api/get-container-users requires admin role
+  category: api-server
+  status: implemented
+  acceptance:
+  - 管理者はコンテナのユーザーリストを取得できる
+  - 非管理者がアクセスした場合403エラーを返す
+  tests:
+  - client/e2e/core/api-admin-check-for-container-user-listing-bada0e86.spec.ts
+  - server/tests/get-container-users.test.js
+  components:
+  - server/log-service.js
+  title-ja: コンテナユーザーリストの管理者チェック
+- id: API-0004
+  title: Admin user list
+  description: /api/list-users returns all users for admins only
+  category: api-server
+  status: implemented
+  acceptance:
+  - 管理者はFirebaseユーザー一覧を取得できる
+  - 管理者以外のリクエストは403エラーを返す
+  tests:
+  - server/tests/log-service.test.js
+  components:
+  - server/log-service.js
+  title-ja: 管理者ユーザーリスト
+- id: APP-0001
+  title: Set focus to global text area when viewing project pages
+  description: プロジェクトページ表示時に自動的にグローバルテキストエリアにフォーカスを設定し、すぐに入力できるようにします。
+  category: application
+  status: implemented
+  acceptance:
+  - カーソルが表示される
+  - プロジェクトページ表示時にグローバルテキストエリアにフォーカスが設定される
+  - ユーザーがクリックせずに直接テキスト入力が可能になる
+  tests:
+  - client/e2e/core/app-set-focus-to-global-text-area-when-viewing-project-pages-d14affb9.spec.ts
+  title-ja: プロジェクトページ表示時にグローバルテキストエリアにフォーカスを設定
+- id: CHT-001
+  title: Chart Component
+  description: 保存されたデータをグラフ表示するチャートコンポーネント
+  category: visualization
+  status: implemented
+  components:
+  - src/components/ChartComponent.svelte
+  tests:
+  - client/e2e/core/cht-chart-component-1b7a8eff.spec.ts
+  acceptance:
+  - データをグラフで表示する
+  - データ更新時にグラフが自動更新される
+  title-ja: チャートコンポーネント
+- id: CLM-0001
+  title: Click to enter edit mode
+  shortcut: クリック
+  description: クリックで編集モードに入ります。
+  category: cursor-movement
+  status: implemented
+  tests:
+  - client/e2e/core/clm-click-to-enter-edit-mode-760e61d9.spec.ts
+  acceptance:
+  - カーソルがクリック位置に表示される（最後の行を除く）
+  - カーソルが点滅する
+  - カーソルが表示される
+  - クリックで編集モードに入る
+  - 編集モードで文字入力が可能になる
+  title-ja: クリックで編集モードに入る
+- id: CLM-0002
+  title: Move left
+  shortcut: ←
+  description: カーソルを1文字左に移動します。
+  category: cursor-movement
+  status: implemented
+  acceptance:
+  - カーソルを1文字左に移動する
+  - 一番最初の文字にある時は、一つ前のアイテムの最後の文字へ移動する
+  tests:
+  - client/e2e/core/clm-move-left-b4e61244.spec.ts
+  title-ja: 左へ移動
+- id: CLM-0003
+  title: Move to the right
+  shortcut: →
+  description: カーソルを1文字右に移動します。
+  category: cursor-movement
+  status: implemented
+  acceptance:
+  - カーソルを1文字右に移動する
+  - 一番最後の文字にある時は、一つ次のアイテムの最初の文字へ移動する
+  tests:
+  - client/e2e/core/clm-move-to-the-right-c4f91a56.spec.ts
+  title-ja: 右へ移動
+- id: CLM-0004
+  title: Move up
+  shortcut: ↑
+  description: カーソルを1行上に移動します。
+  category: cursor-movement
+  status: implemented
+  acceptance:
+  - カーソルを1行上に移動する
+  - 一番上の行にある時で、一つ前のアイテムがない時は、同じアイテムの先頭へ移動する
+  - 一番上の行にある時は、一つ前のアイテムの最後の行へ移動する。このとき、x座標の変化が最も小さい位置にカーソルをセットする。文字数が少ない場合は大きく移動する場合もある。カーソル上下以外の操作をしていない場合は、最初にカーソル上を押し始めた x座標からの変化が小さい位置にカーソルをセットする。
+  - 一番上の行以外にある時は、同じアイテムの1行上へ移動する
+  tests:
+  - client/e2e/core/clm-move-up-810ae124.spec.ts
+  title-ja: 上へ移動
+- id: CLM-0005
+  title: Move down
+  shortcut: ↓
+  description: カーソルを1行下に移動します。
+  category: cursor-movement
+  status: implemented
+  acceptance:
+  - カーソルを1行下に移動する
+  - 一番下の行にある時で、一つ次のアイテムがない時は、同じアイテムの末尾へ移動する
+  - 一番下の行にある時は、一つ次のアイテムの最初の行へ移動する。このとき、x座標の変化が最も小さい位置にカーソルをセットする。文字数が少ない場合は大きく移動する場合もある。カーソル上下以外の操作をしていない場合は、最初にカーソル下を押し始めた x座標からの変化が小さい位置にカーソルをセットする。
+  - 一番下の行以外にある時は、同じアイテムの1行下へ移動する
+  tests:
+  - client/e2e/core/clm-move-down-4215682b.spec.ts
+  title-ja: 下へ移動
+- id: CLM-0007
+  title: Go to the beginning of the line
+  shortcut: Home
+  description: カーソルを行の先頭に移動します。
+  category: cursor-movement
+  status: implemented
+  acceptance:
+  - Homeキーを押すと、カーソルが現在の行の先頭に移動する
+  - 複数行のアイテムでは、現在のカーソルがある行の先頭に移動する
+  tests:
+  - client/e2e/core/clm-go-to-the-beginning-of-the-line-d39d158b.spec.ts
+  title-ja: 行頭へ移動
+- id: CLM-0008
+  title: Go to the end of the line
+  shortcut: End
+  description: カーソルを行の末尾に移動します。
+  category: cursor-movement
+  status: implemented
+  acceptance:
+  - Endキーを押すと、カーソルが現在の行の末尾に移動する
+  tests:
+  - client/e2e/core/clm-go-to-the-end-of-the-line-03dfa6ef.spec.ts
+  title-ja: 行末へ移動
+- id: CLM-0100
+  title: The cursor does not increase when normal clicks
+  description: アイテム間を移動する際に、カーソルが増えないようにします。
+  category: cursor-management
+  status: implemented
+  tests:
+  - client/e2e/core/clm-the-cursor-does-not-increase-when-normal-clicks-1ac82e88.spec.ts
+  acceptance:
+  - アイテム間をクリックで移動しても、カーソルの数が増えない
+  - 前のアイテムのカーソルは完全に削除される
+  - 常に1つのカーソルだけが表示される
+  title-ja: 通常クリックでカーソルが増えないこと
+- id: CLM-0101
+  title: Cursor duplication and input distribution problems when moving between items
+  description: アイテム間を移動する際に、複数のカーソルが生成され、入力が複数のアイテムに分散する問題を検出します。
+  category: cursor-management
+  status: implemented
+  tests:
+  - client/e2e/core/clm-cursor-duplication-and-input-distribution-problems-when-moving-between-items-be4c0ba6.spec.ts
+  acceptance:
+  - 1番目のアイテムに「123」の繰り返しが表示される問題を検出する
+  - 入力が複数のアイテムに分散する問題を検出する
+  - 異なる位置に複数のカーソルが表示される問題を検出する
+  - 複数のアイテムをクリックすると、複数のカーソルが生成される問題を検出する
+  title-ja: アイテム間移動時のカーソル重複と入力分散問題
+- id: CLM-0102
+  title: Move cursors and multiple keyboard operations on empty text items
+  description: 空のテキストアイテムでのカーソル移動と、クリック後の複数回のキーボード操作が正しく機能することを確認します。
+  category: cursor-management
+  status: implemented
+  tests:
+  - client/e2e/core/clm-move-cursors-and-multiple-keyboard-operations-on-empty-text-items-20043fb0.spec.ts
+  acceptance:
+  - アイテム間を移動しても常に1つのカーソルだけが表示される
+  - クリック後に複数回のキーボード操作でカーソルが正しく移動する
+  - 入力が正しいアイテムに行われる
+  - 空のテキストアイテム間をキーボードで移動できる
+  title-ja: 空のテキストアイテムでのカーソル移動と複数回のキーボード操作
+- id: CLM-0103
+  title: Cursor manipulation with format strings
+  description: フォーマット（太字、斜体など）が適用された文字列内でのカーソル移動が正しく機能することを確認します。
+  category: cursor-movement
+  status: implemented
+  tests:
+  - client/e2e/core/clm-cursor-manipulation-with-format-strings-86f0d787.spec.ts
+  acceptance:
+  - Home/Endキーがフォーマット文字列で正しく機能する
+  - Shift+矢印キーによる選択がフォーマット文字列で正しく機能する
+  - フォーマット文字列内でのカーソル移動が正しく機能する
+  - 複数のフォーマットが混在する文字列でのカーソル移動が正しく機能する
+  title-ja: フォーマット文字列でのカーソル操作
+- id: CLM-0104
+  title: Extended navigation commands
+  title-ja: 拡張ナビゲーションコマンド
+  description: Ctrl+Left/Right word jumps, bracket jump with Ctrl+Shift+\, document navigation with Ctrl+Home/End, PageUp/PageDown and scroll commands.
+  category: cursor-movement
+  status: implemented
+  tests:
+  - client/e2e/core/clm-extended-navigation-commands-427d145e.spec.ts
+- id: COL-0001
+  title: Displaying cursors for other users
+  description: 複数ユーザーが同じページを編集しているとき、他ユーザーのカーソル位置をリアルタイムに表示する
+  category: collaboration
+  status: implemented
+  acceptance:
+  - Fluid Framework の signal 機能でカーソル位置を同期する
+  - 他ユーザーがカーソルを移動すると、その位置が表示される
+  tests:
+  - client/e2e/core/COL-0001.spec.ts
+  title-ja: 他ユーザーのカーソル表示
+- id: DBW-001
+  title: Client-Side SQL Database
+  description: IndexedDB上にSQLデータベースを構築し、オフラインでページを保存できる機能
+  category: database
+  status: implemented
+  tests:
+  - client/e2e/new/DBW-001.spec.ts
+  title-ja: クライアント側SQLデータベース
+- id: FLD-0001
+  title: Ability to retrieve FluidClient from project title
+  description: clientRegistryを走査して、Project.titleが一致するFluidClientインスタンスを取得する機能。プロジェクトタイトルとFluid containerのIDは1:1の対応関係にある。
+  category: fluid-service
+  status: implemented
+  acceptance:
+  - clientRegistryに登録されている全てのFluidClientを走査して一致するものを探す
+  - プロジェクトタイトルからFluidClientインスタンスを取得できる
+  - プロジェクトタイトルが指定されていない場合はエラーを返す
+  - プロジェクトタイトルに一致するFluidClientが見つからない場合はundefinedを返す
+  - プロジェクトレイアウトでこの機能を使用してプロジェクトデータを読み込める
+  - 取得したFluidClientインスタンスを使用してプロジェクトデータにアクセスできる
+  - 新しいプロジェクトを作成してからFluidClientを取得できる
+  tests:
+  - client/e2e/core/fld-ability-to-retrieve-fluidclient-from-project-title-f3bf0fec.spec.ts
+  title-ja: プロジェクトタイトルからFluidClientを取得する機能
+- id: FMT-0001
+  title: Format display
+  description: Scrapbox構文のフォーマットを視覚的に表示する機能
+  category: text-formatting
+  status: implemented
+  acceptance:
+  - Scrapbox構文のUXをクローンし、編集中はプレーンテキスト、非編集時はフォーマット表示となる
+  - カーソルがあるアイテムではプレーンテキストの入力内容がそのまま表示される
+  - カーソルがないアイテムではフォーマットされた内容が表示される
+  - コードフォーマット（`text`）が視覚的にコードスタイルで表示される
+  - 取り消し線フォーマット（[- text]）が視覚的に取り消し線付きで表示される
+  - 太字フォーマット（[[text]]）が視覚的に太字で表示される
+  - 斜体フォーマット（[/ text]）が視覚的に斜体で表示される
+  tests:
+  - client/e2e/core/fmt-format-display-048d107c.spec.ts
+  title-ja: フォーマット表示
+- id: FMT-0002
+  title: Format combination
+  description: Scrapbox構文の複数フォーマットの組み合わせを視覚的に表示する機能
+  category: text-formatting
+  status: implemented
+  acceptance:
+  - カーソルがあるアイテムでは組み合わせフォーマットもプレーンテキストで表示される
+  - 太字と取り消し線の組み合わせが正しく表示される
+  - 太字と斜体の組み合わせが正しく表示される
+  - 斜体とコードの組み合わせが正しく表示される
+  - 複数のフォーマットが入れ子になっている場合も正しく表示される
+  tests:
+  - client/e2e/core/fmt-format-combination-bcb56231.spec.ts
+  title-ja: フォーマット組み合わせ
+- id: FMT-0003
+  title: Extended format
+  description: Scrapbox構文の拡張フォーマット（リンク、引用）を視覚的に表示する機能
+  category: text-formatting
+  status: implemented
+  acceptance:
+  - カーソルがあるアイテムでは拡張フォーマットもプレーンテキストで表示される
+  - リンク構文（[URL]）が正しくリンクとして表示される
+  - 引用構文（> テキスト）が正しく引用として表示される
+  - 複合フォーマット（引用内の太字や斜体など）が正しく表示される
+  tests:
+  - client/e2e/core/fmt-extended-format-b471a4b9.spec.ts
+  title-ja: 拡張フォーマット
+- id: FMT-0004
+  title: Paste and format from the clipboard
+  description: クリップボードからのテキストペーストとフォーマット保持機能
+  category: text-formatting
+  status: implemented
+  acceptance:
+  - カーソル位置にテキストがペーストされる
+  - フォーマット構文を含むテキストのペーストが正しく機能する
+  - プレーンテキストのペーストが正しく機能する
+  - ペーストされたフォーマット構文が視覚的に正しく表示される
+  - 複数行テキストのペーストが正しく機能する
+  tests:
+  - client/e2e/core/fmt-paste-and-format-from-the-clipboard-fe4971c2.spec.ts
+  title-ja: クリップボードからのペーストとフォーマット
+- id: FMT-0005
+  title: VS Code style clipboard behavior
+  category: text-formatting
+  status: implemented
+  description: 'Copying and pasting using multi-cursors or box selection should behave the same as Visual Studio Code. Metadata in the clipboard is interpreted so each cursor receives the expected text.
+
+    '
+  acceptance:
+  - Box selection paste inserts each line of text into the corresponding selection range
+  - Clipboard operations work when triggered via keyboard shortcuts
+  - Pasting with application/vscode-editor metadata distributes text across multiple cursors
+  tests:
+  - client/e2e/core/fmt-vscode-clipboard-behavior-3807f353.spec.ts
+  title-ja: VS Code風クリップボード操作
+- id: FMT-0006
+  title: Consistency of format display when moving cursors
+  description: カーソル移動時にフォーマット表示が一貫して適切に切り替わることを確認します
+  category: text-formatting
+  status: implemented
+  acceptance:
+  - カーソルがあるアイテムでは制御文字（[[]], [/], [-], `）が表示される
+  - カーソルがないアイテムでは制御文字が非表示でフォーマットが適用される
+  - カーソル移動時に表示が適切に切り替わる
+  - タイトル（最初の行）は通常のテキスト表示される（ボールド表示されない）
+  - リンク構文（[ text]]）が正しくリンクとして表示される
+  tests:
+  - client/e2e/core/fmt-consistency-of-format-display-when-moving-cursors-36199743.spec.ts
+  title-ja: カーソル移動時のフォーマット表示の一貫性
+- id: FMT-0007
+  title: Displaying internal link function
+  description: /project-name/page-name 形式の内部リンクをサポートする機能
+  category: text-formatting
+  status: implemented
+  acceptance:
+  - '[/project-name/page-name] 形式の内部リンクが正しく表示される'
+  - '[page-name] 形式の内部リンクが正しく表示される'
+  - カーソルがあるアイテムでは内部リンクもプレーンテキストで表示される
+  - カーソルがないアイテムでは内部リンクが視覚的にリンクとして表示される
+  tests:
+  - client/e2e/core/fmt-displaying-internal-link-function-a8a7c97e.spec.ts
+  title-ja: 内部リンク機能の表示
+- id: FMT-0008
+  title: Support multiple internal links in one item
+  title-ja: 1アイテム内で複数の内部リンクをサポート
+  description: 単一のアイテム内で複数の内部リンクを正しく表示・動作させる
+  category: text-formatting
+  status: implemented
+  acceptance:
+  - 1アイテム内に複数の [page] と [/project/page] リンクを含めてもすべてがリンクとして表示される
+  - E2E テストが成功する
+  - ScrapboxFormatter.formatToHtml で複数リンクが適切に生成される
+  - カーソルがある場合はプレーンテキスト表示となる
+  - ページ存在チェッククラス page-exists/page-not-exists がそれぞれ適用される
+  - リンクをクリックすると正しいページへ遷移する
+  - 各リンクにリンクプレビューが表示される
+  tests:
+  - client/e2e/core/fmt-multiple-internal-links-3a606671.spec.ts
+  - client/src/utils/ScrapboxFormatter.test.ts
+- id: FTR-0012
+  title: User can reset forgotten password
+  status: implemented
+  components:
+  - lib/email/resetPassword.ts
+  - routes/auth/forgot.svelte
+  tests:
+  - tests/feature/FTR-0012.spec.ts
+  acceptance:
+  - ユーザーがメールアドレスを入力すると、リセットリンクが送信される
+  - リンクは 30 分で失効する
+  - 正しいトークンを送るとパスワードを再設定できる
+  title-ja: ユーザーは忘れられたパスワードをリセットできます
+- id: FTR-0013
+  title: Use environment variables in min page
+  status: implemented
+  components:
+  - client/.env.example
+  - client/src/routes/min/+page.svelte
+  tests:
+  - client/e2e/core/ftr-use-environment-variables-in-min-page-cfe01fbf.spec.ts
+  acceptance:
+  - Firebase config values come from VITE_FIREBASE_* variables
+  - Token verification URL uses VITE_TOKEN_VERIFY_URL
+  title-ja: 最小ページで環境変数を使用します
+- id: IME-0001
+  title: Japanese input using IME
+  status: implemented
+  tests:
+  - client/e2e/core/ime-japanese-input-using-ime-59109b4a.spec.ts
+  acceptance:
+  - IMEを使用した日本語入力が可能になる
+  - 入力途中の文字がカーソル位置に表示される
+  - 変換候補がカーソル位置に表示される
+  title-ja: IMEを使用した日本語入力
+- id: IND-0001
+  title: Advanced indentation and selection operations
+  description: Use Tab and Shift+Tab to create nested structures and copy them via clipboard.
+  category: editing
+  status: implemented
+  tests:
+  - client/e2e/new/IND-0001.spec.ts
+  acceptance:
+  - Items can be indented with Tab to create nested structure
+  - Items can be outdented with Shift+Tab
+  - Selected nested items can be copied and pasted using clipboard
+  title-ja: 高度なインデントと選択操作
+- id: ITM-0001
+  title: Add new items with Enter
+  shortcut: Enter
+  description: カーソル位置でアイテムを分割し、新しいアイテムを追加します。
+  category: item-management
+  status: implemented
+  acceptance:
+  - Enterキーを押すと、カーソル位置でアイテムが分割される
+  - カーソルは新しいアイテムの先頭に移動する
+  - カーソル位置より前のテキストは現在のアイテムに残る
+  - カーソル位置より後のテキストは新しいアイテムに移動する
+  - タイトルでは、新しいアイテムは最初の子として追加される
+  - 通常のアイテムでは、新しいアイテムは兄弟として追加される
+  tests:
+  - client/e2e/core/itm-add-new-items-with-enter-49d26e99.spec.ts
+  - client/e2e/core/itm-add-new-items-with-enter-49d26e99.spec.ts
+  title-ja: Enterで新規アイテム追加
+- id: LNK-0001
+  title: URL generation function for internal links
+  description: 内部リンクのURLが正しく生成される機能
+  category: navigation
+  status: implemented
+  acceptance:
+  - '[/project-name/page-name] 形式の内部リンクが /project-name/page-name のURLを生成する'
+  - '[page-name] 形式の内部リンクが /page-name のURLを生成する'
+  - 内部リンクのHTMLが正しく生成される
+  - 内部リンクのURLが正しく生成される
+  tests:
+  - client/e2e/core/lnk-url-generation-function-for-internal-links-b840d2c4.spec.ts
+  title-ja: 内部リンクのURL生成機能
+- id: LNK-0002
+  title: Internal link functionality verification
+  description: 内部リンクが正しく機能することを確認する
+  category: navigation
+  status: implemented
+  acceptance:
+  - プロジェクト内部リンク（/project-name/page-name形式）のhref属性が正しく生成される
+  - 内部リンクのhref属性が正しく生成される
+  - 内部リンクのクラスとテキストが正しく設定される
+  - 様々な形式の内部リンクが正しく生成される
+  tests:
+  - client/e2e/core/lnk-internal-link-functionality-verification-eb4d5867.spec.ts
+  title-ja: 内部リンクの機能検証
+- id: LNK-0003
+  title: Internal link navigation feature
+  description: 内部リンクをクリックして別のページに移動する機能
+  category: navigation
+  status: implemented
+  acceptance:
+  - URLを直接入力して内部リンク先のページにアクセスできる
+  - プロジェクト内部リンクの形式が正しく生成される（[/project-name/page-name]形式）
+  - プロジェクト内部リンクをクリックして遷移先のページ内容が正しく表示される
+  - プロジェクト内部リンク（/project-name/page-name形式）をクリックすると対応するページに移動する
+  - 内部リンクの形式が正しく生成される（[page-name]形式）
+  - 内部リンクをクリックして遷移先のページ内容が正しく表示される
+  - 内部リンクをクリックすると対応するページに移動する
+  - 存在しないページへのリンクをクリックした場合も対応するURLに移動する
+  - 存在しないページへの内部リンクをクリックした場合、新規ページが作成される
+  tests:
+  - client/e2e/core/lnk-internal-link-navigation-feature-db56e693.spec.ts
+  testcases:
+  - 内部リンクをクリックして別のページに移動する
+  - URLを直接入力して内部リンク先のページにアクセスする
+  - 実際のアプリケーションで内部リンクを作成する
+  - 実際のアプリケーションでプロジェクト内部リンクを作成する
+  - 内部リンクをクリックして遷移先のページ内容が正しく表示される
+  - 存在しないページへの内部リンクをクリックした場合の挙動
+  - プロジェクト内部リンクをクリックして遷移先のページ内容が正しく表示される
+  title-ja: 内部リンクのナビゲーション機能
+- id: LNK-0004
+  title: Temporary page function
+  description: 存在しないページへのリンクをクリックした場合に仮ページを表示し、編集時のみ実際のページとして保存する機能
+  category: navigation
+  status: implemented
+  acceptance:
+  - 仮ページが保存された後は、通常のページとして扱われる
+  - 仮ページであることを示すUIは表示されない（非表示設定）
+  - 仮ページにアクセスしただけでは、ページは作成されない
+  - 仮ページの通知UIは非表示になっている
+  - 仮ページを編集した場合のみ、実際のページとして保存される
+  - 存在しないページへのリンクをクリックした場合、仮ページを表示する
+  tests:
+  - client/e2e/core/lnk-temporary-page-function-08bbbbfc.spec.ts
+  testcases:
+  - 存在しないページへのリンクをクリックした場合に仮ページが表示される
+  - 仮ページを編集した場合に実際のページとして保存される
+  - 仮ページにアクセスしただけではページが作成されないことを確認
+  - 仮ページの通知UIが非表示になっている
+  - 仮ページの通知UIのアクションボタンが機能する（スキップされる）
+  title-ja: 仮ページ機能
+- id: LNK-0005
+  title: Link preview feature
+  description: 内部リンクにマウスオーバーした際にページ内容のプレビューを表示する機能
+  category: navigation
+  status: implemented
+  acceptance:
+  - プレビューにはページのタイトルと内容の一部が表示される
+  - プレビューはマウスが離れると非表示になる
+  - 内部リンクにマウスオーバーするとプレビューが表示される
+  - 別プロジェクトのページへのリンクの場合は、その旨が表示される
+  - 存在しないページへのリンクの場合は、その旨が表示される
+  tests:
+  - client/e2e/core/LNK-0005.spec.ts
+  testcases:
+  - 内部リンクにマウスオーバーするとプレビューが表示される
+  - プレビューにページのタイトルと内容の一部が表示される
+  - プレビューはマウスが離れると非表示になる
+  - 存在しないページへのリンクの場合は、その旨が表示される
+  notes:
+  - テスト環境ではマウスイベントが正確に動作しない場合があるため、TestHelpers.forceHoverEvent()とTestHelpers.forceLinkPreview()を使用してテストを安定化
+  title-ja: リンクプレビュー機能
+- id: LNK-0007
+  title: Backlink function
+  description: あるページからリンクされているページの一覧を表示する機能
+  category: navigation
+  status: implemented
+  acceptance:
+  - バックリンクのコンテキスト（リンクを含む文脈）が表示される
+  - バックリンクの数がバッジとして表示される
+  - バックリンクをクリックすると、リンク元のページに移動できる
+  - バックリンクパネルには、そのページへのリンクを含むページの一覧が表示される
+  - バックリンクパネルは開閉できる
+  - ページにバックリンクパネルが表示される
+  tests:
+  - client/e2e/core/lnk-backlink-function-7976aef8.spec.ts
+  testcases:
+  - ページにバックリンクパネルが表示される
+  - バックリンクパネルにリンク元ページの一覧が表示される
+  - バックリンクの数がバッジとして表示される
+  - バックリンクパネルを開閉できる
+  - バックリンクをクリックするとリンク元ページに移動できる
+  notes:
+  - テスト環境ではバックリンクパネルの開閉が正確に動作しない場合があるため、TestHelpers.openBacklinkPanel()を使用してテストを安定化
+  title-ja: バックリンク機能
+- id: LOG-0001
+  title: Development log service
+  title-ja: 開発ログサービス
+  description: Node server used in development and test environments to store logs. Firebase emulator initialization is handled by a separate script.
+  category: api-server
+  status: implemented
+  components:
+  - server/log-service.js
+  - server/scripts/init-firebase-emulator.js
+  tests:
+  - client/e2e/core/log-development-log-service-8f761bd4.spec.ts
+- id: MCE-0001
+  title: Multi-Cursor Editing
+  description: 複数のカーソルを使って同時に編集できる機能
+  category: collaboration
+  status: implemented
+  acceptance:
+  - Undo/redoがすべてのカーソルに適用される
+  - 各カーソルから独立してテキスト編集できる
+  - 複数のカーソルを配置できる
+  tests:
+  - client/e2e/disabled/multi-cursor.spec.ts
+  - client/src/stores/EditorOverlayStore.test.ts
+  title-ja: マルチカーサーの編集
+- id: NAV-0001
+  title: Project Selection and Page Navigation
+  description: ルートページでプロジェクトを選択した場合にプロジェクトページへ遷移し、プロジェクトページからページリストを通じて個別ページへ遷移する機能
+  category: navigation
+  status: implemented
+  acceptance:
+  - プロジェクトページ(/[project_name])のページリストから、対応するページ(/[project_name]/[page_name])へ遷移するリンクが機能する
+  - プロジェクト選択後、プロジェクト内のページ一覧が表示される
+  - ページリストの各ページ名をクリックすると、そのページの内容が表示される
+  - ルートページ(/)でプロジェクトを選択すると、対応するプロジェクトページ(/[project_name])へ遷移する
+  tests:
+  - client/e2e/core/nav-project-selection-and-page-navigation-bf35d422.spec.ts
+  title-ja: プロジェクト選択とページナビゲーション
+- id: NAV-0002
+  title: Link function to project page
+  description: ページ表示時にプロジェクトページへのリンクをパンくずナビゲーションとして表示する機能
+  category: navigation
+  status: implemented
+  acceptance:
+  - パンくずナビゲーションにプロジェクトページへのリンクが表示される
+  - パンくずナビゲーションにホームへのリンクが表示される
+  - パンくずナビゲーションに現在のページ名が表示される
+  - プロジェクトページへのリンクをクリックするとプロジェクトページに遷移する
+  - ページ表示時にパンくずナビゲーションが表示される
+  - ホームへのリンクをクリックするとホームページに遷移する
+  tests:
+  - client/e2e/core/nav-link-function-to-project-page-a0e7d28a.spec.ts
+  title-ja: プロジェクトページへのリンク機能
+- id: SEC-0001
+  title: Dotenvx encrypted env files
+  description: Use dotenvx to encrypt server environment files
+  category: security
+  status: implemented
+  components: []
+  tests:
+  - client/e2e/core/sec-dotenvx-encrypted-env-files-fa94885c.spec.ts
+  title-ja: dotenvx暗号化されたenvファイル
+- id: SEC-0002
+  title: Two-Factor Authentication (2FA)
+  description: This project intentionally omits two-factor authentication. Firebase Authentication handles user sign-in, and email link authentication is used only during testing.
+  category: security
+  status: deprecated
+  components: []
+  tests: []
+  title-ja: 二因子認証（2FA）
+- id: SLR-0001
+  title: Shift + Up, down, left, right
+  shortcut: Shift + 上下左右
+  description: カーソルを1文字上下左右に移動し、選択範囲を広げます。
+  category: selection-range
+  status: implemented
+  acceptance:
+  - Shift + 上で選択範囲の上端を広げる
+  - Shift + 下で選択範囲の下端を広げる
+  - Shift + 右で選択範囲の右端を広げる
+  - Shift + 左で選択範囲の左端を広げる
+  tests:
+  - client/e2e/core/slr-shift-up-down-left-right-eb1d392a.spec.ts
+  title-ja: Shift + 上下左右
+- id: SLR-0002
+  title: Select up to the beginning of the line
+  shortcut: Shift + Home
+  description: カーソル位置から行の先頭までを選択します。
+  category: selection-range
+  status: implemented
+  acceptance:
+  - Shift + Homeで現在位置から行頭までを選択する
+  - 複数行のアイテムでは、現在のカーソルがある行の先頭までを選択する
+  tests:
+  - client/e2e/core/slr-select-up-to-the-beginning-of-the-line-6c287e80.spec.ts
+  title-ja: 行頭まで選択
+- id: SLR-0003
+  title: Select to the end of the line
+  shortcut: Shift + End
+  description: カーソル位置から行の末尾までを選択します。
+  category: selection-range
+  status: implemented
+  acceptance:
+  - Shift + Endで現在位置から行末までを選択する
+  - 複数行のアイテムでは、現在のカーソルがある行の末尾までを選択する
+  tests:
+  - client/e2e/core/slr-select-to-the-end-of-the-line-8467ba25.spec.ts
+  title-ja: 行末まで選択
+- id: SLR-0004
+  title: Selection by dragging mouse
+  description: マウスドラッグでテキストを選択します。
+  category: selection-range
+  status: implemented
+  acceptance:
+  - マウスドラッグで単一アイテム内のテキストを選択できる
+  - 選択範囲が視覚的に表示される
+  - 選択範囲のテキストをコピーできる
+  tests:
+  - client/e2e/core/slr-selection-by-dragging-mouse-c032a81b.spec.ts
+  title-ja: マウスドラッグによる選択
+- id: SLR-0005
+  title: Selection spans multiple items
+  description: 複数アイテムにまたがるテキスト選択機能
+  category: selection-range
+  status: implemented
+  acceptance:
+  - Shift+上下キーで複数アイテムにまたがる選択範囲を作成できる
+  - マウスドラッグで複数アイテムにまたがる選択範囲を作成できる
+  - 複数アイテムにまたがる選択範囲が視覚的に表示される
+  tests:
+  - client/e2e/core/slr-selection-spans-multiple-items-7374d150.spec.ts
+  title-ja: 複数アイテムにまたがる選択
+- id: SLR-0006
+  title: Copy and paste multiple item selection ranges
+  description: 複数アイテムにまたがる選択範囲のコピー＆ペースト機能
+  category: selection-range
+  status: implemented
+  acceptance:
+  - コピーしたテキストを別の場所にペーストできる
+  - 複数アイテムにまたがる選択範囲のテキストをコピーできる
+  - 複数行テキストをペーストすると適切に複数アイテムに分割される
+  tests:
+  - client/e2e/core/slr-copy-and-paste-multiple-item-selection-ranges-5896d5f4.spec.ts
+  title-ja: 複数アイテム選択範囲のコピー＆ペースト
+- id: SLR-0007
+  title: Delete a multi-item selection
+  description: 複数アイテムにまたがる選択範囲の削除機能
+  category: selection-range
+  status: implemented
+  acceptance:
+  - カーソル位置が適切に更新される
+  - 削除後、アイテムが適切に結合される
+  - 複数アイテムにまたがる選択範囲をBackspace/Deleteキーで削除できる
+  tests:
+  - client/e2e/core/slr-delete-a-multi-item-selection-9d60773c.spec.ts
+  title-ja: 複数アイテム選択範囲の削除
+- id: SLR-0008
+  title: Selected Edge Case
+  description: 選択範囲機能のエッジケースのテスト
+  category: selection-range
+  status: implemented
+  acceptance:
+  - 空のアイテムを含む選択範囲を作成できる
+  - 複数アイテムにまたがる選択範囲を削除した後、カーソル位置が適切に更新される
+  - 選択範囲の方向（正方向/逆方向）を切り替えることができる
+  - 長いテキストを含むアイテムの選択範囲を作成できる
+  tests:
+  - client/e2e/core/slr-selected-edge-case-e818d989.spec.ts
+  title-ja: 選択範囲のエッジケース
+- id: SLR-0009
+  title: Drag and drop text movement
+  description: 選択範囲のテキストをドラッグ＆ドロップで移動する機能
+  category: selection-range
+  status: implemented
+  acceptance:
+  - アイテム全体をドラッグ＆ドロップで移動できる
+  - ドラッグ中に視覚的なフィードバックが表示される
+  - ドロップ位置に応じて適切にテキストが挿入される
+  - 単一アイテム内の選択範囲をドラッグ＆ドロップで移動できる
+  - 複数アイテムにまたがる選択範囲をドラッグ＆ドロップで移動できる
+  tests:
+  - client/e2e/core/slr-drag-and-drop-text-movement-e889233a.spec.ts
+  title-ja: ドラッグ＆ドロップによるテキスト移動
+- id: SLR-0010
+  title: Change the format of the selection
+  description: 選択範囲のテキストのフォーマット（太字、斜体、下線、取り消し線、コード）を変更する機能
+  category: selection-range
+  status: implemented
+  acceptance:
+  - Scrapbox構文に準拠したフォーマットが適用される
+  - キーボードショートカットでフォーマットを変更できる
+  - コードフォーマット（`text`）を適用できる
+  - 単一アイテム内の選択範囲のフォーマットを変更できる
+  - 取り消し線フォーマット（[- text]）を適用できる
+  - 同じフォーマットを再度適用すると、フォーマットが解除される
+  - 太字フォーマット（[[text]]）を適用できる
+  - 斜体フォーマット（[/ text]）を適用できる
+  - 複数アイテムにまたがる選択範囲のフォーマットを変更できる
+  tests:
+  - client/e2e/core/slr-change-the-format-of-the-selection-880de1fa.spec.ts
+  title-ja: 選択範囲のフォーマット変更
+- id: SLR-0100
+  title: Box Selection (Rectangle Selection) Function - Keyboard
+  shortcut: Alt+Shift+矢印キー
+  description: Alt+Shift+矢印キーによる矩形選択機能
+  category: selection-range
+  status: implemented
+  acceptance:
+  - Alt+Shift+矢印キーで矩形選択を開始できる
+  - Escキーで矩形選択をキャンセルできる
+  - 矩形選択の範囲が視覚的に表示される
+  - 矩形選択の範囲を矢印キーで拡張できる
+  - 矩形選択範囲にテキストをペーストできる
+  - 矩形選択範囲のテキストをコピーできる
+  - 複数アイテムにまたがる矩形選択を作成できる
+  tests:
+  - client/e2e/core/slr-box-selection-rectangle-selection-function-keyboard-50ee5e3d.spec.ts
+  title-ja: ボックス選択（矩形選択）機能 - キーボード
+- id: SLR-0101
+  title: Box Selection (Rectangle Selection) Function - Mouse
+  shortcut: Alt+Shift+ドラッグ
+  description: Alt+Shift+マウスドラッグによる矩形選択機能
+  category: selection-range
+  status: implemented
+  acceptance:
+  - Alt+Shift+マウスドラッグで矩形選択を開始できる
+  - 矩形選択の範囲がドラッグに合わせて拡張される
+  - 矩形選択の範囲が視覚的に表示される
+  - 矩形選択範囲にテキストをペーストできる
+  - 矩形選択範囲のテキストをコピーできる
+  - 矩形選択範囲のテキストを削除できる
+  - 複数アイテムにまたがる矩形選択を作成できる
+  tests:
+  - client/e2e/core/slr-box-selection-rectangle-selection-function-mouse-ca340ca3.spec.ts
+  title-ja: ボックス選択（矩形選択）機能 - マウス
+- id: SRE-001
+  title: Advanced Search & Replace
+  description: 正規表現や範囲指定に対応した検索・置換機能
+  category: search
+  status: implemented
+  components:
+  - client/src/components/SearchPanel.svelte
+  - client/src/lib/search/index.ts
+  - client/src/routes/[project]/[page]/+page.svelte
+  tests:
+  - client/e2e/new/SRE-001.spec.ts
+  title-ja: 高度な検索と交換
+- id: TBL-0001
+  title: Editable JOIN Table
+  description: SQL query results editable via Fluid Framework and SQLite cache
+  category: table
+  status: implemented
+  components:
+  - src/components/ChartPanel.svelte
+  - src/components/EditableQueryGrid.svelte
+  - src/components/QueryEditor.svelte
+  services:
+  - src/services/sqlService.ts
+  - src/services/editMapper.ts
+  - src/services/syncWorker.ts
+  tests:
+  - client/e2e/new/TBL-0001.spec.ts
+  - src/tests/editMapper.test.ts
+  - src/tests/sqlService.test.ts
+  - src/tests/syncWorker.test.ts
+  acceptance:
+  - JOINクエリで編集した値が正しいテーブルに反映される
+  - PKエイリアスを利用してJOIN結果の各行が編集対象テーブルに正しくマッピングされる
+  - SQLクエリ結果をグリッド表示する
+  - クエリ実行後、ChartPanelが表示される
+  - セル編集後、ChartPanelに変更が表示される
+  - セル編集後、queryStoreのデータが更新される
+  - セル編集後に再実行したクエリ結果も更新される
+  - 編集内容がFluid経由で同期される
+  - 編集後チャートが自動更新される
+  title-ja: 編集可能な結合テーブル
+- id: TST-0001
+  title: SharedTree Data Verification Utility
+  description: テストにおいてSharedTreeの内容をJSONとして取得し、結果を厳密かつ簡易に判定するユーティリティ
+  category: testing
+  status: implemented
+  acceptance:
+  - SharedTreeのデータ構造をJSON形式で取得できる
+  - スナップショットを取得して後で比較できる
+  - ネストされた構造（親子関係）を正確に検証できる
+  - 期待値と実際の値を厳密に比較できる
+  - 期待値と実際の値を部分的に比較できる
+  - 特定のパスのデータを検証できる
+  - 特定のパスを無視して比較できる
+  tests:
+  - client/e2e/utils/tree-validation.spec.ts
+  examples:
+  - client/e2e/utils/tree-validator-examples.ts
+  - client/e2e/utils/tree-validator-usage.md
+  title-ja: SharedTreeデータ検証ユーティリティ
+- id: TST-0002
+  title: Cursor Information Verification Utility
+  description: テストにおいてカーソル情報をJSONとして取得し、結果を厳密かつ簡易に判定するユーティリティ
+  category: testing
+  status: implemented
+  acceptance:
+  - アクティブなアイテムIDを検証できる
+  - カーソルの数を検証できる
+  - カーソル情報をJSON形式で取得できる
+  - スナップショットを取得して後で比較できる
+  - 期待値と実際の値を厳密に比較できる
+  - 期待値と実際の値を部分的に比較できる
+  - 特定のパスのデータを検証できる
+  tests:
+  - client/e2e/utils/cursor-validation.spec.ts
+  examples:
+  - client/e2e/utils/cursor-validator-examples.ts
+  - client/e2e/utils/cursor-validator-usage.md
+  title-ja: カーソル情報検証ユーティリティ
+- id: TST-0003
+  title: Test Helper Utility
+  description: テストにおいてカーソル状態の検証を容易にするヘルパー関数群
+  category: testing
+  status: implemented
+  acceptance:
+  - DOM要素の可視性を強制的に確認できる（forceCheckVisibility）
+  - class:editingセレクタの代わりにカーソル状態を検証できる
+  - アイテムをクリックして編集モードに入れる（clickItemToEdit）
+  - アクティブなアイテムIDを取得できる（getActiveItemId）
+  - アクティブなアイテム要素を取得できる（getActiveItemLocator）
+  - カーソルが表示されるまで待機できる（waitForCursorVisible）
+  - カーソルデバッグ機能をセットアップできる（setupCursorDebugger）
+  - バックリンクパネルを開くことができる（openBacklinkPanel）
+  - マウスアウトイベントを強制的にシミュレートできる（forceMouseOutEvent）
+  - マウスオーバーイベントを強制的にシミュレートできる（forceHoverEvent）
+  - リンクプレビューを強制的に表示できる（forceLinkPreview）
+  tests:
+  - client/e2e/auth/auth.spec.ts
+  - client/e2e/core/CLM-0001.spec.ts
+  - client/e2e/core/CLM-0002.spec.ts
+  - client/e2e/core/CLM-0003.spec.ts
+  - client/e2e/core/CLM-0004.spec.ts
+  - client/e2e/core/CLM-0005.spec.ts
+  - client/e2e/core/CLM-0007.spec.ts
+  - client/e2e/core/CLM-0008.spec.ts
+  - client/e2e/core/CLM-0100.spec.ts
+  - client/e2e/core/CLM-0101.spec.ts
+  - client/e2e/core/CLM-0103.spec.ts
+  - client/e2e/core/FMT-0006.spec.ts
+  - client/e2e/core/IME-0001.spec.ts
+  - client/e2e/core/ITM-0001-title.spec.ts
+  - client/e2e/core/ITM-0001.spec.ts
+  - client/e2e/core/SLR-0003.spec.ts
+  - client/e2e/core/SLR-0004.spec.ts
+  - client/e2e/core/SLR-0005.spec.ts
+  - client/e2e/core/SLR-0010.spec.ts
+  - client/e2e/core/tinylicious.spec.ts
+  - client/e2e/core/tst-test-helper-utility-2020b233.spec.ts
+  examples:
+  - client/e2e/utils/testHelpers.ts
+  title-ja: テストヘルパーユーティリティ
+- id: TST-0004
+  title: Improve your test environment
+  description: テスト環境の安定性と信頼性を向上させるための改善
+  category: testing
+  status: implemented
+  acceptance:
+  - DOM要素の検出と操作のためのヘルパー関数を提供する
+  - テスト実行時のタイムアウト設定を延長し、テストの安定性を向上させる
+  - テスト環境の制約を考慮したテスト条件の調整を行う
+  - マウスイベントが正確に動作しない場合に代替手段を提供する
+  - 要素の検出待機のタイムアウト設定を延長し、テストの安定性を向上させる
+  tests:
+  - client/e2e/core/LNK-0007.spec.ts
+  - client/e2e/core/tst-improve-your-test-environment-72a51b65.spec.ts
+  notes:
+  - テスト環境ではマウスイベントやDOM要素の検出が不安定な場合があるため、専用のヘルパー関数を使用してテストを安定化
+  - headlessモードでの実行時に一部の機能が正常に動作しない場合があるため、代替手段を提供
+  title-ja: テスト環境の改善
+- id: TST-0005
+  title: Initializing and preparing the test environment
+  description: テスト実行前の環境準備を改善し、テストの安定性と再現性を向上させる
+  category: testing
+  status: implemented
+  acceptance:
+  - DOM要素の検出問題を解決するための改善されたヘルパー関数を提供する
+  - UI操作ではなくFluid APIを使用して直接データを作成することで安定性を向上させる
+  - テスト実行前にプロジェクトとページを自動的に作成する仕組みを提供する
+  - テスト環境の初期化を一貫した方法で行うヘルパー関数を提供する
+  - テスト間の依存関係を減らし、各テストが独立して実行できるようにする
+  tests:
+  - client/e2e/helpers.ts
+  - client/e2e/utils/linkTestHelpers.ts
+  - client/e2e/utils/testHelpers.ts
+  notes:
+  - テスト環境では要素の検出が不安定な場合があるため、再試行機能を持つヘルパー関数を使用してテストを安定化
+  - テストデータの作成にはUI操作ではなくFluid APIを使用し、テストの安定性を向上
+  - テスト前の環境準備を標準化することで、テスト間の依存関係を減少
+  title-ja: テスト環境の初期化と準備
+- id: USR-0001
+  title: User deletion function
+  description: ユーザーアカウントとそれに関連するデータを削除する機能
+  category: user-management
+  status: implemented
+  acceptance:
+  - Firebase Authからユーザーアカウントが削除される
+  - ユーザーがアクセス可能だったコンテナからユーザーIDが削除される
+  - ユーザーが最後のアクセス者だったコンテナは完全に削除される
+  - ユーザーに関連するコンテナ情報が削除される
+  - ユーザーアカウントを削除できる
+  tests:
+  - client/e2e/core/usr-user-deletion-function-baaa8b62.spec.ts
+  title-ja: ユーザー削除機能
+- id: USR-0002
+  title: Container removal function
+  description: コンテナとそれに関連するデータを削除する機能
+  category: container-management
+  status: implemented
+  acceptance:
+  - コンテナがデフォルトコンテナだった場合、ユーザーのデフォルトコンテナが更新される
+  - コンテナが存在しない場合は適切なエラーメッセージが表示される
+  - コンテナにアクセス可能だったユーザーのアクセス権からコンテナIDが削除される
+  - コンテナへのアクセス権がない場合は適切なエラーメッセージが表示される
+  - コンテナを削除できる
+  tests:
+  - client/e2e/core/usr-container-removal-function-0661ecad.spec.ts
+  title-ja: コンテナ削除機能

--- a/docs/client-features/clm-extended-navigation-commands-427d145e.yaml
+++ b/docs/client-features/clm-extended-navigation-commands-427d145e.yaml
@@ -1,0 +1,8 @@
+id: CLM-0104
+title: Extended navigation commands
+title-ja: 拡張ナビゲーションコマンド
+description: Ctrl+Left/Right word jumps, bracket jump with Ctrl+Shift+\, document navigation with Ctrl+Home/End, PageUp/PageDown and scroll commands.
+category: cursor-movement
+status: implemented
+tests:
+- client/e2e/core/clm-extended-navigation-commands-427d145e.spec.ts

--- a/docs/client-features/fmt-vscode-clipboard-behavior-3807f353.yaml
+++ b/docs/client-features/fmt-vscode-clipboard-behavior-3807f353.yaml
@@ -2,12 +2,13 @@ id: FMT-0005
 title: VS Code style clipboard behavior
 category: text-formatting
 status: implemented
-description: |
-  Copying and pasting using multi-cursors or box selection should behave the same as Visual Studio Code. Metadata in the clipboard is interpreted so each cursor receives the expected text.
+description: 'Copying and pasting using multi-cursors or box selection should behave the same as Visual Studio Code. Metadata in the clipboard is interpreted so each cursor receives the expected text.
+
+  '
 acceptance:
-  - Pasting with application/vscode-editor metadata distributes text across multiple cursors
-  - Box selection paste inserts each line of text into the corresponding selection range
-  - Clipboard operations work when triggered via keyboard shortcuts
+- Box selection paste inserts each line of text into the corresponding selection range
+- Clipboard operations work when triggered via keyboard shortcuts
+- Pasting with application/vscode-editor metadata distributes text across multiple cursors
 tests:
-  - client/e2e/core/fmt-vscode-clipboard-behavior-3807f353.spec.ts
+- client/e2e/core/fmt-vscode-clipboard-behavior-3807f353.spec.ts
 title-ja: VS Code風クリップボード操作

--- a/docs/dev-features.yaml
+++ b/docs/dev-features.yaml
@@ -45,17 +45,6 @@
   status: implemented
   components: []
   tests:
-    - scripts/tests/ENV-0005.spec.ts
-- id: ENV-0006
-  title: Consolidate Firebase emulator host variables
-  description: Use VITE_FIREBASE_EMULATOR_HOST for all emulator services and remove redundant host settings.
-  category: environment
-  status: implemented
-  components: []
-  tests: []
-  acceptance:
-    - Environment files define VITE_FIREBASE_EMULATOR_HOST
-    - Client and scripts reference the unified variable
   - scripts/tests/ENV-0005.spec.ts
   title-ja: dotenvx handles env variables without cross-env
 - id: TST-0006

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -18,6 +18,7 @@
 | CLM-0101 | Cursor duplication and input distribution problems when moving between items | client/e2e/core/clm-cursor-duplication-and-input-distribution-problems-when-moving-between-items-be4c0ba6.spec.ts | implemented |
 | CLM-0102 | Move cursors and multiple keyboard operations on empty text items | client/e2e/core/clm-move-cursors-and-multiple-keyboard-operations-on-empty-text-items-20043fb0.spec.ts | implemented |
 | CLM-0103 | Cursor manipulation with format strings | client/e2e/core/clm-cursor-manipulation-with-format-strings-86f0d787.spec.ts | implemented |
+| CLM-0104 | Extended navigation commands | — | implemented |
 | COL-0001 | Displaying cursors for other users | — | implemented |
 | DBW-001 | Client-Side SQL Database | — | implemented |
 | FLD-0001 | Ability to retrieve FluidClient from project title | client/e2e/core/fld-ability-to-retrieve-fluidclient-from-project-title-f3bf0fec.spec.ts | implemented |
@@ -25,6 +26,7 @@
 | FMT-0002 | Format combination | client/e2e/core/fmt-format-combination-bcb56231.spec.ts | implemented |
 | FMT-0003 | Extended format | client/e2e/core/fmt-extended-format-b471a4b9.spec.ts | implemented |
 | FMT-0004 | Paste and format from the clipboard | client/e2e/core/fmt-paste-and-format-from-the-clipboard-fe4971c2.spec.ts | implemented |
+| FMT-0005 | VS Code style clipboard behavior | client/e2e/core/fmt-vscode-clipboard-behavior-3807f353.spec.ts | implemented |
 | FMT-0006 | Consistency of format display when moving cursors | client/e2e/core/fmt-consistency-of-format-display-when-moving-cursors-36199743.spec.ts | implemented |
 | FMT-0007 | Displaying internal link function | client/e2e/core/fmt-displaying-internal-link-function-a8a7c97e.spec.ts | implemented |
 | FMT-0008 | Support multiple internal links in one item | client/e2e/core/fmt-multiple-internal-links-3a606671.spec.ts | implemented |
@@ -63,5 +65,6 @@
 | TST-0002 | Cursor Information Verification Utility | client/e2e/utils/cursor-validation.spec.ts | implemented |
 | TST-0003 | Test Helper Utility | — | implemented |
 | TST-0004 | Improve your test environment | — | implemented |
+| TST-0005 | Initializing and preparing the test environment | client/e2e/basic.spec.ts<br>client/e2e/basic/homepage-auth.spec.ts<br>client/e2e/basic/google-access.spec.ts<br>client/e2e/basic/add-text-functionality.spec.ts<br>client/e2e/auth/auth.spec.ts<br>client/e2e/core/port.spec.ts | implemented |
 | USR-0001 | User deletion function | client/e2e/core/usr-user-deletion-function-baaa8b62.spec.ts | implemented |
 | USR-0002 | Container removal function | client/e2e/core/usr-container-removal-function-0661ecad.spec.ts | implemented |

--- a/scripts/tests/feature-map-removal.spec.ts
+++ b/scripts/tests/feature-map-removal.spec.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from "url";
 describe("TST-0006: feature-map削除スクリプト", () => {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
-    const repoRoot = path.resolve(__dirname, "../../.." );
+    const repoRoot = path.resolve(__dirname, "..", ".." );
     const docsPath = path.join(repoRoot, "docs", "feature-map.md");
     const scriptPath = path.join(repoRoot, "scripts", "remove_feature_map.sh");
 


### PR DESCRIPTION
## Summary
- add missing word-jump step in extended navigation E2E
- start typing in a new empty item for deterministic offsets
- fix repo root path in feature-map removal test

## Testing
- `npm run test:unit`
- `npm run test:e2e -- ./e2e/core/clm-extended-navigation-commands-427d145e.spec.ts`
- `npm test` in scripts/tests *(fails: ENV-0003, ENV-0004, ENV-0005)*

------
https://chatgpt.com/codex/tasks/task_e_685c8927d460832fb8f85655900ac7f7