### PR TITLE
Fix feature ids with uuid

### DIFF
--- a/client/e2e/core/clm-cursor-count-stable-after-drag-1cef29b1.spec.ts
+++ b/client/e2e/core/clm-cursor-count-stable-after-drag-1cef29b1.spec.ts
@@ -1,0 +1,52 @@
+/** @feature CLM-1cef29b1
+ *  Title   : ドラッグ後もカーソル数は変化しない
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("CLM-1cef29b1: ドラッグ後もカーソル数は変化しない", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("アイテムをドラッグして移動してもカーソル数が変化しない", async ({ page }) => {
+        await TestHelpers.waitForOutlinerItems(page);
+        const firstId = await TestHelpers.getItemIdByIndex(page, 0);
+        await TestHelpers.setCursor(page, firstId!);
+        await TestHelpers.insertText(page, firstId!, "Item A");
+        await page.keyboard.press("Enter");
+        await TestHelpers.waitForCursorVisible(page);
+        const secondId = await TestHelpers.getItemIdByIndex(page, 1);
+        await TestHelpers.setCursor(page, secondId!);
+        await TestHelpers.insertText(page, secondId!, "Item B");
+        await page.keyboard.press("Enter");
+        await TestHelpers.waitForCursorVisible(page);
+        const thirdId = await TestHelpers.getItemIdByIndex(page, 2);
+        await TestHelpers.setCursor(page, thirdId!);
+        await TestHelpers.insertText(page, thirdId!, "Item C");
+        await page.waitForTimeout(300);
+
+        const cursorCountBefore = await page.evaluate(() => {
+            return (window as any).editorOverlayStore.getCursorInstances().length;
+        });
+
+        const secondLocator = page.locator(`.outliner-item[data-item-id="${secondId}"] .item-content`);
+        const thirdLocator = page.locator(`.outliner-item[data-item-id="${thirdId}"] .item-content`);
+        const secondBox = await secondLocator.boundingBox();
+        const thirdBox = await thirdLocator.boundingBox();
+        if (secondBox && thirdBox) {
+            await page.mouse.move(secondBox.x + secondBox.width / 2, secondBox.y + secondBox.height / 2);
+            await page.mouse.down();
+            await page.mouse.move(thirdBox.x + thirdBox.width / 2, thirdBox.y + thirdBox.height / 2, { steps: 10 });
+            await page.mouse.up();
+        }
+        await page.waitForTimeout(500);
+
+        const cursorCountAfter = await page.evaluate(() => {
+            return (window as any).editorOverlayStore.getCursorInstances().length;
+        });
+
+        expect(cursorCountAfter).toBe(cursorCountBefore);
+    });
+});

--- a/client/e2e/core/itm-drag-items-to-reorder-00cbb408.spec.ts
+++ b/client/e2e/core/itm-drag-items-to-reorder-00cbb408.spec.ts
@@ -1,0 +1,47 @@
+/** @feature ITM-00cbb408
+ *  Title   : ドラッグでアイテムを移動
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("ITM-00cbb408: ドラッグでアイテムを移動", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("ドラッグでアイテムを移動できる", async ({ page }) => {
+        await TestHelpers.waitForOutlinerItems(page);
+        const firstId = await TestHelpers.getItemIdByIndex(page, 0);
+        await TestHelpers.setCursor(page, firstId!);
+        await TestHelpers.insertText(page, firstId!, "Item 1");
+        await page.keyboard.press("Enter");
+        await TestHelpers.waitForCursorVisible(page);
+        const secondId = await TestHelpers.getItemIdByIndex(page, 1);
+        await TestHelpers.setCursor(page, secondId!);
+        await TestHelpers.insertText(page, secondId!, "Item 2");
+        await page.keyboard.press("Enter");
+        await TestHelpers.waitForCursorVisible(page);
+        const thirdId = await TestHelpers.getItemIdByIndex(page, 2);
+        await TestHelpers.setCursor(page, thirdId!);
+        await TestHelpers.insertText(page, thirdId!, "Item 3");
+        await page.waitForTimeout(300);
+
+        const secondText = await page.locator(`.outliner-item[data-item-id="${secondId}"] .item-text`).textContent();
+
+        const secondLocator = page.locator(`.outliner-item[data-item-id="${secondId}"] .item-content`);
+        const thirdLocator = page.locator(`.outliner-item[data-item-id="${thirdId}"] .item-content`);
+        const secondBox = await secondLocator.boundingBox();
+        const thirdBox = await thirdLocator.boundingBox();
+        if (secondBox && thirdBox) {
+            await page.mouse.move(secondBox.x + secondBox.width / 2, secondBox.y + secondBox.height / 2);
+            await page.mouse.down();
+            await page.mouse.move(thirdBox.x + thirdBox.width / 2, thirdBox.y + thirdBox.height / 2, { steps: 10 });
+            await page.mouse.up();
+        }
+        await page.waitForTimeout(500);
+
+        const movedText = await page.locator(".outliner-item").nth(2).locator(".item-text").textContent();
+        expect(movedText).toBe(secondText);
+    });
+});

--- a/client/e2e/core/itm-title-child-aligned-x-position-ff843c45.spec.ts
+++ b/client/e2e/core/itm-title-child-aligned-x-position-ff843c45.spec.ts
@@ -1,0 +1,28 @@
+/** @feature ITM-ff843c45
+ *  Title   : タイトルと子アイテムの水平位置を揃える
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("ITM-ff843c45: タイトルと子アイテムの位置", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("タイトルと子アイテムのX座標が同じ", async ({ page }) => {
+        await TestHelpers.waitForOutlinerItems(page);
+        const titleId = await TestHelpers.getItemIdByIndex(page, 0);
+        await TestHelpers.setCursor(page, titleId!);
+        await TestHelpers.insertText(page, titleId!, "Title text");
+        await page.keyboard.press("Enter");
+        await TestHelpers.waitForCursorVisible(page);
+        const childId = await TestHelpers.getItemIdByIndex(page, 1);
+        await TestHelpers.insertText(page, childId!, "Child item");
+        await page.waitForTimeout(300);
+
+        const titleBox = await page.locator(`.outliner-item[data-item-id="${titleId}"]`).boundingBox();
+        const childBox = await page.locator(`.outliner-item[data-item-id="${childId}"]`).boundingBox();
+        expect(Math.abs((titleBox?.x || 0) - (childBox?.x || 0))).toBeLessThan(1);
+    });
+});

--- a/docs/client-features/clm-cursor-count-stable-after-drag-1cef29b1.yaml
+++ b/docs/client-features/clm-cursor-count-stable-after-drag-1cef29b1.yaml
@@ -1,0 +1,10 @@
+id: CLM-1cef29b1
+title: Cursor count stable after drag
+description: ドラッグでアイテムを移動してもカーソルの数は変化しません。
+category: cursor-management
+status: implemented
+acceptance:
+- アイテムをドラッグして移動したあともカーソルの総数が変わらない
+tests:
+- client/e2e/core/clm-cursor-count-stable-after-drag-1cef29b1.spec.ts
+title-ja: ドラッグ後もカーソル数は変化しない

--- a/docs/client-features/itm-drag-items-to-reorder-00cbb408.yaml
+++ b/docs/client-features/itm-drag-items-to-reorder-00cbb408.yaml
@@ -1,0 +1,10 @@
+id: ITM-00cbb408
+title: Drag items to reorder
+description: アイテムをドラッグ＆ドロップで並び替えできます。
+category: item-management
+status: implemented
+acceptance:
+- アイテムをドラッグ＆ドロップで移動できる
+tests:
+- client/e2e/core/itm-drag-items-to-reorder-00cbb408.spec.ts
+title-ja: ドラッグでアイテムを移動

--- a/docs/client-features/itm-title-child-aligned-x-position-ff843c45.yaml
+++ b/docs/client-features/itm-title-child-aligned-x-position-ff843c45.yaml
@@ -1,0 +1,10 @@
+id: ITM-ff843c45
+title: Title and child align horizontally
+description: ページタイトルとその直下の子アイテムの表示位置は同じX座標になります。
+category: item-management
+status: implemented
+acceptance:
+- タイトルとその子アイテムのx座標が同じ
+tests:
+- client/e2e/core/itm-title-child-aligned-x-position-ff843c45.spec.ts
+title-ja: タイトルと子アイテムの水平位置を揃える


### PR DESCRIPTION
## Summary
- use uuid-based feature ids instead of sequential numbers
- update feature comments in Playwright tests

## Testing
- `scripts/run-e2e-progress-for-codex.sh 1` *(fails: cursor count differs)*
- `scripts/run-e2e-progress-for-codex.sh 1` *(fails: item not moved correctly)*
- `scripts/run-e2e-progress-for-codex.sh 1` *(fails: x coordinate mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686317dbe5e4832fb0da9b79c839d493