### PR TITLE
[#571] Server health & readiness probes – resolve merge conflicts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,3 @@
-# Firebase configuration
-VITE_FIREBASE_API_KEY=your-api-key
-VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
-VITE_FIREBASE_PROJECT_ID=your-project-id
-VITE_FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
-VITE_FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
-VITE_FIREBASE_APP_ID=your-app-id
-VITE_FIREBASE_MEASUREMENT_ID=your-measurement-id
-
-# Local host configuration
-VITE_HOST=localhost
-VITE_FIREBASE_EMULATOR_HOST=localhost
-VITE_FIRESTORE_EMULATOR_PORT=58080
-VITE_AUTH_EMULATOR_PORT=59099
-
-# Firebase service account
-FIREBASE_PROJECT_ID=your-project-id
-FIREBASE_PRIVATE_KEY_ID=your-private-key-id
-FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYour Private Key Here\n-----END PRIVATE KEY-----\n"
-FIREBASE_CLIENT_EMAIL=firebase-adminsdk-xxxx@your-project-id.iam.gserviceaccount.com
-FIREBASE_CLIENT_ID=your-client-id
-FIREBASE_CLIENT_CERT_URL=https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-xxxx%40your-project-id.iam.gserviceaccount.com
-
+PORT=3000
+YJS_DATA_DIR=/data/yjs
+HOSTNAME=example.com

--- a/client/e2e/d67-server-health-endpoint-d67f3a5b.spec.ts
+++ b/client/e2e/d67-server-health-endpoint-d67f3a5b.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+import { spawn } from "child_process";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+function startServer() {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const cwd = path.resolve(__dirname, "../../server");
+    const proc = spawn("node", ["-r", "ts-node/register", "src/index.ts"], {
+        cwd,
+        env: { ...process.env, PORT: "12349", LOG_LEVEL: "silent" },
+        stdio: "inherit",
+    });
+    return proc;
+}
+
+test("server health endpoint", async ({ request }) => {
+    const proc = startServer();
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    const res = await request.get("http://localhost:12349/");
+    expect(res.status()).toBe(200);
+    expect(await res.text()).toBe("ok");
+    proc.kill();
+});

--- a/client/e2e/server/srv-websocket-basic-integration-9a4b1c2d.spec.ts
+++ b/client/e2e/server/srv-websocket-basic-integration-9a4b1c2d.spec.ts
@@ -1,0 +1,24 @@
+/** @feature SRV-9a4b1c2d
+ *  Title   : WebSocket server basic integration
+ *  Source  : docs/client-features/srv-websocket-basic-integration-9a4b1c2d.yaml
+ */
+import { expect, test } from "@playwright/test";
+import WebSocket from "ws";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("WebSocket server authentication", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("invalid token is rejected", async () => {
+        await new Promise<void>(resolve => {
+            const port = process.env.TEST_API_PORT ?? "7091";
+            const ws = new WebSocket(`ws://localhost:${port}/projects/testproj?auth=bad`);
+            ws.on("close", code => {
+                expect(code).toBe(4001);
+                resolve();
+            });
+        });
+    });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+services:
+  server:
+    build: ./server
+    env_file: .env
+    ports:
+      - "${PORT:-3000}:${PORT:-3000}"
+    volumes:
+      - yjs-data:${YJS_DATA_DIR:-/data/yjs}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${PORT:-3000}/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    depends_on:
+      server:
+        condition: service_healthy
+    command: tunnel --no-autoupdate --url http://server:${PORT:-3000} --hostname ${HOSTNAME}
+    env_file: .env
+    volumes:
+      - ./cloudflared:/etc/cloudflared
+volumes:
+  yjs-data:

--- a/docs/client-features/d67-server-health-endpoint-d67f3a5b.yaml
+++ b/docs/client-features/d67-server-health-endpoint-d67f3a5b.yaml
@@ -1,0 +1,5 @@
+id: FTR-d67f3a5b
+title: Server health endpoint
+title-ja: サーバーヘルスエンドポイント
+tests:
+- client/e2e/d67-server-health-endpoint-d67f3a5b.spec.ts

--- a/docs/client-features/db5-leveldb-persistence-db5e7a9c.yaml
+++ b/docs/client-features/db5-leveldb-persistence-db5e7a9c.yaml
@@ -2,6 +2,7 @@ id: FTR-db5e7a9c
 slug: db5
 title: LevelDB persistence
 title-ja: LevelDB 永続化
-status: implemented
+category: server
+status: experimental
 tests:
 - client/e2e/new/db5-leveldb-persistence-db5e7a9c.spec.ts

--- a/docs/client-features/srv-websocket-basic-integration-9a4b1c2d.yaml
+++ b/docs/client-features/srv-websocket-basic-integration-9a4b1c2d.yaml
@@ -1,0 +1,10 @@
+id: SRV-9a4b1c2d
+title: WebSocket server basic integration
+title-ja: WebSocketサーバー基本統合テスト
+category: server
+status: experimental
+components:
+- server/src/server.ts
+tests:
+- client/e2e/server/srv-websocket-basic-integration-9a4b1c2d.spec.ts
+- server/tests/server-persistence-roundtrip.test.js

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine AS prod
+WORKDIR /app
+COPY --from=build /app/package.json /app/package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist ./dist
+RUN apk add --no-cache curl
+ENV NODE_ENV=production
+CMD ["node", "dist/index.js"]

--- a/server/README.md
+++ b/server/README.md
@@ -44,3 +44,12 @@ cp .env.example .env
 2. 「Your apps」セクションで「Add app」をクリック（Webアプリ）
 3. アプリを登録し、Firebaseの設定情報を取得
 4. クライアントプロジェクトの `.env` ファイルに以下の情報を設定:
+
+## Docker Quickstart
+
+```bash
+cp ../.env.example .env
+docker compose up --build
+```
+
+Expected output includes the y-websocket server listening log and a Cloudflare Tunnel URL for the configured hostname.

--- a/server/package.json
+++ b/server/package.json
@@ -43,6 +43,7 @@
     "scripts": {
         "create-test-user": "node utils/create-test-user.js",
         "dev": "ts-node src/index.ts",
+        "build": "tsc",
         "start": "node dist/index.js",
         "test": "bash ../scripts/run-server-tests.sh",
         "test:emulator-wait": "mocha tests/log-service-emulator-wait.test.js --timeout 10000"

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -12,5 +12,8 @@ const ConfigSchema = z.object({
 export type Config = z.infer<typeof ConfigSchema>;
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
+    if (env.YJS_DATA_DIR && !env.LEVELDB_PATH) {
+        env.LEVELDB_PATH = env.YJS_DATA_DIR;
+    }
     return ConfigSchema.parse(env);
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,6 +1,15 @@
 import admin from "firebase-admin";
 import http from "http";
 import { WebSocketServer } from "ws";
+// y-websocket utilities may not export setupWSConnection in all builds
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let setupWSConnection: any;
+try {
+    // @ts-ignore fallback for CommonJS build
+    setupWSConnection = require("y-websocket/bin/utils");
+} catch {
+    setupWSConnection = () => undefined;
+}
 import { type Config } from "./config";
 import { logger as defaultLogger } from "./logger";
 import { createPersistence, logTotalSize, warnIfRoomTooLarge } from "./persistence";
@@ -14,14 +23,6 @@ export function startServer(config: Config, logger = defaultLogger, autoReady = 
     };
     const roomCounts = new Map<string, number>();
     let openSockets = 0;
-    // Lazy load y-websocket setup, fallback to noop if unavailable
-    let setupWSConnection: any;
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        setupWSConnection = require("y-websocket/bin/utils");
-    } catch {
-        setupWSConnection = () => undefined;
-    }
     const server = http.createServer((req, res) => {
         if (req.method !== "GET") {
             res.writeHead(405).end();

--- a/server/tests/config.test.js
+++ b/server/tests/config.test.js
@@ -9,4 +9,8 @@ describe("config", () => {
         expect(cfg.LOG_LEVEL).to.equal("info");
         expect(cfg.ROOM_PREFIX_ENFORCE).to.be.false;
     });
+    it("uses YJS_DATA_DIR for LEVELDB_PATH", () => {
+        const cfg = loadConfig({ YJS_DATA_DIR: "/data" });
+        expect(cfg.LEVELDB_PATH).to.equal("/data");
+    });
 });

--- a/server/tests/health-endpoint.test.js
+++ b/server/tests/health-endpoint.test.js
@@ -1,0 +1,31 @@
+const { expect } = require("chai");
+require("ts-node/register");
+const http = require("http");
+const { loadConfig } = require("../src/config");
+const { startServer } = require("../src/server");
+
+function waitListening(server) {
+    return new Promise(resolve => server.on("listening", resolve));
+}
+
+function get(port) {
+    return new Promise((resolve, reject) => {
+        http.get(`http://localhost:${port}/`, res => {
+            let data = "";
+            res.on("data", chunk => data += chunk);
+            res.on("end", () => resolve({ status: res.statusCode, text: data }));
+        }).on("error", reject);
+    });
+}
+
+describe("health endpoint", () => {
+    it("returns ok", async () => {
+        const cfg = loadConfig({ PORT: "12347", LOG_LEVEL: "silent" });
+        const { server } = startServer(cfg);
+        await waitListening(server);
+        const { status, text } = await get(cfg.PORT);
+        expect(status).to.equal(200);
+        expect(text).to.equal("ok");
+        server.close();
+    });
+});

--- a/server/tests/server-persistence-roundtrip.test.js
+++ b/server/tests/server-persistence-roundtrip.test.js
@@ -1,0 +1,103 @@
+const { expect } = require("chai");
+const fs = require("fs-extra");
+const os = require("os");
+const path = require("path");
+const { once } = require("events");
+const WebSocket = require("ws");
+const Y = require("yjs");
+const { WebsocketProvider } = require("y-websocket");
+const sinon = require("sinon");
+require("ts-node/register");
+const admin = require("firebase-admin");
+const { loadConfig } = require("../src/config");
+const { startServer } = require("../src/server");
+const { clearTokenCache } = require("../src/websocket-auth");
+
+function waitListening(server) {
+    return new Promise(resolve => server.on("listening", resolve));
+}
+
+function waitConnected(provider) {
+    return new Promise(resolve => {
+        provider.on("status", event => {
+            if (event.status === "connected") {
+                resolve();
+            }
+        });
+    });
+}
+
+describe("server integration: persistence and sync", () => {
+    afterEach(() => {
+        sinon.restore();
+        clearTokenCache();
+    });
+
+    it("persists document across restart", async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ydb-"));
+        const port = 13000 + Math.floor(Math.random() * 1000);
+        sinon.stub(admin.auth(), "verifyIdToken").resolves({ uid: "user", exp: Math.floor(Date.now() / 1000) + 60 });
+        const cfg = loadConfig({ PORT: String(port), LOG_LEVEL: "silent", LEVELDB_PATH: dir });
+        let { server } = startServer(cfg);
+        await waitListening(server);
+        const doc1 = new Y.Doc();
+        const provider1 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc1, {
+            params: { auth: "token" },
+            WebSocketPolyfill: WebSocket,
+        });
+        await waitConnected(provider1);
+        doc1.getText("t").insert(0, "hello");
+        await new Promise(r => setTimeout(r, 100));
+        provider1.destroy();
+        doc1.destroy();
+        server.close();
+
+        ({ server } = startServer(cfg));
+        await waitListening(server);
+        const doc2 = new Y.Doc();
+        const provider2 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc2, {
+            params: { auth: "token" },
+            WebSocketPolyfill: WebSocket,
+        });
+        await waitConnected(provider2);
+        expect(doc2.getText("t").toString()).to.equal("hello");
+        provider2.destroy();
+        doc2.destroy();
+        server.close();
+        await fs.remove(dir);
+    });
+
+    it("syncs updates between two clients", async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ydb-"));
+        const port = 14000 + Math.floor(Math.random() * 1000);
+        sinon
+            .stub(admin.auth(), "verifyIdToken")
+            .callsFake(token => Promise.resolve({ uid: token, exp: Math.floor(Date.now() / 1000) + 60 }));
+        const cfg = loadConfig({ PORT: String(port), LOG_LEVEL: "silent", LEVELDB_PATH: dir });
+        const { server } = startServer(cfg);
+        await waitListening(server);
+
+        const doc1 = new Y.Doc();
+        const provider1 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc1, {
+            params: { auth: "token1" },
+            WebSocketPolyfill: WebSocket,
+        });
+        const doc2 = new Y.Doc();
+        const provider2 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc2, {
+            params: { auth: "token2" },
+            WebSocketPolyfill: WebSocket,
+        });
+        await Promise.all([waitConnected(provider1), waitConnected(provider2)]);
+
+        doc1.getText("t").insert(0, "hi");
+        await new Promise(resolve => doc2.once("update", () => resolve()));
+        expect(doc2.getText("t").toString()).to.equal("hi");
+
+        provider1.destroy();
+        provider2.destroy();
+        doc1.destroy();
+        doc2.destroy();
+        server.close();
+        await fs.remove(dir);
+    });
+});


### PR DESCRIPTION
## Summary
- merge latest base into feature branch
- keep LevelDB persistence doc categorized under server and marked experimental
- expose `/livez`, `/readyz`, and `/metrics` endpoints while loading `setupWSConnection` globally

## Testing
- `npx dprint fmt` *(fails: Error resolving plugin typescript-0.95.5.wasm)*
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json` *(fails: Cannot find type definition file for '@playwright/test')*
- `cd client && npx tsc --noEmit --project tsconfig.json` *(fails: Cannot read file '/workspace/outliner/client/.svelte-kit/tsconfig.json')*
- `cd client && npm run build` *(fails: paraglide-js not found)*
- `cd client && npm test` *(fails: dotenvx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6590a7edc832fbb7addfeb9fc6ad3

## Related Issues

Fixes #571
Related to #562
Related to #558
Related to #567
Related to #572
Related to #563
Related to #550
