### PR TITLE
[P1] Remove per-connection update listener to avoid leaking memory (#580)

### DIFF
--- a/client/e2e/new/wsl-update-listener-cleanup-6fe3a9c1.spec.ts
+++ b/client/e2e/new/wsl-update-listener-cleanup-6fe3a9c1.spec.ts
@@ -1,0 +1,23 @@
+/** @feature WSL-6fe3a9c1
+ *  Title   : Update listener cleanup on reconnect
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("Update listener cleanup", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("editing works after reload", async ({ page }) => {
+        const item = page.locator(".outliner-item").first();
+        await item.click();
+        await page.keyboard.type("abc");
+        await page.reload();
+        const item2 = page.locator(".outliner-item").first();
+        await item2.click();
+        await page.keyboard.type("d");
+        await expect(item2.locator(".item-text")).toHaveText("abcd");
+    });
+});

--- a/docs/client-features/wsl-update-listener-cleanup-6fe3a9c1.yaml
+++ b/docs/client-features/wsl-update-listener-cleanup-6fe3a9c1.yaml
@@ -1,0 +1,6 @@
+id: WSL-6fe3a9c1
+title: Remove per-connection update listener
+title-ja: 接続ごとの更新リスナーを削除
+status: implemented
+tests:
+- client/e2e/new/wsl-update-listener-cleanup-6fe3a9c1.spec.ts

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -6,6 +6,7 @@ import { type Config } from "./config";
 import { logger as defaultLogger } from "./logger";
 import { createPersistence, logTotalSize, warnIfRoomTooLarge } from "./persistence";
 import { parseRoom } from "./room-validator";
+import { addRoomSizeListener, removeRoomSizeListener } from "./update-listeners";
 import { extractAuthToken, verifyIdTokenCached } from "./websocket-auth";
 
 export function startServer(config: Config, logger = defaultLogger) {
@@ -34,17 +35,13 @@ export function startServer(config: Config, logger = defaultLogger) {
             }
             const docName = roomInfo.page ? `${roomInfo.project}/${roomInfo.page}` : roomInfo.project;
             logger.info({ event: "ws_connection_accepted", uid: decoded.uid, room: docName });
-            const warn = () =>
-                warnIfRoomTooLarge(
-                    persistence,
-                    docName,
-                    config.LEVELDB_ROOM_SIZE_WARN_MB * 1024 * 1024,
-                    logger,
-                );
-            const doc = await persistence.getYDoc(docName);
-            doc.on("update", warn);
-            await warn();
+            const limitBytes = config.LEVELDB_ROOM_SIZE_WARN_MB * 1024 * 1024;
+            await addRoomSizeListener(persistence, docName, limitBytes, logger);
+            await warnIfRoomTooLarge(persistence, docName, limitBytes, logger);
             setupWSConnection(ws, req, { docName, persistence });
+            ws.on("close", () => {
+                removeRoomSizeListener(persistence, docName).catch(() => undefined);
+            });
         } catch {
             logger.warn({ event: "ws_connection_denied", reason: "invalid_token" });
             ws.close(4001, "UNAUTHORIZED");

--- a/server/src/update-listeners.ts
+++ b/server/src/update-listeners.ts
@@ -1,0 +1,41 @@
+import type { Logger } from "pino";
+import type { LeveldbPersistence } from "y-leveldb";
+import { warnIfRoomTooLarge } from "./persistence";
+
+interface ListenerInfo {
+    warn: () => void;
+    count: number;
+}
+
+const listeners = new Map<string, ListenerInfo>();
+
+export async function addRoomSizeListener(
+    persistence: LeveldbPersistence,
+    docName: string,
+    limitBytes: number,
+    logger: Logger,
+): Promise<void> {
+    let info = listeners.get(docName);
+    if (!info) {
+        const doc = await persistence.getYDoc(docName);
+        const warn = () => warnIfRoomTooLarge(persistence, docName, limitBytes, logger);
+        doc.on("update", warn);
+        info = { warn, count: 0 };
+        listeners.set(docName, info);
+    }
+    info.count++;
+}
+
+export async function removeRoomSizeListener(
+    persistence: LeveldbPersistence,
+    docName: string,
+): Promise<void> {
+    const info = listeners.get(docName);
+    if (!info) return;
+    info.count--;
+    if (info.count <= 0) {
+        const doc = await persistence.getYDoc(docName);
+        doc.off("update", info.warn);
+        listeners.delete(docName);
+    }
+}

--- a/server/tests/server-update-listener.test.js
+++ b/server/tests/server-update-listener.test.js
@@ -1,0 +1,44 @@
+const { once } = require("events");
+const WebSocket = require("ws");
+require("ts-node/register");
+const admin = require("firebase-admin");
+const sinon = require("sinon");
+const { loadConfig } = require("../src/config");
+const { startServer } = require("../src/server");
+const persistenceModule = require("../src/persistence");
+
+function waitListening(server) {
+    return new Promise(resolve => server.on("listening", resolve));
+}
+
+describe("server update listener cleanup", () => {
+    afterEach(() => sinon.restore());
+
+    it("removes update listeners when connections close", async () => {
+        sinon.stub(admin.auth(), "verifyIdToken").resolves({ uid: "user", exp: Math.floor(Date.now() / 1000) + 60 });
+        const warnStub = sinon.stub(persistenceModule, "warnIfRoomTooLarge").resolves();
+        const cfg = loadConfig({ PORT: "12348", LOG_LEVEL: "silent", LEVELDB_ROOM_SIZE_WARN_MB: "0" });
+        const { server, persistence } = startServer(cfg);
+        await waitListening(server);
+        const url = `ws://localhost:${cfg.PORT}/projects/testproj?auth=token`;
+
+        const ws1 = new WebSocket(url);
+        await once(ws1, "open");
+        const ws2 = new WebSocket(url);
+        await once(ws2, "open");
+
+        const doc = await persistence.getYDoc("testproj");
+        doc.getArray("a").insert(0, ["1"]);
+        sinon.assert.calledOnce(warnStub);
+
+        ws1.close();
+        doc.getArray("a").insert(0, ["2"]);
+        sinon.assert.calledTwice(warnStub);
+
+        ws2.close();
+        doc.getArray("a").insert(0, ["3"]);
+        sinon.assert.calledTwice(warnStub);
+
+        server.close();
+    });
+});

--- a/server/tests/update-listeners.test.js
+++ b/server/tests/update-listeners.test.js
@@ -1,0 +1,27 @@
+require("ts-node/register");
+const { expect } = require("chai");
+const sinon = require("sinon");
+const Y = require("yjs");
+const { addRoomSizeListener, removeRoomSizeListener } = require("../src/update-listeners");
+
+describe("update-listeners", () => {
+    afterEach(() => sinon.restore());
+
+    it("adds and removes listeners based on connection count", async () => {
+        const doc = new Y.Doc();
+        const onSpy = sinon.spy(doc, "on");
+        const offSpy = sinon.spy(doc, "off");
+        const persistence = { getYDoc: sinon.stub().resolves(doc) };
+        const logger = { warn: () => undefined };
+
+        await addRoomSizeListener(persistence, "room", 0, logger);
+        await addRoomSizeListener(persistence, "room", 0, logger);
+        expect(onSpy.callCount).to.equal(1);
+
+        await removeRoomSizeListener(persistence, "room");
+        expect(offSpy.called).to.be.false;
+
+        await removeRoomSizeListener(persistence, "room");
+        expect(offSpy.callCount).to.equal(1);
+    });
+});


### PR DESCRIPTION
## Summary
- manage Y.Doc update listeners with reference counting to avoid leaks
- add server unit and integration tests for listener cleanup
- add E2E test and document feature

## Testing
- `npx mocha tests/update-listeners.test.js --timeout 10000`
- `npx mocha tests/server-update-listener.test.js --timeout 10000` *(failed: Package subpath './bin/utils' is not defined by "exports")*
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json` *(failed: 51 errors)*
- `cd client && npx tsc --noEmit --project tsconfig.json` *(failed: 53 errors)*
- `npm run test:e2e -- new/wsl-update-listener-cleanup-6fe3a9c1.spec.ts` *(failed: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b6513e547c832fbc70291de8d95609

## Related Issues

Fixes #580
