### PR TITLE
Add dprint pre-push hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ dotenvx run -- npm run test:env
 Codex環境では複数のE2Eテストを一度に実行するとタイムアウト (timeout) することがあります。`scripts/run-e2e-progress-for-codex.sh 1` を使うと、テストファイルを1件ずつ実行できます。
 This prevents timeout errors during cording agent's env runs.
 
-
 ```bash
 scripts/run-e2e-progress-for-codex.sh 1
 ```
@@ -229,3 +228,13 @@ scripts/run-e2e-progress-for-codex.sh 1
 ```bash
 python scripts/aggregate_features.py
 ```
+
+### pre-push でフォーマットを検証する
+
+push 前に `dprint check` を実行して未フォーマットのファイルがないか確認します。次のようにフックを設定してください。
+
+```bash
+ln -s ../../scripts/pre_push.sh .git/hooks/pre-push
+```
+
+未フォーマットのファイルがある場合、push は拒否されます。

--- a/docs/dev-features/env-pre-push-format-check-c017dc07.yaml
+++ b/docs/dev-features/env-pre-push-format-check-c017dc07.yaml
@@ -1,0 +1,10 @@
+id: ENV-0010
+title: Pre-push formatting check
+title-ja: pre-pushでフォーマットを検証
+description: A git pre-push hook runs dprint to ensure changed files are formatted before pushing.
+category: environment
+status: implemented
+components:
+  - scripts/pre_push.sh
+tests:
+  - scripts/tests/env-pre-push-format-check-c017dc07.spec.ts

--- a/scripts/pre_push.sh
+++ b/scripts/pre_push.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! npx --yes dprint --version >/dev/null 2>&1; then
+    echo "dprint is not installed." >&2
+    exit 1
+fi
+
+CHANGED=$(git diff --name-only --cached --diff-filter=AM | grep -E '\.(ts|tsx|js|jsx|json|md|yaml|yml|svelte|css|html)$' || true)
+if [ -z "$CHANGED" ]; then
+    exit 0
+fi
+
+if ! npx --yes dprint check $CHANGED; then
+    echo "\nCommit includes unformatted files. Run 'npx dprint fmt $CHANGED' before pushing." >&2
+    exit 1
+fi
+
+exit 0

--- a/scripts/tests/env-pre-push-format-check-c017dc07.spec.ts
+++ b/scripts/tests/env-pre-push-format-check-c017dc07.spec.ts
@@ -1,0 +1,55 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+    expect,
+    test,
+} from "vitest";
+
+/** @feature ENV-0010
+ *  Title   : Pre-push formatting check
+ *  Source  : docs/dev-features/env-pre-push-format-check-c017dc07.yaml
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../..");
+const script = path.join(repoRoot, "scripts", "pre_push.sh");
+
+const tempFile = path.join(repoRoot, "temp_pre_push.ts");
+
+function runScript(): number {
+    try {
+        execSync(script, { cwd: repoRoot, stdio: "pipe" });
+        return 0;
+    }
+    catch (err) {
+        return (err as any).status ?? 1;
+    }
+}
+
+test("pre_push.sh exists and is executable", () => {
+    expect(fs.existsSync(script)).toBe(true);
+    const mode = fs.statSync(script).mode & 0o111;
+    expect(mode).toBeGreaterThan(0);
+});
+
+test("pre_push.sh fails when formatting is incorrect", () => {
+    fs.writeFileSync(tempFile, "const x=1\n");
+    execSync(`git add ${tempFile}`, { cwd: repoRoot });
+    const code = runScript();
+    execSync(`git reset HEAD ${tempFile}`, { cwd: repoRoot });
+    fs.unlinkSync(tempFile);
+    expect(code).not.toBe(0);
+});
+
+test("pre_push.sh succeeds when formatting is correct", () => {
+    fs.writeFileSync(tempFile, "const x = 1;\n");
+    execSync(`npx --yes dprint fmt ${tempFile}`, { cwd: repoRoot });
+    execSync(`git add ${tempFile}`, { cwd: repoRoot });
+    const code = runScript();
+    execSync(`git reset HEAD ${tempFile}`, { cwd: repoRoot });
+    fs.unlinkSync(tempFile);
+    expect(code).toBe(0);
+});


### PR DESCRIPTION
## Summary
- switch pre_push.sh to use dprint for formatting checks
- document dprint pre-push hook setup in README
- update dev feature file about the pre-push check
- test pre_push.sh with formatted and unformatted files

## Testing
- `npm run build`
- `bash scripts/run-env-tests.sh` *(fails: env-ci-test-annotations-60806e89.spec.ts)*
- `bash scripts/run-e2e-progress-for-codex.sh 1` *(fails: auth/auth.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6868b7de9fd4832fbc9c71dbf71b61e1