### PR TITLE
Add pre-push dprint validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,10 @@ repos:
         additional_dependencies:
           - loguru
           - PyYAML
+      - id: dprint-format
+        name: Check formatting with dprint
+        language: script
+        entry: ./scripts/check_format.sh
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit, pre-push]

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+exit_code=0
+
+if [ -n "$PRE_COMMIT_FROM_REF" ] && [ -n "$PRE_COMMIT_TO_REF" ]; then
+    changed_files=$(git diff --name-only "$PRE_COMMIT_FROM_REF" "$PRE_COMMIT_TO_REF")
+else
+    changed_files=$(git diff --cached --name-only)
+fi
+
+if [ -z "$changed_files" ]; then
+    exit 0
+fi
+
+root_files=()
+functions_files=()
+for f in $changed_files; do
+    if [[ $f == functions/* ]]; then
+        functions_files+=("$f")
+    else
+        root_files+=("$f")
+    fi
+done
+
+if [ ${#root_files[@]} -gt 0 ]; then
+    npx --yes dprint check "${root_files[@]}" || exit_code=1
+fi
+
+if [ ${#functions_files[@]} -gt 0 ] && [ -d "functions" ]; then
+    (cd functions && npx --yes dprint check "${functions_files[@]}" ) || exit_code=1
+fi
+
+if [ $exit_code -ne 0 ]; then
+  echo "\nFormatting issues detected. Run 'npx dprint fmt' to fix." >&2
+fi
+
+exit $exit_code


### PR DESCRIPTION
## Summary
- check files pending push using `PRE_COMMIT_FROM_REF` and `PRE_COMMIT_TO_REF`
- run formatting check during `pre-push` stage via pre-commit

## Testing
- `npm run build`
- `./scripts/run-env-tests.sh` *(fails: env-ci-test-annotations-60806e89.spec.ts)*
- `./scripts/run-e2e-progress-for-codex.sh 1`

------
https://chatgpt.com/codex/tasks/task_e_686884abf864832f93305ecc50e71236