### PR TITLE
Fix IME candidate window position during composition

### DIFF
--- a/client/e2e/core/ime-candidate-window-fixed-during-composition-90db08fa.spec.ts
+++ b/client/e2e/core/ime-candidate-window-fixed-during-composition-90db08fa.spec.ts
@@ -1,0 +1,52 @@
+/** @feature IME-0004
+ *  Title   : IME candidate window remains fixed during composition
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("IME-0004: IME candidate window remains fixed during composition", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("textarea position stays constant while composing", async ({ page }) => {
+        const item = page.locator(".outliner-item.page-title");
+        if (await item.count() === 0) {
+            const visibleItems = page.locator(".outliner-item").filter({ hasText: /.*/ });
+            await visibleItems.first().locator(".item-content").click({ force: true });
+        } else {
+            await item.locator(".item-content").click({ force: true });
+        }
+
+        const textarea = page.locator("textarea.global-textarea");
+        await textarea.waitFor({ state: "visible" });
+        await textarea.focus();
+
+        await TestHelpers.waitForCursorVisible(page);
+
+        const initialPos = await textarea.evaluate(el => ({ left: el.style.left, top: el.style.top }));
+
+        await page.evaluate(() => {
+            const el = document.querySelector("textarea.global-textarea")!;
+            el.dispatchEvent(new CompositionEvent("compositionstart", { data: "" }));
+            el.dispatchEvent(new CompositionEvent("compositionupdate", { data: "に" }));
+        });
+        await page.waitForTimeout(50);
+        const posAfterUpdate = await textarea.evaluate(el => ({ left: el.style.left, top: el.style.top }));
+        expect(posAfterUpdate).toEqual(initialPos);
+
+        await page.evaluate(() => {
+            const el = document.querySelector("textarea.global-textarea")!;
+            el.dispatchEvent(new CompositionEvent("compositionupdate", { data: "にほ" }));
+        });
+        await page.waitForTimeout(50);
+        const posAfterSecond = await textarea.evaluate(el => ({ left: el.style.left, top: el.style.top }));
+        expect(posAfterSecond).toEqual(initialPos);
+
+        await page.evaluate(() => {
+            const el = document.querySelector("textarea.global-textarea")!;
+            el.dispatchEvent(new CompositionEvent("compositionend", { data: "日本" }));
+        });
+    });
+});

--- a/client/e2e/core/ime-candidate-window-repositions-after-composition-end-1e01279f.spec.ts
+++ b/client/e2e/core/ime-candidate-window-repositions-after-composition-end-1e01279f.spec.ts
@@ -1,0 +1,46 @@
+/** @feature IME-0004
+ *  Title   : IME candidate window remains fixed during composition
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("IME-0004: IME candidate window remains fixed during composition", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("textarea repositions after composition ends", async ({ page }) => {
+        const item = page.locator(".outliner-item.page-title");
+        if (await item.count() === 0) {
+            const visibleItems = page.locator(".outliner-item").filter({ hasText: /.*/ });
+            await visibleItems.first().locator(".item-content").click({ force: true });
+        } else {
+            await item.locator(".item-content").click({ force: true });
+        }
+
+        const textarea = page.locator("textarea.global-textarea");
+        await textarea.waitFor({ state: "visible" });
+        await textarea.focus();
+
+        await TestHelpers.waitForCursorVisible(page);
+
+        const initialPos = await textarea.evaluate(el => ({ left: el.style.left, top: el.style.top }));
+
+        await page.evaluate(() => {
+            const el = document.querySelector("textarea.global-textarea")!;
+            el.dispatchEvent(new CompositionEvent("compositionstart", { data: "" }));
+            el.dispatchEvent(new CompositionEvent("compositionupdate", { data: "ほ" }));
+        });
+        await page.waitForTimeout(50);
+
+        await page.evaluate(() => {
+            const el = document.querySelector("textarea.global-textarea")!;
+            el.dispatchEvent(new CompositionEvent("compositionend", { data: "ほ" }));
+        });
+        await page.waitForTimeout(100);
+
+        const posAfter = await textarea.evaluate(el => ({ left: el.style.left, top: el.style.top }));
+        expect(posAfter).not.toEqual(initialPos);
+    });
+});

