### PR TITLE
E2E test for log rotation endpoint (#308)

### DIFF
--- a/client/e2e/core/log-rotate-log-files-endpoint-6f1a5793.spec.ts
+++ b/client/e2e/core/log-rotate-log-files-endpoint-6f1a5793.spec.ts
@@ -1,0 +1,25 @@
+/** @feature LOG-0002
+ *  Title   : Log rotation endpoint
+ *  Source  : docs/client-features/log-rotate-log-files-endpoint-6f1a5793.yaml
+ */
+import { expect, test } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+test.describe('LOG-0002: /api/rotate-logs', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const serverLog = path.resolve(__dirname, '../../..', 'server', 'logs', 'log-service.log');
+
+  test('rotates logs via endpoint', async ({ request }) => {
+    const res = await request.post('http://localhost:7091/api/rotate-logs');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(typeof body.timestamp).toBe('string');
+
+    const backup = serverLog + '.1';
+    const exists = fs.existsSync(backup);
+    expect(exists).toBe(true);
+  });
+});

--- a/docs/client-features/log-rotate-log-files-endpoint-6f1a5793.yaml
+++ b/docs/client-features/log-rotate-log-files-endpoint-6f1a5793.yaml
@@ -1,0 +1,13 @@
+id: LOG-0002
+title: Log rotation endpoint
+title-ja: ログローテーションエンドポイント
+description: POST /api/rotate-logs rotates client, telemetry, and server logs.
+category: api-server
+status: implemented
+components:
+- server/log-service.js
+- server/utils/logger.js
+tests:
+- server/tests/logger-rotate-logfile.test.js
+- server/tests/rotate-logs-endpoint.test.js
+- client/e2e/logs/log-rotate-log-files-endpoint-6f1a5793.spec.ts

--- a/server/tests/log-service-test-helper.js
+++ b/server/tests/log-service-test-helper.js
@@ -249,6 +249,39 @@ app.get("/debug/token-info", async (req, res) => {
     }
 });
 
+// ログファイルをローテーションするエンドポイント
+const {
+    rotateClientLogs,
+    rotateTelemetryLogs,
+    rotateServerLogs,
+    refreshClientLogStream,
+    refreshTelemetryLogStream,
+    refreshServerLogStream,
+} = require("../utils/logger");
+
+app.post("/api/rotate-logs", async (req, res) => {
+    try {
+        const clientRotated = await rotateClientLogs(2);
+        const telemetryRotated = await rotateTelemetryLogs(2);
+        const serverRotated = await rotateServerLogs(2);
+
+        if (clientRotated) refreshClientLogStream();
+        if (telemetryRotated) refreshTelemetryLogStream();
+        if (serverRotated) refreshServerLogStream();
+
+        res.status(200).json({
+            success: true,
+            clientRotated,
+            telemetryRotated,
+            serverRotated,
+            timestamp: new Date().toISOString(),
+        });
+    }
+    catch (error) {
+        res.status(500).json({ success: false, error: error.message });
+    }
+});
+
 // Azure Fluid Relay用トークン生成関数
 function generateAzureFluidToken(user, containerId = undefined) {
     return {

--- a/server/tests/logger-rotate-logfile.test.js
+++ b/server/tests/logger-rotate-logfile.test.js
@@ -1,0 +1,28 @@
+const { describe, it, beforeEach, afterEach } = require('mocha');
+const { expect } = require('chai');
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+const { rotateLogFile } = require('../utils/logger');
+
+describe('rotateLogFile utility (LOG-0002)', function () {
+  let tmpDir;
+  let logFile;
+
+  beforeEach(async function () {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'log-'));
+    logFile = path.join(tmpDir, 'test.log');
+    await fs.outputFile(logFile, 'test');
+  });
+
+  afterEach(async function () {
+    await fs.remove(tmpDir);
+  });
+
+  it('creates a .1 backup file', async function () {
+    const result = await rotateLogFile(logFile, 2);
+    expect(result).to.be.true;
+    const backupExists = await fs.pathExists(logFile + '.1');
+    expect(backupExists).to.be.true;
+  });
+});

--- a/server/tests/rotate-logs-endpoint.test.js
+++ b/server/tests/rotate-logs-endpoint.test.js
@@ -1,0 +1,32 @@
+const request = require('supertest');
+const sinon = require('sinon');
+const { describe, it, beforeEach, afterEach } = require('mocha');
+const { expect } = require('chai');
+let app;
+const loggerUtils = require('../utils/logger');
+
+describe('/api/rotate-logs endpoint (LOG-0002)', function () {
+  let clientStub, telemetryStub, serverStub;
+
+  beforeEach(function () {
+    clientStub = sinon.stub(loggerUtils, 'rotateClientLogs').resolves(true);
+    telemetryStub = sinon.stub(loggerUtils, 'rotateTelemetryLogs').resolves(true);
+    serverStub = sinon.stub(loggerUtils, 'rotateServerLogs').resolves(true);
+    sinon.stub(loggerUtils, 'refreshClientLogStream');
+    sinon.stub(loggerUtils, 'refreshTelemetryLogStream');
+    sinon.stub(loggerUtils, 'refreshServerLogStream');
+    app = require('./log-service-test-helper');
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('returns success when rotation completes', async function () {
+    const res = await request(app).post('/api/rotate-logs').expect(200);
+    expect(res.body.success).to.be.true;
+    expect(clientStub.called).to.be.true;
+    expect(telemetryStub.called).to.be.true;
+    expect(serverStub.called).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- add server-side utilities and endpoint tests for log rotation
- verify log rotation via Playwright
- document log rotation endpoint feature

## Testing
- `scripts/run-env-tests.sh`
- `npx mocha tests/logger-rotate-logfile.test.js --timeout 10000`
- `npx mocha tests/rotate-logs-endpoint.test.js --timeout 10000`
- `npm run test:e2e -- core/log-rotate-log-files-endpoint-6f1a5793.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_6865ffbad498832f9049e3524436e6f5