### PR TITLE
fix: resolve README path in tunnel spec

### DIFF
--- a/client/e2e/ctd-cloudflare-tunnel-docs-8c6d1ad4.spec.ts
+++ b/client/e2e/ctd-cloudflare-tunnel-docs-8c6d1ad4.spec.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 
 test("Cloudflare Tunnel docs mention setup steps", async () => {
-    const readme = fs.readFileSync(path.resolve("server", "README.md"), "utf8");
+    const readme = fs.readFileSync(path.resolve("..", "server", "README.md"), "utf8");
     expect(readme).toContain("Cloudflare Tunnel Setup");
     expect(readme).toContain("cloudflared tunnel create");
 });


### PR DESCRIPTION
## Summary
- fix path to server README in Cloudflare Tunnel docs test

## Testing
- `npx dprint fmt`
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json` *(fails: Cannot find type definition file for '@playwright/test')*
- `cd client && npx tsc --noEmit --project tsconfig.json` *(fails: Cannot find type definition file for '@playwright/test')*
- `npm run build` *(fails: paraglide-js: not found)*
- `npm run test:e2e -- ./e2e/ctd-cloudflare-tunnel-docs-8c6d1ad4.spec.ts` *(fails: dotenvx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b661709368832f97863d65c595afb1

## Related Issues

Related to #591
Related to #574
Related to #564
Related to #596
Related to #581
Related to #573