--- a/client/src/components/EditorOverlay.svelte
+++ b/client/src/components/EditorOverlay.svelte
@@ -58,14 +58,18 @@ $effect(() => {
     const activeItemId = store.activeItemId; // アクティブアイテムの変更を追跡
     const currentPositionMap = positionMap; // positionMapの変更を追跡
     const textareaRef = store.getTextareaRef();
+    const isComposing = store.isComposing;
 
     if (!textareaRef || !overlayRef) return;
 
     const lastCursor = store.getLastActiveCursor();
     if (!lastCursor) return;
 
-    // 即座に位置を更新し、positionMapが不完全な場合は再試行
-    updateTextareaPosition();
+    // Composition中はテキストエリア位置を固定
+    if (!isComposing) {
+        // 即座に位置を更新し、positionMapが不完全な場合は再試行
+        updateTextareaPosition();
+    }
 
     function updateTextareaPosition() {
         if (!lastCursor || !textareaRef) return;

--- a/client/src/components/GlobalTextArea.svelte
+++ b/client/src/components/GlobalTextArea.svelte
@@ -103,6 +103,7 @@ function updateCompositionWidth(text: string) {
 
 function handleCompositionStart(event: CompositionEvent) {
     isComposing = true;
+    store.setIsComposing(true);
     textareaRef.classList.add("ime-input");
     textareaRef.style.opacity = "1";
     updateCompositionWidth(event.data || "");
@@ -131,6 +132,7 @@ function handleInput(event: Event) {
 function handleCompositionEnd(event: CompositionEvent) {
     KeyEventHandler.handleCompositionEnd(event);
     isComposing = false;
+    store.setIsComposing(false);
     textareaRef.classList.remove("ime-input");
     textareaRef.style.opacity = "0";
     textareaRef.style.width = "1px";

--- a/client/src/stores/EditorOverlayStore.svelte.ts
+++ b/client/src/stores/EditorOverlayStore.svelte.ts
@@ -60,6 +60,8 @@ export class EditorOverlayStore {
     activeItemId = $state<string | null>(null);
     cursorVisible = $state<boolean>(true);
     animationPaused = $state<boolean>(false);
+    // IME composition state
+    isComposing = $state<boolean>(false);
     // GlobalTextArea の textarea 要素を保持
     textareaRef = $state<HTMLTextAreaElement | null>(null);
     // onEdit コールバック
@@ -448,6 +450,14 @@ export class EditorOverlayStore {
 
     setAnimationPaused(paused: boolean) {
         this.animationPaused = paused;
+    }
+
+    setIsComposing(value: boolean) {
+        this.isComposing = value;
+    }
+
+    getIsComposing(): boolean {
+        return this.isComposing;
     }
 
     startCursorBlink() {

--- a/docs/client-features/ime-candidate-window-fixed-during-composition-90db08fa.yaml
+++ b/docs/client-features/ime-candidate-window-fixed-during-composition-90db08fa.yaml
@@ -1,0 +1,10 @@
+id: IME-0004
+title: IME candidate window remains fixed during composition
+title-ja: IME変換候補ウィンドウが入力途中に移動しない
+category: input-method
+status: implemented
+tests:
+- client/e2e/core/ime-candidate-window-fixed-during-composition-90db08fa.spec.ts
+- client/e2e/core/ime-candidate-window-repositions-after-composition-end-1e01279f.spec.ts
+acceptance:
+- Hidden textarea position does not update between compositionstart and compositionend


### PR DESCRIPTION
## Summary
- keep IME hidden textarea fixed while composing so candidate window stays in place
- expose composition state on `EditorOverlayStore`
- update `GlobalTextArea` events to toggle composing flag
- reposition textarea after composition ends (new test)

## Testing
- `npx playwright test e2e/core/ime-candidate-window-fixed-during-composition-90db08fa.spec.ts`
- `npx playwright test e2e/core/ime-candidate-window-repositions-after-composition-end-1e01279f.spec.ts`
- `./scripts/run-env-tests.sh`
- `./scripts/run-e2e-progress-for-codex.sh 1` *(auth tests passed)*
- `npx -y dprint check` *(failed: syntax errors in Svelte files)*

------
https://chatgpt.com/codex/tasks/task_e_68678cd7f4ac832fac4c25b5091e8cfa