### PR TITLE
chore: remove lock personality in service

### DIFF
--- a/server/systemd/outliner.service
+++ b/server/systemd/outliner.service
@@ -16,7 +16,6 @@ PrivateTmp=true
 PrivateDevices=yes
 ProtectSystem=strict
 ProtectHome=yes
-LockPersonality=yes
 ReadWritePaths=/srv/outliner
 
 [Install]


### PR DESCRIPTION
## Summary
- remove `LockPersonality` directive from systemd unit to avoid excessive sandboxing

## Testing
- `npx tsc --noEmit --project tsconfig.json` *(fails: numerous type errors)*
- `cd e2e && npx tsc --noEmit --project tsconfig.json` *(fails: missing type definitions and other errors)*
- `npx playwright test d67-server-health-endpoint-d67f3a5b.spec.ts --reporter=list` *(fails: No tests found)*
- `npm run build` *(warnings; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b65d7d7560832f8bb7d441b778e56e