### PR TITLE
Add DBW-001 test and note Slack exclusion

### DIFF
--- a/client/e2e/new/DBW-001.spec.ts
+++ b/client/e2e/new/DBW-001.spec.ts
@@ -1,0 +1,26 @@
+/** @feature DBW-001
+ *  Title   : Client-Side SQL Database
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("DBW-001: Client-Side SQL Database", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("run basic SQL query", async ({ page }) => {
+        await page.goto("/sql");
+        await page.waitForSelector("textarea");
+        const sql = [
+            "CREATE TABLE tbl(id TEXT PRIMARY KEY, val INTEGER);",
+            "INSERT INTO tbl VALUES('1',1);",
+            "SELECT val AS tbl_val FROM tbl;",
+        ].join(" ");
+        await page.fill("textarea", sql);
+        await page.click("text=Run");
+        await expect(page.locator(".editable-query-grid")).toContainText("tbl_val");
+        await expect(page.locator(".editable-query-grid")).toContainText("1");
+    });
+});

--- a/docs/NON_GOALS.md
+++ b/docs/NON_GOALS.md
@@ -6,3 +6,8 @@ This document tracks features that are intentionally left out of the Outliner pr
 
 ### SEC-0002 Two-Factor Authentication (2FA)
 Firebase Authentication is used for sign-in. Two-factor authentication is outside the scope of this project and will not be implemented.
+
+## Notifications
+
+### NOT-0001 External Notification Services
+Outliner does not send notifications through Slack or any other external applications.


### PR DESCRIPTION
## Summary
- clarify that Slack and similar notifications are not used
- add DBW-001 end-to-end test for the client-side SQL database

## Testing
- `scripts/run-env-tests.sh` *(fails: env-schedule-functions-dotenvx-3c0f73e5.spec.ts)*
- `scripts/run-e2e-progress-for-codex.sh 1`

------
https://chatgpt.com/codex/tasks/task_e_68632b21c2a8832f9bf54d28b703f040