### PR TITLE
Mark HDV-0001 diff viewer as implemented #290

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ dotenvx run -- npm run test:env
 
 ### Playwrightテストを順番に実行する
 
-Codex環境では複数のE2Eテストを一度に実行するとタイムアウトすることがあります。`scripts/run-e2e-progress-for-codex.sh 1` を使うと、テストファイルを1件ずつ実行できます。
+Codex環境では複数のE2Eテストを一度に実行するとタイムアウト (timeout) することがあります。`scripts/run-e2e-progress-for-codex.sh 1` を使うと、テストファイルを1件ずつ実行できます。
 
 ```bash
 scripts/run-e2e-progress-for-codex.sh 1

--- a/docs/client-features/hdv-page-diff-d3e5ac75.yaml
+++ b/docs/client-features/hdv-page-diff-d3e5ac75.yaml
@@ -2,7 +2,7 @@ id: HDV-0001
 title: Page snapshot diff viewer
 title-ja: ページのスナップショット差分ビューア
 category: history
-status: draft
+status: implemented
 description: 'Allow users to view differences between the current page state and previous snapshots.
 
   Users can select two snapshots to see changes and revert to a chosen version.


### PR DESCRIPTION
## Summary
- mark Page snapshot diff viewer as implemented
- mention `timeout` in README to explain sequential Playwright testing

## Testing
- `scripts/run-env-tests.sh`
- `cd client && npm run test:unit` *(fails: auth/network-request-failed)*
- `cd client && npm run test:e2e -- e2e/new/diff-view.spec.ts` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68631820ea6c832fa8618a4e6a5d6a8d