### PR TITLE
Fix import.meta.env loading (#255)

### DIFF
--- a/client/src/auth/UserManager.ts
+++ b/client/src/auth/UserManager.ts
@@ -49,16 +49,16 @@ type AuthEventListener = (result: IAuthResult | null) => void;
 export class UserManager {
     // Firebase 設定
     private firebaseConfig = {
-        apiKey: import.meta.env.VITE_FIREBASE_API_KEY || "AIzaSyCikgn1YY06j6ZlAJPYab1FIOKSQAuzcH4",
-        authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || "outliner-d57b0.firebaseapp.com",
-        projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || "outliner-d57b0",
-        storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || "outliner-d57b0.firebasestorage.app",
-        messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || "560407608873",
-        appId: import.meta.env.VITE_FIREBASE_APP_ID || "1:560407608873:web:147817f4a93a4678606638",
-        measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID || "G-FKSFRCT7GR",
+        apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+        authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+        projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+        storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+        messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+        appId: import.meta.env.VITE_FIREBASE_APP_ID,
+        measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID,
     };
 
-    private apiBaseUrl = getEnv("VITE_FIREBASE_FUNCTIONS_URL", "http://localhost:57000");
+    private apiBaseUrl = getEnv("VITE_FIREBASE_FUNCTIONS_URL");
     private app = this.initializeFirebaseApp();
     auth = getAuth(this.app);
 

--- a/client/src/lib/fluidService.svelte.ts
+++ b/client/src/lib/fluidService.svelte.ts
@@ -69,8 +69,8 @@ const clientRegistry = new CustomKeyMap<FluidClientKey, FluidInstances>();
 
 // Azure Fluid Relayエンドポイント設定
 const azureConfig = {
-    tenantId: import.meta.env.VITE_AZURE_TENANT_ID || "00000000-0000-0000-0000-000000000000",
-    endpoint: import.meta.env.VITE_AZURE_FLUID_RELAY_ENDPOINT || "https://us.fluidrelay.azure.com",
+    tenantId: import.meta.env.VITE_AZURE_TENANT_ID,
+    endpoint: import.meta.env.VITE_AZURE_FLUID_RELAY_ENDPOINT,
 };
 
 // 開発環境ではTinyliciousを使用する - 環境変数で強制的に切り替え可能
@@ -414,7 +414,7 @@ export async function getUserContainers(): Promise<{ containers: string[]; defau
         }
 
         // Firebase Functionsのエンドポイントを取得
-        const apiBaseUrl = import.meta.env.VITE_FIREBASE_FUNCTIONS_URL || "http://localhost:57000";
+        const apiBaseUrl = import.meta.env.VITE_FIREBASE_FUNCTIONS_URL;
         log("fluidService", "info", `Getting user containers from Firebase Functions at ${apiBaseUrl}`);
 
         // Firebase Functionsを呼び出してコンテナリストを取得
@@ -467,7 +467,7 @@ export async function deleteContainer(containerId: string): Promise<boolean> {
         }
 
         // Firebase Functionsのエンドポイントを取得
-        const apiBaseUrl = import.meta.env.VITE_FIREBASE_FUNCTIONS_URL || "http://localhost:57000";
+        const apiBaseUrl = import.meta.env.VITE_FIREBASE_FUNCTIONS_URL;
         log("fluidService", "info", `Deleting container ${containerId} via Firebase Functions at ${apiBaseUrl}`);
 
         // Firebase Functionsを呼び出してコンテナを削除

--- a/docs/dev-features/env-dotenvx-functions-root-9a2b7c8d.yaml
+++ b/docs/dev-features/env-dotenvx-functions-root-9a2b7c8d.yaml
@@ -1,0 +1,11 @@
+id: ENV-0008
+title: Functions load env via dotenvx
+category: environment
+status: implemented
+description: Ensure Firebase functions load environment variables with dotenvx and test env file is generated.
+components:
+- functions/index.js
+- scripts/setup-local-env.sh
+tests:
+- scripts/tests/ENV-0008.spec.ts
+title-ja: dotenvxでFunctionsの環境変数を読み込む

--- a/functions/.env.test
+++ b/functions/.env.test
@@ -1,0 +1,5 @@
+AZURE_TENANT_ID=test-tenant-id
+AZURE_ENDPOINT=https://test.fluidrelay.azure.com
+AZURE_PRIMARY_KEY=test-primary-key
+AZURE_SECONDARY_KEY=test-secondary-key
+AZURE_ACTIVE_KEY=primary

--- a/functions/index.js
+++ b/functions/index.js
@@ -26,8 +26,8 @@ function setCorsHeaders(req, res) {
 // ロガーの設定
 const logger = require("firebase-functions/logger");
 
-// 環境変数を読み込み
-require("dotenv").config();
+// dotenvxを使用して環境変数を読み込み
+require("@dotenvx/dotenvx/config");
 
 // 環境変数を直接使用（ローカル開発用）
 const azureConfig = {

--- a/scripts/setup-local-env.sh
+++ b/scripts/setup-local-env.sh
@@ -37,5 +37,15 @@ fi
 # Server and functions env files
 copy_if_missing "$ROOT_DIR/server/.env.test" "$ROOT_DIR/server/.env"
 copy_if_missing "$ROOT_DIR/functions/.env.test" "$ROOT_DIR/functions/.env"
+if [ ! -f "$ROOT_DIR/functions/.env.test" ]; then
+    cat >> "$ROOT_DIR/functions/.env.test" <<'EOV'
+AZURE_TENANT_ID=test-tenant-id
+AZURE_ENDPOINT=https://test.fluidrelay.azure.com
+AZURE_PRIMARY_KEY=test-primary-key
+AZURE_SECONDARY_KEY=test-secondary-key
+AZURE_ACTIVE_KEY=primary
+EOV
+    echo "Created functions/.env.test"
+fi
 
 echo "Environment files are ready"

--- a/scripts/tests/ENV-0008.spec.ts
+++ b/scripts/tests/ENV-0008.spec.ts
@@ -1,0 +1,18 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test } from 'vitest';
+
+/** @feature ENV-0008
+ *  Title   : Functions load env via dotenvx
+ */
+
+test('functions env variables load with dotenvx', () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const repoRoot = path.resolve(__dirname, '..', '..');
+
+  const command = "node -e \"require('./functions/index.js'); console.log(process.env.AZURE_TENANT_ID)\"";
+  const output = execSync(command, { cwd: repoRoot }).toString().trim();
+  expect(output).toBe('test-tenant-id');
+});


### PR DESCRIPTION
## Summary
- use @dotenvx/dotenvx/config in functions
- remove hard-coded firebase defaults from UserManager
- remove Azure defaults from fluidService
- generate functions/.env.test via setup script
- document ENV-0008 and add tests

## Testing
- `npm run test:unit` *(fails: auth network errors)*
- `npm test` in scripts/tests *(fails: could not fetch package)*
- `npm run test:e2e -- e2e/core/ftr-use-environment-variables-in-min-page-cfe01fbf.spec.ts` *(failed to install deps)*


------
https://chatgpt.com/codex/tasks/task_e_685fc3bc8a80832f83a00c1b70255756