### PR TITLE
Refine multiline input test

### DIFF
--- a/client/e2e/core/itm-multi-line-input-6dcdbeef.spec.ts
+++ b/client/e2e/core/itm-multi-line-input-6dcdbeef.spec.ts
@@ -1,0 +1,75 @@
+/** @feature ITM-0004
+ *  Title   : 複数行テキスト入力
+ *  Source  : docs/client-features.yaml
+ */
+import {
+    expect,
+    test,
+} from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("ITM-0004: 複数行テキスト入力", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        // start with an empty page so item indices are predictable
+        await TestHelpers.prepareTestEnvironment(page, testInfo, []);
+    });
+
+    test("Enter キーで 3 行のアイテムが追加される", async ({ page }) => {
+        await TestHelpers.waitForOutlinerItems(page);
+
+        const items = page.locator(".outliner-item");
+        const countBefore = await items.count();
+
+        const firstId = await TestHelpers.getItemIdByIndex(page, 0);
+        await page.locator(`.outliner-item[data-item-id="${firstId}"] .item-content`).click({ force: true });
+        await TestHelpers.waitForCursorVisible(page);
+        await page.keyboard.press("End");
+        await page.keyboard.type("Line 1");
+        await page.keyboard.press("Enter");
+        await TestHelpers.waitForCursorVisible(page);
+        await page.keyboard.type("Line 2");
+        await page.keyboard.press("Enter");
+        await TestHelpers.waitForCursorVisible(page);
+        await page.keyboard.type("Line 3");
+        await page.keyboard.press("Enter");
+        await TestHelpers.waitForCursorVisible(page);
+        await page.waitForTimeout(500);
+
+        const countAfter = await items.count();
+        expect(countAfter).toBe(countBefore + 3);
+        const id1 = await TestHelpers.getItemIdByIndex(page, 1);
+        const id2 = await TestHelpers.getItemIdByIndex(page, 2);
+        const id3 = await TestHelpers.getItemIdByIndex(page, 3);
+        await expect(page.locator(`.outliner-item[data-item-id="${id1}"] .item-text`)).toHaveText("Line 1");
+        await expect(page.locator(`.outliner-item[data-item-id="${id2}"] .item-text`)).toHaveText("Line 2");
+        await expect(page.locator(`.outliner-item[data-item-id="${id3}"] .item-text`)).toHaveText("Line 3");
+    });
+
+    test("Backspace 後の入力が正しく反映される", async ({ page }) => {
+        await TestHelpers.waitForOutlinerItems(page);
+
+        const firstId = await TestHelpers.getItemIdByIndex(page, 0);
+        const firstItem = page.locator(`.outliner-item[data-item-id="${firstId}"] .item-content`);
+        await firstItem.click({ force: true });
+        await TestHelpers.waitForCursorVisible(page);
+        await page.keyboard.press("End");
+
+        // create a new empty item
+        await page.keyboard.press("Enter");
+        await TestHelpers.waitForCursorVisible(page);
+
+        const newId = await TestHelpers.getItemIdByIndex(page, 1);
+        const newItem = page.locator(`.outliner-item[data-item-id="${newId}"] .item-content`);
+        await newItem.click({ force: true });
+        await TestHelpers.waitForCursorVisible(page);
+
+        await page.keyboard.type("abc");
+        await page.keyboard.press("Backspace");
+        await page.keyboard.type("d");
+        await page.waitForTimeout(500);
+
+        await expect(
+            page.locator(`.outliner-item[data-item-id="${newId}"] .item-text`),
+        ).toHaveText("abd");
+    });
+});

--- a/docs/client-features/itm-multi-line-input-6dcdbeef.yaml
+++ b/docs/client-features/itm-multi-line-input-6dcdbeef.yaml
@@ -1,0 +1,12 @@
+id: ITM-0004
+title: Multi-line text input
+description: Users can create multiple items by typing text and pressing Enter.
+category: item-management
+status: implemented
+acceptance:
+  - Enterキーを押すたびに新しいアイテムが追加される
+  - 入力したテキストはそのアイテムだけに表示される
+  - Backspaceキーで文字を削除後、再入力したテキストが表示される
+tests:
+  - client/e2e/core/itm-multi-line-input-6dcdbeef.spec.ts
+title-ja: 複数行テキスト入力


### PR DESCRIPTION
## Summary
- adjust ITM-0004 spec setup to create an empty page
- wait for cursor after each Enter to ensure item focus
- verify Backspace behavior on a newly created item

## Testing
- `bash scripts/codex-setup.sh`
- `bash scripts/run-e2e-progress-for-codex.sh 1` *(fails: ITM-0004 spec)*

------
https://chatgpt.com/codex/tasks/task_e_686315c0c944832fbcad091ce3ab18e4