### PR TITLE
fix: prevent editing when clicking external links

### DIFF
--- a/client/e2e/core/lnk-external-link-navigation-9a2f4dce.spec.ts
+++ b/client/e2e/core/lnk-external-link-navigation-9a2f4dce.spec.ts
@@ -1,0 +1,39 @@
+/** @feature LNK-9a2f4dce
+ *  Title   : External link navigation
+ *  Source  : docs/client-features.yaml
+ */
+
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+(test.describe)("External link navigation", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("clicking bracketed URL opens the target", async ({ page }) => {
+        const item = page.locator(".outliner-item").first();
+        await item.locator(".item-content").click();
+
+        await page.keyboard.type("[https://example.com]");
+        await page.keyboard.press("Enter");
+        await page.keyboard.type("Second item");
+
+        const secondItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(secondItemId).not.toBeNull();
+        await page.locator(`.outliner-item[data-item-id="${secondItemId}"]`).locator(".item-content").click();
+
+        await page.waitForTimeout(500);
+
+        const link = page.locator(".outliner-item").first().locator("a");
+        await expect(link).toBeVisible();
+
+        const [popup] = await Promise.all([
+            page.waitForEvent("popup"),
+            link.click(),
+        ]);
+        await popup.waitForLoadState();
+        expect(popup.url()).toContain("https://example.com");
+        await popup.close();
+    });
+});

--- a/client/src/components/OutlinerItem.svelte
+++ b/client/src/components/OutlinerItem.svelte
@@ -496,6 +496,11 @@ function toggleComments() {
  * @param event マウスイベント
  */
 function handleClick(event: MouseEvent) {
+    // Anchor click: navigate to link without entering edit mode
+    if ((event.target as HTMLElement).closest("a")) {
+        return;
+    }
+
     // Alt+Click: 新しいカーソルを追加
     if (event.altKey) {
         // イベントの伝播を確実に停止
@@ -572,6 +577,11 @@ function handleClick(event: MouseEvent) {
 function handleMouseDown(event: MouseEvent) {
     // 右クリックは無視
     if (event.button !== 0) return;
+
+    // Anchor click should not trigger editing or dragging
+    if ((event.target as HTMLElement).closest("a")) {
+        return;
+    }
 
     // Shift+クリックの場合は選択範囲を拡張
     if (event.shiftKey) {

--- a/docs/client-features/lnk-external-link-navigation-9a2f4dce.yaml
+++ b/docs/client-features/lnk-external-link-navigation-9a2f4dce.yaml
@@ -1,0 +1,10 @@
+id: LNK-9a2f4dce
+title: External link navigation
+title-ja: 外部リンクナビゲーション
+description: Bracketed URLs open the target URL instead of entering edit mode.
+category: navigation
+status: implemented
+acceptance:
+- Clicking a bracketed URL opens the external site in a new tab.
+tests:
+- client/e2e/core/lnk-external-link-navigation-9a2f4dce.spec.ts


### PR DESCRIPTION
## Summary
- ignore anchor clicks in outliner items so bracketed URLs navigate instead of entering edit mode
- document external link navigation feature
- add Playwright test covering external link behavior

## Testing
- `npx tsc --noEmit --project e2e/tsconfig.json`
- `npx tsc --noEmit --project tsconfig.json`
- `scripts/codex-setup.sh` *(servers started)*
- `npm run test:e2e -- e2e/core/lnk-external-link-navigation-9a2f4dce.spec.ts` *(missing system deps)*
- `npm run build`
- `npm test` *(missing system deps)*

------
https://chatgpt.com/codex/tasks/task_e_68934651515c832fabf633b35666c85a