### PR TITLE
Add scripts to run server and environment tests

### DIFF
--- a/scripts/run-env-tests.sh
+++ b/scripts/run-env-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Install dependencies without starting servers
+SKIP_SERVER_START=1 SKIP_PORT_WAIT=1 bash "$ROOT_DIR/scripts/codex-setup.sh"
+
+cd "$ROOT_DIR/scripts/tests"
+
+npx vitest run *.spec.ts

--- a/scripts/run-server-tests.sh
+++ b/scripts/run-server-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Install dependencies without starting servers
+SKIP_SERVER_START=1 SKIP_PORT_WAIT=1 bash "$ROOT_DIR/scripts/codex-setup.sh"
+
+cd "$ROOT_DIR/server"
+
+npx mocha tests/**/*.test.js --timeout 10000

--- a/scripts/tests/package.json
+++ b/scripts/tests/package.json
@@ -4,7 +4,7 @@
   "description": "Development environment tests for Outliner",
   "type": "module",
   "scripts": {
-    "test": "vitest run *.spec.ts",
+    "test": "bash ../../scripts/run-env-tests.sh",
     "test:watch": "vitest *.spec.ts"
   },
   "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
         "start": "node log-service.js",
         "dev": "nodemon log-service.js",
         "create-test-user": "node utils/create-test-user.js",
-        "test": "mocha tests/**/*.test.js --timeout 10000",
+        "test": "bash ../scripts/run-server-tests.sh",
         "test:emulator-wait": "mocha tests/log-service-emulator-wait.test.js --timeout 10000"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary
- make `npm test` runnable in server and scripts/tests by calling helper scripts
- helper scripts run `codex-setup` (skipping server start) then execute mocha or vitest

## Testing
- `npm test` in `server`
- `npm test` in `scripts/tests`


------
https://chatgpt.com/codex/tasks/task_e_685d449f39e4832f94d6ed3be7a1f49c