### PR TITLE
Document schedule management API #282

### DIFF
--- a/docs/client-features/sch-schedule-api-documentation-43bb575f.yaml
+++ b/docs/client-features/sch-schedule-api-documentation-43bb575f.yaml
@@ -1,0 +1,15 @@
+id: SCH-43BB575F
+title: Schedule Management API Documentation
+description: README describes schedule management endpoints and example usage.
+category: publishing
+status: implemented
+acceptance:
+- README lists /api/create-schedule, /api/update-schedule, /api/list-schedules and /api/cancel-schedule
+- README shows sample curl requests for creating and cancelling schedules
+components:
+- functions/README.md
+- functions/index.js
+tests:
+- functions/test/schedule-management.test.js
+- functions/test/scheduled-publishing.test.js
+title-ja: スケジュール管理APIのドキュメント

--- a/functions/README.md
+++ b/functions/README.md
@@ -9,7 +9,22 @@
 2. `/api/save-container` - ユーザーのコンテナIDを保存するエンドポイント
 3. `/api/get-user-containers` - ユーザーがアクセス可能なコンテナIDのリストを取得するエンドポイント
 4. `/health` - ヘルスチェックエンドポイント
+5. `/api/create-schedule` - 指定したページに公開スケジュールを登録するエンドポイント
+6. `/api/update-schedule` - 既存のスケジュールを更新するエンドポイント
+7. `/api/list-schedules` - ユーザーが作成したスケジュール一覧を取得するエンドポイント
+8. `/api/cancel-schedule` - スケジュールをキャンセルするエンドポイント
 
+### サンプル
+
+```bash
+curl -X POST http://localhost:57000/api/create-schedule \
+  -H 'Content-Type: application/json' \
+  -d '{"idToken":"<ID_TOKEN>","pageId":"<PAGE_ID>","schedule":{"strategy":"one_shot","nextRunAt":<TIMESTAMP>}}'
+
+curl -X POST http://localhost:57000/api/cancel-schedule \
+  -H 'Content-Type: application/json' \
+  -d '{"idToken":"<ID_TOKEN>","pageId":"<PAGE_ID>","scheduleId":"<SCHEDULE_ID>"}'
+```
 ## セットアップ
 
 1. 依存関係をインストール:


### PR DESCRIPTION
## Summary
- document schedule API endpoints in `functions/README.md`
- add feature file `sch-schedule-api-documentation-43bb575f.yaml`

## Testing
- `scripts/run-env-tests.sh` *(fails: patch-package not found)*
- `scripts/run-e2e-progress-for-codex.sh 1` *(fails: Firebase emulator timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68613da877dc832f9fcc96d3aa0f4073