### PR TITLE
Ensure server restarts await close and add WebSocket sync e2e test

### DIFF
--- a/client/e2e/server/srv-websocket-sync-updates-fd3a7b21.spec.ts
+++ b/client/e2e/server/srv-websocket-sync-updates-fd3a7b21.spec.ts
@@ -1,0 +1,42 @@
+/** @feature SRV-fd3a7b21
+ *  Title   : WebSocket sync updates between clients
+ *  Source  : docs/client-features/srv-websocket-sync-updates-fd3a7b21.yaml
+ */
+import { expect, test } from "@playwright/test";
+import WebSocket from "ws";
+import { WebsocketProvider } from "y-websocket";
+import * as Y from "yjs";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("WebSocket document synchronization", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("updates from one client propagate to another", async () => {
+        const port = process.env.TEST_API_PORT ?? "7091";
+        const doc1 = new Y.Doc();
+        const provider1 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc1, {
+            params: { auth: "token1" },
+            WebSocketPolyfill: WebSocket,
+        });
+        const doc2 = new Y.Doc();
+        const provider2 = new WebsocketProvider(`ws://localhost:${port}`, "projects/testproj", doc2, {
+            params: { auth: "token2" },
+            WebSocketPolyfill: WebSocket,
+        });
+        await Promise.all([
+            new Promise<void>(resolve => provider1.on("status", e => e.status === "connected" && resolve())),
+            new Promise<void>(resolve => provider2.on("status", e => e.status === "connected" && resolve())),
+        ]);
+
+        doc1.getText("t").insert(0, "hi");
+        await new Promise(resolve => doc2.once("update", () => resolve()));
+        expect(doc2.getText("t").toString()).toBe("hi");
+
+        provider1.destroy();
+        provider2.destroy();
+        doc1.destroy();
+        doc2.destroy();
+    });
+});

--- a/docs/client-features/srv-websocket-sync-updates-fd3a7b21.yaml
+++ b/docs/client-features/srv-websocket-sync-updates-fd3a7b21.yaml
@@ -1,0 +1,10 @@
+id: SRV-fd3a7b21
+title: WebSocket client synchronization
+title-ja: WebSocketクライアント間の同期
+category: server
+status: experimental
+components:
+- server/src/server.ts
+tests:
+- client/e2e/server/srv-websocket-sync-updates-fd3a7b21.spec.ts
+- server/tests/server-persistence-roundtrip.test.js

--- a/server/tests/server-persistence-roundtrip.test.js
+++ b/server/tests/server-persistence-roundtrip.test.js
@@ -51,6 +51,7 @@ describe("server integration: persistence and sync", () => {
         provider1.destroy();
         doc1.destroy();
         server.close();
+        await once(server, "close");
 
         ({ server } = startServer(cfg));
         await waitListening(server);
@@ -64,6 +65,7 @@ describe("server integration: persistence and sync", () => {
         provider2.destroy();
         doc2.destroy();
         server.close();
+        await once(server, "close");
         await fs.remove(dir);
     });
 


### PR DESCRIPTION
## Summary
- wait for server close before restarting to avoid race conditions
- add WebSocket sync E2E spec and accompanying feature doc

## Testing
- `npx tsc --noEmit --project e2e/tsconfig.json` *(fails: Cannot assign to 'after2' because it is a constant, etc.)*
- `npx tsc --noEmit --project tsconfig.json` *(fails: Argument of type 'Error' is not assignable to parameter of type 'undefined', etc.)*
- `npx mocha tests/server-persistence-roundtrip.test.js --timeout 10000` *(fails: Package subpath './bin/utils' is not defined by "exports"...)*
- `npm run test:e2e -- e2e/server/srv-websocket-sync-updates-fd3a7b21.spec.ts` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b65d3a1174832f96a282a6e4625ac9

## Related Issues

Related to #584
Related to #559
Related to #557
Related to #520
Related to #560
Related to #599
Related to #582
Related to #580
Related to #583
Related to #405
Related to #550
