### PR TITLE
Fix alias tests

### DIFF
--- a/client/e2e/new/als-alias-node-58ad30d4.spec.ts
+++ b/client/e2e/new/als-alias-node-58ad30d4.spec.ts
@@ -2,7 +2,10 @@
  *  Title   : Alias node referencing existing items
  *  Source  : docs/client-features.yaml
  */
-import { expect, test } from "@playwright/test";
+import {
+    expect,
+    test,
+} from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
 test.describe("ALS-0001: Alias node", () => {
@@ -29,14 +32,20 @@ test.describe("ALS-0001: Alias node", () => {
 
         await expect(page.locator(".alias-picker")).toBeVisible();
         const firstText = await page.locator(`.outliner-item[data-item-id="${firstId}"] .item-text`).innerText();
-        const newIndex = await page.locator('.outliner-item').count() - 1;
+        const newIndex = await page.locator(".outliner-item").count() - 1;
         const aliasId = await TestHelpers.getItemIdByIndex(page, newIndex);
-        if (!aliasId) throw new Error('alias item not found');
-        await TestHelpers.setAliasTarget(page, aliasId, firstId);
-        await TestHelpers.hideAliasPicker(page);
+        if (!aliasId) throw new Error("alias item not found");
+        const optionCount = await page.locator(".alias-picker li").count();
+        expect(optionCount).toBeGreaterThan(0);
+        await TestHelpers.selectAliasOption(page, firstId);
+        await expect(page.locator(".alias-picker")).toBeHidden();
 
-        const aliasPath = page.locator('.alias-path');
+        const targetSet = await TestHelpers.getAliasTarget(page, aliasId);
+        expect(targetSet).toBe(firstId);
+
+        const aliasPath = page.locator(".alias-path");
         await expect(aliasPath).toContainText(firstText);
+        await expect(aliasPath.locator("a")).toHaveCount(1);
         const targetInput = `.alias-subtree .outliner-item[data-item-id="${firstId}"] .item-content`;
         await page.click(targetInput);
         await TestHelpers.setCursor(page, firstId, 0);
@@ -44,5 +53,8 @@ test.describe("ALS-0001: Alias node", () => {
 
         const textAfter = await page.locator(`.outliner-item[data-item-id="${firstId}"] .item-text`).innerText();
         expect(textAfter.startsWith("X")).toBeTruthy();
+
+        const aliasPathTextAfter = await aliasPath.innerText();
+        expect(aliasPathTextAfter.startsWith("X")).toBeTruthy();
     });
 });

--- a/client/e2e/new/als-alias-target-change-f508c5a9.spec.ts
+++ b/client/e2e/new/als-alias-target-change-f508c5a9.spec.ts
@@ -1,0 +1,60 @@
+import {
+    expect,
+    test,
+} from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("ALS-0001: Alias change target", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("change alias target and update path", async ({ page }) => {
+        await TestHelpers.waitForOutlinerItems(page);
+        const firstId = await TestHelpers.getItemIdByIndex(page, 0);
+        const secondId = await TestHelpers.getItemIdByIndex(page, 1);
+        if (!firstId || !secondId) throw new Error("item ids not found");
+
+        // create alias of first item
+        await page.click(`.outliner-item[data-item-id="${firstId}"] .item-content`);
+        await page.waitForTimeout(1000);
+        await page.evaluate(() => {
+            const textarea = document.querySelector(".global-textarea") as HTMLTextAreaElement;
+            textarea?.focus();
+        });
+        await page.waitForTimeout(500);
+        await page.keyboard.type("/");
+        await page.keyboard.type("alias");
+        await page.keyboard.press("Enter");
+        await expect(page.locator(".alias-picker")).toBeVisible();
+        const newIndex = await page.locator(".outliner-item").count() - 1;
+        const aliasId = await TestHelpers.getItemIdByIndex(page, newIndex);
+        if (!aliasId) throw new Error("alias item not found");
+        const optionCount = await page.locator(".alias-picker li").count();
+        expect(optionCount).toBeGreaterThan(0);
+        await TestHelpers.selectAliasOption(page, firstId);
+        await expect(page.locator(".alias-picker")).toBeHidden();
+        let targetSet = await TestHelpers.getAliasTarget(page, aliasId);
+        expect(targetSet).toBe(firstId);
+
+        // show picker again and change target
+        await TestHelpers.showAliasPicker(page, aliasId);
+        await expect(page.locator(".alias-picker")).toBeVisible();
+        const optionCount2 = await page.locator(".alias-picker li").count();
+        expect(optionCount2).toBeGreaterThan(0);
+        await TestHelpers.selectAliasOption(page, secondId);
+        await expect(page.locator(".alias-picker")).toBeHidden();
+        targetSet = await TestHelpers.getAliasTarget(page, aliasId);
+        expect(targetSet).toBe(secondId);
+
+        const secondText = await page.locator(`.outliner-item[data-item-id="${secondId}"] .item-text`).innerText();
+        await expect(page.locator(".alias-path")).toContainText(secondText);
+
+        // edit target text and ensure path updates
+        await page.click(`.outliner-item[data-item-id="${secondId}"] .item-content`);
+        await TestHelpers.setCursor(page, secondId, 0);
+        await TestHelpers.insertText(page, secondId, "Z");
+        const aliasPathText = await page.locator(".alias-path").innerText();
+        expect(aliasPathText.startsWith("Z")).toBeTruthy();
+    });
+});

--- a/client/src/components/OutlinerItem.svelte
+++ b/client/src/components/OutlinerItem.svelte
@@ -69,9 +69,18 @@ $effect(() => {
 let aliasTarget = $state<Item | undefined>(undefined);
 let aliasPath = $state<Item[]>([]);
 
+const aliasTargetSub = new TreeSubscriber<Item, Item | undefined>(
+    generalStore.currentPage,
+    "nodeChanged",
+    () => {
+        if (!aliasTargetId) return undefined;
+        return findItem(generalStore.currentPage, aliasTargetId);
+    },
+);
+
 $effect(() => {
     if (aliasTargetId && generalStore.currentPage) {
-        aliasTarget = findItem(generalStore.currentPage, aliasTargetId);
+        aliasTarget = aliasTargetSub.current;
         const p = findPath(generalStore.currentPage, aliasTargetId);
         aliasPath = p || [];
     } else {

--- a/docs/client-features/als-alias-node-58ad30d4.yaml
+++ b/docs/client-features/als-alias-node-58ad30d4.yaml
@@ -17,3 +17,4 @@ components:
 tests:
 - client/e2e/new/als-alias-node-58ad30d4.spec.ts
 - client/e2e/new/als-alias-path-navigation.spec.ts
+- client/e2e/new/als-alias-target-change-f508c5a9.spec.ts


### PR DESCRIPTION
## Summary
- update alias target reaction via TreeSubscriber
- add showAliasPicker helper and verify alias options
- extend alias tests to confirm alias path updates
- add new test for changing alias target

## Testing
- `npm run test:e2e -- e2e/new/als-alias-node-58ad30d4.spec.ts` *(fails: element click)*
- `npm run test:e2e -- e2e/new/als-alias-path-navigation.spec.ts` *(fails: element click)*
- `npm run test:e2e -- e2e/new/als-alias-target-change-f508c5a9.spec.ts` *(fails: element click)*


------
https://chatgpt.com/codex/tasks/task_e_685e985297a0832fa0f78e123b7501de