### PR TITLE
382 Project Deletion Page

### DIFF
--- a/client/e2e/new/DEL-0001.spec.ts
+++ b/client/e2e/new/DEL-0001.spec.ts
@@ -1,0 +1,34 @@
+/** @feature DEL-0001
+ *  Title   : Project Deletion Page
+ *  Source  : docs/client-features/del-project-deletion-page-c8da7a47.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("DEL-0001: Project Deletion Page", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("list and delete a project", async ({ page }) => {
+        await page.goto("/projects/delete");
+        await expect(page.locator("h1")).toHaveText("Delete Projects");
+
+        const table = page.locator("table");
+        if (await table.count()) {
+            await expect(table).toBeVisible();
+            const checkbox = page.locator(
+                "tbody tr td input[type=checkbox]"
+            ).first();
+            if (await checkbox.count()) {
+                await checkbox.check();
+                await page.getByRole("button", { name: "Delete" }).click();
+                await expect(
+                    page.getByText("選択したプロジェクトを削除しました")
+                ).toBeVisible();
+            }
+        } else {
+            await expect(page.getByText("No projects found.")).toBeVisible();
+        }
+    });
+});

--- a/client/src/routes/projects/delete/+page.svelte
+++ b/client/src/routes/projects/delete/+page.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+import { onMount } from "svelte";
+import * as fluidService from "../../../lib/fluidService.svelte";
+import { getProjectTitle } from "../../../lib/fluidService.svelte";
+
+interface ProjectEntry {
+    id: string;
+    title: string;
+    selected: boolean;
+}
+
+let projects: ProjectEntry[] = $state([]);
+let loading = $state(false);
+let error: string | undefined = $state(undefined);
+let success: string | undefined = $state(undefined);
+
+async function loadProjects() {
+    loading = true;
+    error = undefined;
+    try {
+        const { containers } = await fluidService.getUserContainers();
+        projects = containers.map(id => ({ id, title: getProjectTitle(id), selected: false }));
+    } catch (err) {
+        error = err instanceof Error ? err.message : "プロジェクト一覧の取得に失敗しました";
+    } finally {
+        loading = false;
+    }
+}
+
+async function deleteSelected() {
+    const targets = projects.filter(p => p.selected);
+    if (targets.length === 0) return;
+    loading = true;
+    error = undefined;
+    success = undefined;
+    for (const p of targets) {
+        const ok = await fluidService.deleteContainer(p.id);
+        if (ok) {
+            projects = projects.filter(pr => pr.id !== p.id);
+        } else {
+            error = `削除に失敗しました: ${p.title}`;
+            break;
+        }
+    }
+    if (!error) success = "選択したプロジェクトを削除しました";
+    loading = false;
+}
+
+onMount(() => {
+    loadProjects();
+});
+</script>
+
+<svelte:head>
+    <title>Delete Projects</title>
+</svelte:head>
+
+<main class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Delete Projects</h1>
+    {#if error}
+        <div class="mb-2 text-red-600">{error}</div>
+    {/if}
+    {#if success}
+        <div class="mb-2 text-green-600">{success}</div>
+    {/if}
+    {#if loading}
+        <p>Loading...</p>
+    {/if}
+    {#if projects.length > 0}
+        <table class="min-w-full border mb-4">
+            <thead>
+                <tr>
+                    <th class="px-2">Select</th>
+                    <th class="px-2">Title</th>
+                    <th class="px-2">ID</th>
+                </tr>
+            </thead>
+            <tbody>
+                {#each projects as project}
+                    <tr>
+                        <td class="px-2 text-center">
+                            <input type="checkbox" bind:checked={project.selected} />
+                        </td>
+                        <td class="px-2">{project.title || "(loading...)"}</td>
+                        <td class="px-2">{project.id}</td>
+                    </tr>
+                {/each}
+            </tbody>
+        </table>
+        <button on:click={deleteSelected} disabled={loading || projects.every(p => !p.selected)} class="bg-red-500 text-white px-4 py-2 rounded">Delete</button>
+    {:else}
+        <p>No projects found.</p>
+    {/if}
+</main>
+
+<style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 4px; }
+</style>

--- a/docs/client-features/del-project-deletion-page-c8da7a47.yaml
+++ b/docs/client-features/del-project-deletion-page-c8da7a47.yaml
@@ -1,0 +1,17 @@
+id: DEL-0001
+title: Project Deletion Page
+title-ja: プロジェクト削除ページ
+description: Dedicated page listing all user projects with checkboxes to delete inaccessible or unwanted containers.
+category: project
+status: draft
+components:
+- src/routes/projects/delete/+page.svelte
+services:
+- src/lib/fluidService.svelte
+- src/stores/firestoreStore.svelte.ts
+tests:
+- client/e2e/new/DEL-0001.spec.ts
+acceptance:
+- Clicking Delete removes the selected projects
+- Multiple projects can be selected via checkboxes
+- Users can see all project container IDs and titles


### PR DESCRIPTION
## Summary
- add project deletion page listing all containers with checkboxes
- document feature DEL-0001
- add E2E test for deletion page and handle empty list case

## Testing
- `npm run build`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e -- e2e/new/DEL-0001.spec.ts`
- `./scripts/run-env-tests.sh` *(fails: env variables not set)*

------
https://chatgpt.com/codex/tasks/task_e_686901b83a4c832f8dc1516ff16a9256