### PR TITLE
feat: support system clipboard paste

### DIFF
--- a/client/e2e/core/clp-system-clipboard-paste-b6ebf516.spec.ts
+++ b/client/e2e/core/clp-system-clipboard-paste-b6ebf516.spec.ts
@@ -1,0 +1,31 @@
+/** @feature FTR-b6ebf516
+ *  Title   : Paste text from the system clipboard
+ *  Source  : docs/client-features.yaml
+ */
+
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("System clipboard paste", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("pastes text from clipboard", async ({ page, context }) => {
+        await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+        await page.evaluate(async () => {
+            await navigator.clipboard.writeText("pasted text");
+        });
+
+        const item = page.locator(".outliner-item").first();
+        await item.locator(".item-content").click();
+        await TestHelpers.waitForCursorVisible(page);
+
+        await page.keyboard.press("Control+v");
+        await page.waitForTimeout(500);
+
+        const text = await item.locator(".item-text").textContent();
+        expect(text).toContain("pasted text");
+    });
+});

--- a/client/e2e/core/fmt-vscode-clipboard-behavior-3807f353.spec.ts
+++ b/client/e2e/core/fmt-vscode-clipboard-behavior-3807f353.spec.ts
@@ -20,7 +20,7 @@ test.describe("VS Code clipboard behavior", () => {
         await TestHelpers.waitForCursorVisible(page);
         await page.locator(".outliner-item").nth(1).locator(".item-content").click({ force: true });
 
-        await page.evaluate(() => {
+        await page.evaluate(async () => {
             const data = new DataTransfer();
             data.setData("text/plain", "AAA\nBBB");
             const metadata = {
@@ -33,7 +33,7 @@ test.describe("VS Code clipboard behavior", () => {
             data.setData("application/vscode-editor", JSON.stringify(metadata));
             const evt = new ClipboardEvent("paste", { clipboardData: data, bubbles: true, cancelable: true });
             const handler = (window as any).__KEY_EVENT_HANDLER__;
-            handler.handlePaste(evt);
+            await handler.handlePaste(evt);
         });
 
         await page.waitForTimeout(500);
@@ -47,14 +47,14 @@ test.describe("VS Code clipboard behavior", () => {
         await TestHelpers.setCursor(page, firstId!, 0, "user1");
         await TestHelpers.setCursor(page, secondId!, 0, "user2");
 
-        await page.evaluate(() => {
+        await page.evaluate(async () => {
             const data = new DataTransfer();
             data.setData("text/plain", "111\n222");
             const metadata = { version: 1, isFromEmptySelection: false, mode: "plaintext" };
             data.setData("application/vscode-editor", JSON.stringify(metadata));
             const evt = new ClipboardEvent("paste", { clipboardData: data, bubbles: true, cancelable: true });
             const handler = (window as any).__KEY_EVENT_HANDLER__;
-            handler.handlePaste(evt);
+            await handler.handlePaste(evt);
         });
 
         await page.waitForTimeout(500);

--- a/client/e2e/core/slr-copy-selection-4c4c4f1a.spec.ts
+++ b/client/e2e/core/slr-copy-selection-4c4c4f1a.spec.ts
@@ -122,7 +122,7 @@ test.describe("SLR-0006: 複数アイテム選択範囲のコピー＆ペース�
         await page.keyboard.press("Control+v");
 
         // KeyEventHandlerのhandlePasteを直接呼び出す
-        await page.evaluate(text => {
+        await page.evaluate(async text => {
             console.log("Calling KeyEventHandler.handlePaste directly with text:", text);
 
             // ClipboardEventを手動で作成
@@ -147,7 +147,7 @@ test.describe("SLR-0006: 複数アイテム選択範囲のコピー＆ペース�
             // KeyEventHandlerのhandlePasteを直接呼び出し
             const KeyEventHandler = (window as any).__KEY_EVENT_HANDLER__;
             if (KeyEventHandler && KeyEventHandler.handlePaste) {
-                KeyEventHandler.handlePaste(clipboardEvent);
+                await KeyEventHandler.handlePaste(clipboardEvent);
                 console.log("KeyEventHandler.handlePaste called successfully");
             } else {
                 console.log("KeyEventHandler.handlePaste not found");

--- a/client/e2e/core/slr-paste-copied-text-20a382d6.spec.ts
+++ b/client/e2e/core/slr-paste-copied-text-20a382d6.spec.ts
@@ -135,7 +135,7 @@ test.describe("SLR-20a382d6: コピーしたテキストのペースト", () => 
         await page.keyboard.press("Control+v");
 
         // KeyEventHandlerのhandlePasteを直接呼び出す
-        await page.evaluate(text => {
+        await page.evaluate(async text => {
             console.log("Calling KeyEventHandler.handlePaste directly with text:", text);
 
             // ClipboardEventを手動で作成
@@ -160,7 +160,7 @@ test.describe("SLR-20a382d6: コピーしたテキストのペースト", () => 
             // KeyEventHandlerのhandlePasteを直接呼び出し
             const KeyEventHandler = (window as any).__KEY_EVENT_HANDLER__;
             if (KeyEventHandler && KeyEventHandler.handlePaste) {
-                KeyEventHandler.handlePaste(clipboardEvent);
+                await KeyEventHandler.handlePaste(clipboardEvent);
                 console.log("KeyEventHandler.handlePaste called successfully");
             } else {
                 console.log("KeyEventHandler.handlePaste not found");

--- a/client/e2e/tsconfig.json
+++ b/client/e2e/tsconfig.json
@@ -14,7 +14,8 @@
         "allowImportingTsExtensions": false,
         "types": [
             "@playwright/test",
-            "node"
+            "node",
+            "vitest"
         ],
         "noUnusedLocals": false,
         "target": "es2017"
@@ -22,8 +23,7 @@
     "include": [
         "../src/vite-env.d.ts",
         "**/*.ts",
-        "**/*.js",
-        "../../scripts/tests/tst-feature-map-removal-f9984020.spec.ts"
+        "**/*.js"
     ],
     "exclude": [
         "node_modules"

--- a/client/src/lib/KeyEventHandler.test.ts
+++ b/client/src/lib/KeyEventHandler.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeyEventHandler } from "./KeyEventHandler";
+
+// Svelte store mock as permitted by AGENTS.md
+const insertText = vi.fn();
+const clearSelections = vi.fn();
+const startCursorBlink = vi.fn();
+let selections: Record<string, unknown> = {};
+
+vi.mock("../stores/EditorOverlayStore.svelte", () => ({
+    editorOverlayStore: {
+        getCursorInstances: () => [{ insertText }],
+        selections,
+        clearSelections,
+        startCursorBlink,
+    },
+}));
+
+describe("KeyEventHandler.handlePaste", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        selections = {};
+        (window as any).lastCopiedText = undefined;
+    });
+
+    afterEach(() => {
+        delete (navigator as any).clipboard;
+    });
+
+    const createEvent = (text: string): ClipboardEvent => {
+        const clipboardData = {
+            getData: vi.fn((_format: string) => text),
+        } as unknown as DataTransfer;
+        return {
+            clipboardData,
+            preventDefault: vi.fn(),
+        } as unknown as ClipboardEvent;
+    };
+
+    it("inserts clipboard text when available", async () => {
+        const event = createEvent("hello world");
+        await KeyEventHandler.handlePaste(event);
+        expect(insertText).toHaveBeenCalledWith("hello world");
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("dispatches permission denied event and skips insert", async () => {
+        const event = createEvent("");
+        const listener = vi.fn();
+        window.addEventListener("clipboard-permission-denied", listener);
+        Object.defineProperty(navigator, "clipboard", {
+            value: { readText: () => Promise.reject({ name: "NotAllowedError" }) },
+            configurable: true,
+        });
+        await KeyEventHandler.handlePaste(event);
+        expect(listener).toHaveBeenCalled();
+        expect(insertText).not.toHaveBeenCalled();
+        window.removeEventListener("clipboard-permission-denied", listener);
+    });
+
+    it("dispatches read error event and skips insert", async () => {
+        const event = createEvent("");
+        const listener = vi.fn();
+        window.addEventListener("clipboard-read-error", listener);
+        Object.defineProperty(navigator, "clipboard", {
+            value: { readText: () => Promise.reject({ name: "UnknownError" }) },
+            configurable: true,
+        });
+        await KeyEventHandler.handlePaste(event);
+        expect(listener).toHaveBeenCalled();
+        expect(insertText).not.toHaveBeenCalled();
+        window.removeEventListener("clipboard-read-error", listener);
+    });
+
+    it("falls back to global lastCopiedText when clipboard empty", async () => {
+        const event = createEvent("");
+        (window as any).lastCopiedText = "fallback";
+        Object.defineProperty(navigator, "clipboard", {
+            value: { readText: () => Promise.resolve("") },
+            configurable: true,
+        });
+        await KeyEventHandler.handlePaste(event);
+        expect(insertText).toHaveBeenCalledWith("fallback");
+    });
+
+    it("dispatches read error when cursor insertion throws", async () => {
+        const event = createEvent("oops");
+        insertText.mockImplementationOnce(() => {
+            throw new Error("boom");
+        });
+        const listener = vi.fn();
+        window.addEventListener("clipboard-read-error", listener);
+        await KeyEventHandler.handlePaste(event);
+        expect(listener).toHaveBeenCalled();
+        window.removeEventListener("clipboard-read-error", listener);
+    });
+});

--- a/client/src/lib/KeyEventHandler.ts
+++ b/client/src/lib/KeyEventHandler.ts
@@ -123,25 +123,6 @@ export class KeyEventHandler {
             // カットイベントをディスパッチ
             document.dispatchEvent(clipboardEvent);
         });
-
-        // Ctrl+V paste
-        add("v", true, false, false, event => {
-            // ペーストイベントを手動で発生させる
-            const clipboardEvent = new ClipboardEvent("paste", {
-                clipboardData: new DataTransfer(),
-                bubbles: true,
-                cancelable: true,
-            });
-
-            // グローバル変数からテキストを取得（テスト用）
-            if (typeof window !== "undefined" && (window as any).lastCopiedText) {
-                const text = (window as any).lastCopiedText;
-                clipboardEvent.clipboardData?.setData("text/plain", text);
-                console.log(`Using text from global variable for paste: "${text}"`);
-            }
-
-            KeyEventHandler.handlePaste(clipboardEvent);
-        });
     }
     /**
      * KeyDown イベントを各カーソルに委譲
@@ -1106,10 +1087,14 @@ export class KeyEventHandler {
     }
 
     /**
-     * ペーストイベントを処理する
+     * ペーストイベントを処理する非同期メソッド。
+     * 呼び出し側は `await` して権限拒否や読み取り失敗を捕捉する。
+     * Clipboard API の権限エラーを捕捉し DEBUG_MODE 時にログ出力する。
+     * 失敗時は `clipboard-permission-denied` または `clipboard-read-error`
+     * を dispatch し、空文字を挿入してユーザーにはペーストされないように見せる。
      * @param event ClipboardEvent
      */
-    static handlePaste(event: ClipboardEvent) {
+    static async handlePaste(event: ClipboardEvent): Promise<void> {
         // デバッグ情報
         if (typeof window !== "undefined" && (window as any).DEBUG_MODE) {
             console.log(`KeyEventHandler.handlePaste called`);
@@ -1118,6 +1103,33 @@ export class KeyEventHandler {
         try {
             // プレーンテキストを取得
             let text = event.clipboardData?.getData("text/plain") || "";
+
+            // イベントから取得できない場合はClipboard APIを使用
+            if (!text && typeof navigator !== "undefined" && navigator.clipboard) {
+                try {
+                    text = await navigator.clipboard.readText();
+                } catch (error: any) {
+                    if (typeof window !== "undefined" && (window as any).DEBUG_MODE) {
+                        if (error?.name === "NotAllowedError") {
+                            console.warn("Clipboard permission denied", error);
+                        } else {
+                            console.error("navigator.clipboard.readText failed", error);
+                        }
+                    }
+
+                    if (typeof window !== "undefined") {
+                        window.dispatchEvent(
+                            new CustomEvent(
+                                error?.name === "NotAllowedError"
+                                    ? "clipboard-permission-denied"
+                                    : "clipboard-read-error",
+                            ),
+                        );
+                    }
+
+                    text = "";
+                }
+            }
 
             // テキストが取得できない場合はグローバル変数から取得（テスト用）
             if (!text && typeof window !== "undefined" && (window as any).lastCopiedText) {
@@ -1374,9 +1386,12 @@ export class KeyEventHandler {
             const cursorInstances = store.getCursorInstances();
             cursorInstances.forEach(cursor => cursor.insertText(text));
         } catch (error) {
-            // エラーが発生した場合はログに出力
+            // エラーが発生した場合はログに出力し UI に通知
             if (typeof window !== "undefined" && (window as any).DEBUG_MODE) {
                 console.error(`Error in handlePaste:`, error);
+            }
+            if (typeof window !== "undefined") {
+                window.dispatchEvent(new CustomEvent("clipboard-read-error"));
             }
         }
     }

--- a/docs/client-features/clp-system-clipboard-paste-b6ebf516.yaml
+++ b/docs/client-features/clp-system-clipboard-paste-b6ebf516.yaml
@@ -1,0 +1,20 @@
+id: FTR-b6ebf516
+title: Paste text from the system clipboard
+description: >
+  Allow pasting text copied outside the app using the native clipboard API.
+  `KeyEventHandler.handlePaste` is asynchronous and should be awaited so
+  permission or read failures dispatch `clipboard-permission-denied` or
+  `clipboard-read-error` events and no text is inserted.
+  Clipboard text is resolved in order of `event.clipboardData`,
+  `navigator.clipboard.readText()`, then the nonstandard `window.lastCopiedText`
+  fallback. When text contains newlines, lines are only split and distributed
+  across selections when VS Code multicursor or box-selection metadata is
+  present; otherwise only the first line is inserted.
+category: editing
+status: implemented
+acceptance:
+- Text copied in another application can be pasted into an item with Ctrl+V
+- The pasted text appears at the cursor position
+tests:
+- client/e2e/core/clp-system-clipboard-paste-b6ebf516.spec.ts
+title-ja: システムクリップボードからのテキストペースト


### PR DESCRIPTION
## Summary
- handle paste through the native clipboard API and drop synthetic paste events
- document the new system clipboard paste feature
- add an end-to-end test covering clipboard pasting
- log clipboard permission errors and emit a browser event when paste fails
- document error handling for clipboard permission fallback in paste handlers
- await the global textarea's paste handler so rejected clipboard reads are logged instead of unhandled
- add unit tests for clipboard paste, covering permission failures, read errors, global fallbacks, and unexpected errors
- mention fallback to window.lastCopiedText when clipboard data is unavailable
- type clipboard event mocks in unit tests instead of suppressing TypeScript
- document that `KeyEventHandler.handlePaste` is async, must be awaited, and dispatches clipboard error events
- update existing E2E specs to await the async paste handler

## Testing
- `npx -y dprint fmt`
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json` *(fails: Cannot find type definition file for '@playwright/test', 'node', 'vitest')*
- `cd client && npx tsc --noEmit --project tsconfig.json` *(fails: Cannot find type definition file for '@playwright/test'; Cannot read file '/workspace/outliner/client/.svelte-kit/tsconfig.json'; Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later)*
- `cd client && npm run build` *(fails: paraglide-js: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890c3e3ff74832fa40793446c0280b8