### PR TITLE
Implement dark mode theme (#292)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ dotenvx run -- npm run test:env
 
 Codex環境では複数のE2Eテストを一度に実行するとタイムアウトすることがあります。`scripts/run-e2e-progress-for-codex.sh 1` を使うと、テストファイルを1件ずつ実行できます。
 
+This prevents timeout errors during CI runs.
+
 ```bash
 scripts/run-e2e-progress-for-codex.sh 1
 ```

--- a/client/e2e/core/thm-dark-mode-toggle-5e7cbe61.spec.ts
+++ b/client/e2e/core/thm-dark-mode-toggle-5e7cbe61.spec.ts
@@ -1,0 +1,18 @@
+/** @feature THM-0001
+ *  Title   : Dark mode theme toggle
+ *  Source  : docs/client-features/thm-dark-mode-toggle-5e7cbe61.yaml
+ */
+import { expect, test } from '@playwright/test';
+import { TestHelpers } from '../utils/testHelpers';
+
+test.describe('THM-0001: Dark mode theme toggle', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await TestHelpers.prepareTestEnvironment(page, testInfo);
+  });
+
+  test('toggle dark mode', async ({ page }) => {
+    await expect(page.evaluate(() => document.documentElement.classList.contains('dark'))).resolves.toBe(false);
+    await page.getByRole('button', { name: 'Dark Mode' }).click();
+    await expect(page.evaluate(() => document.documentElement.classList.contains('dark'))).resolves.toBe(true);
+  });
+});

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -2,6 +2,14 @@
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/typography";
 
+html {
+    @apply bg-white text-black;
+}
+
+html.dark {
+    @apply bg-gray-900 text-gray-100;
+}
+
 /* 内部リンクのスタイル */
 .internal-link {
     color: #1a73e8;

--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -13,6 +13,7 @@ import { userManager } from "../auth/UserManager";
 import { setupGlobalDebugFunctions } from "../lib/debug";
 import * as fluidService from "../lib/fluidService.svelte";
 import "../utils/ScrapboxFormatter"; // グローバルに公開するためにインポート
+import { userPreferencesStore } from "../stores/UserPreferencesStore.svelte";
 import {
     cleanupFluidClient,
     initFluidClientWithAuth,
@@ -24,6 +25,16 @@ const logger = getLogger("AppLayout");
 // 認証関連の状態
 let isAuthenticated = $state(false);
 let error: string | undefined = $state(undefined);
+
+let currentTheme = $derived(userPreferencesStore.theme);
+$effect(() => {
+    if (browser) {
+        document.documentElement.classList.toggle(
+            'dark',
+            currentTheme === 'dark',
+        );
+    }
+});
 
 // APIサーバーのURLを取得
 const API_URL = getEnv("VITE_API_SERVER_URL", "http://localhost:7071");
@@ -241,3 +252,10 @@ onDestroy(() => {
 </script>
 
 {@render children()}
+
+<button
+    class="fixed bottom-4 right-4 p-2 rounded bg-gray-200 dark:bg-gray-700"
+    on:click={() => userPreferencesStore.toggleTheme()}
+>
+    {currentTheme === 'light' ? 'Dark Mode' : 'Light Mode'}
+</button>

--- a/client/src/stores/UserPreferencesStore.svelte.ts
+++ b/client/src/stores/UserPreferencesStore.svelte.ts
@@ -1,0 +1,23 @@
+export interface UserPreferences {
+    theme: 'light' | 'dark';
+}
+
+export class UserPreferencesStore {
+    preferences = $state<UserPreferences>({ theme: 'light' });
+
+    theme = $derived(this.preferences.theme);
+
+    setTheme(theme: 'light' | 'dark') {
+        this.preferences = { ...this.preferences, theme };
+    }
+
+    toggleTheme() {
+        this.setTheme(this.preferences.theme === 'light' ? 'dark' : 'light');
+    }
+}
+
+export const userPreferencesStore = new UserPreferencesStore();
+
+if (typeof window !== 'undefined') {
+    (window as any).userPreferencesStore = userPreferencesStore;
+}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: 'class',
     content: ["./src/**/*.{html,js,svelte,ts}"],
     theme: {
         extend: {},

--- a/docs/client-features/thm-dark-mode-toggle-5e7cbe61.yaml
+++ b/docs/client-features/thm-dark-mode-toggle-5e7cbe61.yaml
@@ -1,0 +1,10 @@
+id: THM-0001
+title: Dark mode theme toggle
+title-ja: ダークモードテーマの切り替え
+description: User can switch between light and dark themes.
+category: ui
+status: implemented
+tests:
+- client/e2e/core/thm-dark-mode-toggle-5e7cbe61.spec.ts
+acceptance:
+- アプリ全体でダークテーマとライトテーマを切り替えられる


### PR DESCRIPTION
## Summary
- add user preferences store with dark mode toggle
- apply dark mode class via layout with button
- style base colors for dark mode
- enable Tailwind dark mode
- document feature in client features
- test environment and add Playwright test for dark mode toggle

## Testing
- `scripts/run-env-tests.sh`
- `cd client && npm run test:e2e -- e2e/core/thm-dark-mode-toggle-5e7cbe61.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68631836ff80832f95783e8b86ea41c3