### PR TITLE
Firebase Auth verification for WebSocket handshake (#556)

### DIFF
--- a/client/e2e/new/wsa-websocket-auth-required-6d3a1b2c.spec.ts
+++ b/client/e2e/new/wsa-websocket-auth-required-6d3a1b2c.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+import { type ChildProcess, spawn } from "child_process";
+import path from "path";
+import { TestHelpers } from "../utils/testHelpers";
+
+let proc: ChildProcess | undefined;
+
+test.beforeEach(async ({ page }) => {
+    await TestHelpers.prepareTestEnvironment(page);
+});
+
+test.afterEach(() => {
+    proc?.kill();
+});
+
+test("websocket requires auth token", async ({ page }) => {
+    const serverPath = path.resolve(__dirname, "../../../server");
+    proc = spawn("pnpm", ["dev"], {
+        cwd: serverPath,
+        env: { ...process.env, PORT: "12352", LOG_LEVEL: "silent" },
+        stdio: "ignore",
+    });
+    await new Promise((res) => setTimeout(res, 1000));
+
+    const closeCode = await page.evaluate(() =>
+        new Promise<number>((resolve) => {
+            const ws = new WebSocket("ws://localhost:12352");
+            ws.onclose = e => resolve(e.code);
+        })
+    );
+    expect(closeCode).toBe(4001);
+});

--- a/docs/client-features/svr-websocket-server-connect-4f5a1b2c.yaml
+++ b/docs/client-features/svr-websocket-server-connect-4f5a1b2c.yaml
@@ -1,5 +1,6 @@
 id: SVR-4f5a1b2c
 title: WebSocket server accepts connections
 title-ja: WebSocketサーバーが接続を受け付ける
+status: implemented
 tests:
 - client/e2e/new/svr-websocket-server-connect-4f5a1b2c.spec.ts

--- a/docs/client-features/wsa-websocket-auth-required-6d3a1b2c.yaml
+++ b/docs/client-features/wsa-websocket-auth-required-6d3a1b2c.yaml
@@ -1,0 +1,6 @@
+id: WSA-6d3a1b2c
+title: WebSocket requires authentication
+title-ja: WebSocket接続には認証が必要
+status: proposed
+tests:
+- client/e2e/new/wsa-websocket-auth-required-6d3a1b2c.spec.ts

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2,13 +2,26 @@ import http from "http";
 import { WebSocketServer } from "ws";
 import { type Config } from "./config";
 import { logger as defaultLogger } from "./logger";
+import { extractAuthToken, verifyIdTokenCached } from "./websocket-auth";
 
 export function startServer(config: Config, logger = defaultLogger) {
     const server = http.createServer();
     const wss = new WebSocketServer({ server });
 
-    wss.on("connection", () => {
-        // connection established
+    wss.on("connection", async (ws, req) => {
+        const token = extractAuthToken(req);
+        if (!token) {
+            logger.warn({ event: "ws_connection_denied", reason: "missing_token" });
+            ws.close(4001, "UNAUTHORIZED");
+            return;
+        }
+        try {
+            const decoded = await verifyIdTokenCached(token);
+            logger.info({ event: "ws_connection_accepted", uid: decoded.uid });
+        } catch {
+            logger.warn({ event: "ws_connection_denied", reason: "invalid_token" });
+            ws.close(4001, "UNAUTHORIZED");
+        }
     });
 
     server.listen(config.PORT, "::", () => {

--- a/server/src/websocket-auth.ts
+++ b/server/src/websocket-auth.ts
@@ -1,0 +1,44 @@
+import admin from "firebase-admin";
+import type { IncomingMessage } from "http";
+
+if (!admin.apps.length) {
+    if (process.env.FIREBASE_PROJECT_ID) {
+        admin.initializeApp({ projectId: process.env.FIREBASE_PROJECT_ID });
+    } else {
+        admin.initializeApp();
+    }
+}
+
+interface CacheEntry {
+    decoded: admin.auth.DecodedIdToken;
+    exp: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const tokenCache = new Map<string, CacheEntry>();
+
+export function clearTokenCache() {
+    tokenCache.clear();
+}
+
+export function extractAuthToken(req: IncomingMessage): string | undefined {
+    try {
+        const url = new URL(req.url ?? "", "http://localhost");
+        const token = url.searchParams.get("auth");
+        return token || undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+export async function verifyIdTokenCached(token: string): Promise<admin.auth.DecodedIdToken> {
+    const cached = tokenCache.get(token);
+    const now = Date.now();
+    if (cached && cached.exp > now) {
+        return cached.decoded;
+    }
+    const decoded = await admin.auth().verifyIdToken(token);
+    const exp = Math.min(decoded.exp ? decoded.exp * 1000 : now + CACHE_TTL_MS, now + CACHE_TTL_MS);
+    tokenCache.set(token, { decoded, exp });
+    return decoded;
+}

--- a/server/tests/server-auth.test.js
+++ b/server/tests/server-auth.test.js
@@ -1,0 +1,56 @@
+const { expect } = require("chai");
+const { once } = require("events");
+const WebSocket = require("ws");
+const sinon = require("sinon");
+require("ts-node/register");
+const admin = require("firebase-admin");
+const { loadConfig } = require("../src/config");
+const { startServer } = require("../src/server");
+
+function waitListening(server) {
+    return new Promise(resolve => server.on("listening", resolve));
+}
+
+describe("server websocket auth", () => {
+    afterEach(() => sinon.restore());
+
+    it("rejects connection without token", async () => {
+        const cfg = loadConfig({ PORT: "12347", LOG_LEVEL: "silent" });
+        const { server } = startServer(cfg);
+        await waitListening(server);
+        await new Promise(resolve => {
+            const ws = new WebSocket(`ws://localhost:${cfg.PORT}`);
+            ws.on("close", code => {
+                expect(code).to.equal(4001);
+                resolve();
+            });
+        });
+        server.close();
+    });
+
+    it("accepts connection with valid token", async () => {
+        sinon.stub(admin.auth(), "verifyIdToken").resolves({ uid: "user", exp: Math.floor(Date.now() / 1000) + 60 });
+        const cfg = loadConfig({ PORT: "12348", LOG_LEVEL: "silent" });
+        const { server } = startServer(cfg);
+        await waitListening(server);
+        const ws = new WebSocket(`ws://localhost:${cfg.PORT}/?auth=token`);
+        await once(ws, "open");
+        ws.close();
+        server.close();
+    });
+
+    it("rejects connection with invalid token", async () => {
+        sinon.stub(admin.auth(), "verifyIdToken").rejects(new Error("bad"));
+        const cfg = loadConfig({ PORT: "12349", LOG_LEVEL: "silent" });
+        const { server } = startServer(cfg);
+        await waitListening(server);
+        await new Promise(resolve => {
+            const ws = new WebSocket(`ws://localhost:${cfg.PORT}/?auth=bad`);
+            ws.on("close", code => {
+                expect(code).to.equal(4001);
+                resolve();
+            });
+        });
+        server.close();
+    });
+});

--- a/server/tests/websocket-auth.test.js
+++ b/server/tests/websocket-auth.test.js
@@ -1,0 +1,47 @@
+const { expect } = require("chai");
+const sinon = require("sinon");
+require("ts-node/register");
+const admin = require("firebase-admin");
+const { extractAuthToken, verifyIdTokenCached, clearTokenCache } = require("../src/websocket-auth");
+
+describe("websocket auth helpers", () => {
+    afterEach(() => {
+        sinon.restore();
+        clearTokenCache();
+    });
+
+    it("extracts auth token from url", () => {
+        const req = { url: "/?auth=test-token" };
+        expect(extractAuthToken(req)).to.equal("test-token");
+    });
+
+    it("returns undefined when token missing", () => {
+        const req = { url: "/" };
+        expect(extractAuthToken(req)).to.be.undefined;
+    });
+
+    it("verifies token and caches result", async () => {
+        const stub = sinon.stub(admin.auth(), "verifyIdToken").resolves({
+            uid: "u1",
+            exp: Math.floor(Date.now() / 1000) + 60,
+        });
+        const token = "valid";
+        const first = await verifyIdTokenCached(token);
+        expect(first.uid).to.equal("u1");
+        expect(stub.calledOnce).to.be.true;
+        const second = await verifyIdTokenCached(token);
+        expect(second.uid).to.equal("u1");
+        expect(stub.calledOnce).to.be.true;
+    });
+
+    it("throws on invalid token", async () => {
+        sinon.stub(admin.auth(), "verifyIdToken").rejects(new Error("bad"));
+        let err;
+        try {
+            await verifyIdTokenCached("bad");
+        } catch (e) {
+            err = e;
+        }
+        expect(err).to.be.instanceOf(Error);
+    });
+});


### PR DESCRIPTION
## Summary
- verify Firebase ID tokens during WebSocket handshake
- cache decoded tokens briefly to reduce verification load
- document WebSocket auth requirement

## Testing
- `npx mocha tests/websocket-auth.test.js --timeout 10000`
- `npx mocha tests/server-auth.test.js --timeout 10000`
- `npx tsc --noEmit --project tsconfig.json` *(fails: Cannot find type definition file for '@playwright/test')*
- `npm run test:e2e -- e2e/new/wsa-websocket-auth-required-6d3a1b2c.spec.ts` *(fails: playwright not found)*
- `npm run build` *(fails: paraglide-js: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b62eb809e4832faf43f0d0d9537f13

## Related Issues

Fixes #556
