### PR TITLE
Server Structured logging & privacy #553

### DIFF
--- a/client/e2e/utils/srv-structured-logging-1ec8f72b.spec.ts
+++ b/client/e2e/utils/srv-structured-logging-1ec8f72b.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@playwright/test";
+import { Writable } from "stream";
+test("srv-structured-logging redacts sensitive data", async () => {
+    const { createLogger } = await import("../../../server/src/logger.ts");
+    let output = "";
+    const stream = new Writable({
+        write(chunk, _enc, cb) {
+            output += chunk.toString();
+            cb();
+        },
+    });
+    const logger = createLogger(stream);
+    logger.info({ authorization: "Bearer secret", email: "user@example.com" }, "redact");
+    const log = JSON.parse(output);
+    expect(log.authorization).toBe("[REDACTED]");
+    expect(log.email).toBe("[REDACTED]");
+});

--- a/docs/client-features/srv-structured-logging-1ec8f72b.yaml
+++ b/docs/client-features/srv-structured-logging-1ec8f72b.yaml
@@ -1,0 +1,10 @@
+id: FTR-1ec8f72b
+title: Structured logging with redaction
+title-ja: 構造化ログとマスキング
+description: Server emits JSON logs and redacts sensitive data.
+category: server
+status: implemented
+tests:
+- client/e2e/utils/srv-structured-logging-1ec8f72b.spec.ts
+- server/tests/logger-redaction.test.js
+- server/tests/server-logging.test.js

--- a/docs/client-features/svr-websocket-server-connect-4f5a1b2c.yaml
+++ b/docs/client-features/svr-websocket-server-connect-4f5a1b2c.yaml
@@ -2,4 +2,4 @@ id: SVR-4f5a1b2c
 title: WebSocket server accepts connections
 title-ja: WebSocketサーバーが接続を受け付ける
 tests:
-  - client/e2e/new/svr-websocket-server-connect-4f5a1b2c.spec.ts
+- client/e2e/new/svr-websocket-server-connect-4f5a1b2c.spec.ts

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,0 +1,25 @@
+import pino from "pino";
+
+export function createLogger(destination: pino.DestinationStream = pino.destination(1)) {
+    return pino(
+        {
+            level: process.env.LOG_LEVEL ?? "info",
+            redact: {
+                paths: [
+                    "req.headers.authorization",
+                    "req.body.token",
+                    "authorization",
+                    "token",
+                    "password",
+                    "email",
+                ],
+                censor: "[REDACTED]",
+            },
+            timestamp: pino.stdTimeFunctions.isoTime,
+        },
+        destination,
+    );
+}
+
+export const logger = createLogger();
+export default logger;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,10 +1,9 @@
 import http from "http";
-import pino from "pino";
 import { WebSocketServer } from "ws";
 import { type Config } from "./config";
+import { logger as defaultLogger } from "./logger";
 
-export function startServer(config: Config) {
-    const logger = pino({ level: config.LOG_LEVEL });
+export function startServer(config: Config, logger = defaultLogger) {
     const server = http.createServer();
     const wss = new WebSocketServer({ server });
 
@@ -13,7 +12,7 @@ export function startServer(config: Config) {
     });
 
     server.listen(config.PORT, "::", () => {
-        logger.info(`y-websocket server listening on :::${config.PORT}`);
+        logger.info({ port: config.PORT }, "y-websocket server listening");
     });
 
     const shutdown = () => {

--- a/server/tests/logger-redaction.test.js
+++ b/server/tests/logger-redaction.test.js
@@ -1,0 +1,24 @@
+require("ts-node/register");
+const { Writable } = require("stream");
+const { expect } = require("chai");
+const { createLogger } = require("../src/logger");
+
+describe("logger redaction", () => {
+    it("redacts tokens and emails", done => {
+        let output = "";
+        const stream = new Writable({
+            write(chunk, _enc, cb) {
+                output += chunk.toString();
+                cb();
+            },
+        });
+        const logger = createLogger(stream);
+        logger.info({ token: "secret", email: "user@example.com" }, "test");
+        stream.end(() => {
+            const log = JSON.parse(output);
+            expect(log.token).to.equal("[REDACTED]");
+            expect(log.email).to.equal("[REDACTED]");
+            done();
+        });
+    });
+});

--- a/server/tests/server-logging.test.js
+++ b/server/tests/server-logging.test.js
@@ -1,0 +1,29 @@
+require("ts-node/register");
+const http = require("http");
+const { Writable } = require("stream");
+const { expect } = require("chai");
+const { createLogger } = require("../src/logger");
+
+describe("server logging", () => {
+    it("logs structured JSON on startup", done => {
+        let output = "";
+        const stream = new Writable({
+            write(chunk, _enc, cb) {
+                output += chunk.toString();
+                cb();
+            },
+        });
+        const logger = createLogger(stream);
+        const server = http.createServer();
+        server.listen(0, "::", () => {
+            const port = server.address().port;
+            logger.info({ port }, "y-websocket server listening");
+            server.close(() => {
+                const log = JSON.parse(output);
+                expect(log.port).to.equal(port);
+                expect(log.msg).to.equal("y-websocket server listening");
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add Pino-based server logger with redaction
- wire structured logging into websocket server
- document structured logging feature

## Testing
- `npx mocha server/tests/logger-redaction.test.js`
- `npx mocha server/tests/server-logging.test.js`
- `npm run test:e2e -- e2e/utils/srv-structured-logging-1ec8f72b.spec.ts` *(fails: Cannot use import statement outside a module)*
- `npx tsc --noEmit --project tsconfig.json` *(fails: Argument of type 'Error' is not assignable to parameter of type 'undefined')*
- `npx tsc --noEmit --project client/e2e/tsconfig.json` *(fails: Cannot assign to 'after2' because it is a constant)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b59dadb680832f9588a81a777b94c1

## Related Issues

Fixes #553
