### PR TITLE
[Server] Integration tests (minimal core: auth, rooms, persistence) (#559)

### DIFF
--- a/client/e2e/server/srv-websocket-basic-integration-9a4b1c2d.spec.ts
+++ b/client/e2e/server/srv-websocket-basic-integration-9a4b1c2d.spec.ts
@@ -1,0 +1,24 @@
+/** @feature SRV-9a4b1c2d
+ *  Title   : WebSocket server basic integration
+ *  Source  : docs/client-features/srv-websocket-basic-integration-9a4b1c2d.yaml
+ */
+import { expect, test } from "@playwright/test";
+import WebSocket from "ws";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("WebSocket server authentication", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("invalid token is rejected", async () => {
+        await new Promise<void>(resolve => {
+            const port = process.env.TEST_API_PORT ?? "7091";
+            const ws = new WebSocket(`ws://localhost:${port}/projects/testproj?auth=bad`);
+            ws.on("close", code => {
+                expect(code).toBe(4001);
+                resolve();
+            });
+        });
+    });
+});

--- a/docs/client-features/db5-leveldb-persistence-db5e7a9c.yaml
+++ b/docs/client-features/db5-leveldb-persistence-db5e7a9c.yaml
@@ -2,5 +2,7 @@ id: FTR-db5e7a9c
 slug: db5
 title: LevelDB persistence
 title-ja: LevelDB 永続化
+category: server
+status: experimental
 tests:
-  - client/e2e/new/db5-leveldb-persistence-db5e7a9c.spec.ts
+- client/e2e/new/db5-leveldb-persistence-db5e7a9c.spec.ts

--- a/docs/client-features/srv-websocket-basic-integration-9a4b1c2d.yaml
+++ b/docs/client-features/srv-websocket-basic-integration-9a4b1c2d.yaml
@@ -1,0 +1,10 @@
+id: SRV-9a4b1c2d
+title: WebSocket server basic integration
+title-ja: WebSocketサーバー基本統合テスト
+category: server
+status: experimental
+components:
+- server/src/server.ts
+tests:
+- client/e2e/server/srv-websocket-basic-integration-9a4b1c2d.spec.ts
+- server/tests/server-persistence-roundtrip.test.js

--- a/server/tests/server-persistence-roundtrip.test.js
+++ b/server/tests/server-persistence-roundtrip.test.js
@@ -1,0 +1,103 @@
+const { expect } = require("chai");
+const fs = require("fs-extra");
+const os = require("os");
+const path = require("path");
+const { once } = require("events");
+const WebSocket = require("ws");
+const Y = require("yjs");
+const { WebsocketProvider } = require("y-websocket");
+const sinon = require("sinon");
+require("ts-node/register");
+const admin = require("firebase-admin");
+const { loadConfig } = require("../src/config");
+const { startServer } = require("../src/server");
+const { clearTokenCache } = require("../src/websocket-auth");
+
+function waitListening(server) {
+    return new Promise(resolve => server.on("listening", resolve));
+}
+
+function waitConnected(provider) {
+    return new Promise(resolve => {
+        provider.on("status", event => {
+            if (event.status === "connected") {
+                resolve();
+            }
+        });
+    });
+}
+
+describe("server integration: persistence and sync", () => {
+    afterEach(() => {
+        sinon.restore();
+        clearTokenCache();
+    });
+
+    it("persists document across restart", async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ydb-"));
+        const port = 13000 + Math.floor(Math.random() * 1000);
+        sinon.stub(admin.auth(), "verifyIdToken").resolves({ uid: "user", exp: Math.floor(Date.now() / 1000) + 60 });
+        const cfg = loadConfig({ PORT: String(port), LOG_LEVEL: "silent", LEVELDB_PATH: dir });
+        let { server } = startServer(cfg);
+        await waitListening(server);
+        const doc1 = new Y.Doc();
+        const provider1 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc1, {
+            params: { auth: "token" },
+            WebSocketPolyfill: WebSocket,
+        });
+        await waitConnected(provider1);
+        doc1.getText("t").insert(0, "hello");
+        await new Promise(r => setTimeout(r, 100));
+        provider1.destroy();
+        doc1.destroy();
+        server.close();
+
+        ({ server } = startServer(cfg));
+        await waitListening(server);
+        const doc2 = new Y.Doc();
+        const provider2 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc2, {
+            params: { auth: "token" },
+            WebSocketPolyfill: WebSocket,
+        });
+        await waitConnected(provider2);
+        expect(doc2.getText("t").toString()).to.equal("hello");
+        provider2.destroy();
+        doc2.destroy();
+        server.close();
+        await fs.remove(dir);
+    });
+
+    it("syncs updates between two clients", async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ydb-"));
+        const port = 14000 + Math.floor(Math.random() * 1000);
+        sinon
+            .stub(admin.auth(), "verifyIdToken")
+            .callsFake(token => Promise.resolve({ uid: token, exp: Math.floor(Date.now() / 1000) + 60 }));
+        const cfg = loadConfig({ PORT: String(port), LOG_LEVEL: "silent", LEVELDB_PATH: dir });
+        const { server } = startServer(cfg);
+        await waitListening(server);
+
+        const doc1 = new Y.Doc();
+        const provider1 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc1, {
+            params: { auth: "token1" },
+            WebSocketPolyfill: WebSocket,
+        });
+        const doc2 = new Y.Doc();
+        const provider2 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc2, {
+            params: { auth: "token2" },
+            WebSocketPolyfill: WebSocket,
+        });
+        await Promise.all([waitConnected(provider1), waitConnected(provider2)]);
+
+        doc1.getText("t").insert(0, "hi");
+        await new Promise(resolve => doc2.once("update", () => resolve()));
+        expect(doc2.getText("t").toString()).to.equal("hi");
+
+        provider1.destroy();
+        provider2.destroy();
+        doc1.destroy();
+        doc2.destroy();
+        server.close();
+        await fs.remove(dir);
+    });
+});


### PR DESCRIPTION
## Summary
- add server integration tests validating Yjs persistence and multi-client sync
- cover invalid token handling with Playwright spec
- document WebSocket server basic integration feature

## Testing
- `npx mocha tests/server-persistence-roundtrip.test.js tests/server-auth.test.js --timeout 10000` (fails: ERR_PACKAGE_PATH_NOT_EXPORTED)
- `npx tsc --noEmit --project tsconfig.json` (fails: Cannot find type definition file for '@playwright/test')
- `npm run test:e2e -- e2e/server/srv-websocket-basic-integration-9a4b1c2d.spec.ts` (fails: playwright: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b6509f20cc832fb7e50edd242b2d32

## Related Issues

Fixes #559
Related to #556
Related to #557
Related to #558
