### PR TITLE
Add fallback logic for Codex e2e script

### DIFF
--- a/docs/dev-features/env-e2e-progress-fallback-717fb3c8.yaml
+++ b/docs/dev-features/env-e2e-progress-fallback-717fb3c8.yaml
@@ -1,0 +1,9 @@
+id: ENV-0011
+title: Codex e2e progress script fallback
+title-ja: Codex以外ではGitHub用E2Eスクリプトを実行
+description: scripts/run-e2e-progress-for-codex.sh detects the Codex environment and runs `npm run github:test:e2e` when not inside Codex.
+category: environment
+status: implemented
+components: []
+tests:
+- scripts/tests/env-e2e-progress-fallback-717fb3c8.spec.ts

--- a/scripts/run-e2e-progress-for-codex.sh
+++ b/scripts/run-e2e-progress-for-codex.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# If not running inside the Codex environment, fallback to the
+# standard GitHub E2E test script.
+if [ -z "${CODEX_ENV_NODE_VERSION:-}" ]; then
+    echo "Codex environment not detected; running full E2E suite"
+    cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../client"
+    npm run github:test:e2e
+    exit $?
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 

--- a/scripts/tests/env-e2e-progress-fallback-717fb3c8.spec.ts
+++ b/scripts/tests/env-e2e-progress-fallback-717fb3c8.spec.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { expect, test } from "vitest";
+
+/** @feature ENV-0011
+ *  Title   : Codex e2e progress script fallback
+ *  Source  : docs/dev-features/env-e2e-progress-fallback-717fb3c8.yaml
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../..");
+const scriptFile = path.join(repoRoot, "scripts", "run-e2e-progress-for-codex.sh");
+
+test("script falls back to GitHub E2E tests outside Codex", () => {
+    const content = fs.readFileSync(scriptFile, "utf-8");
+    expect(content).toMatch(/CODEX_ENV_NODE_VERSION/);
+    expect(content).toMatch(/github:test:e2e/);
+});


### PR DESCRIPTION
## Summary
- detect Codex environment in `scripts/run-e2e-progress-for-codex.sh`
- document fallback behaviour in `env-e2e-progress-fallback-717fb3c8.yaml`
- test script contents in `env-e2e-progress-fallback-717fb3c8.spec.ts`

## Testing
- `scripts/run-env-tests.sh` *(fails: expected 'test-tenant-id' env var, git index lock)*

------
https://chatgpt.com/codex/tasks/task_e_6868e00f0e40832f857ad23b53f9638e