### PR TITLE
fix: avoid lingering metrics timer

### DIFF
--- a/server/src/metrics.ts
+++ b/server/src/metrics.ts
@@ -4,13 +4,15 @@ let totalMessages = 0;
 let currentSecondCount = 0;
 const history: number[] = [];
 
-setInterval(() => {
+const timer = setInterval(() => {
     history.push(currentSecondCount);
     if (history.length > 60) {
         history.shift();
     }
     currentSecondCount = 0;
 }, 1000);
+// Prevent the timer from keeping Node.js event loop alive during tests.
+timer.unref();
 
 export function recordMessage() {
     totalMessages++;
@@ -30,4 +32,8 @@ export function resetMetrics() {
     totalMessages = 0;
     currentSecondCount = 0;
     history.length = 0;
+}
+
+export function stopMetrics() {
+    clearInterval(timer);
 }


### PR DESCRIPTION
## Summary
- store metrics interval handle
- unref metrics timer and expose stopMetrics cleanup

## Testing
- `scripts/codex-setup.sh` *(fails: rm cannot remove .git/hooks/pre-push; install process aborted)*
- `cd server && npx mocha tests/metrics.test.js`
- `cd server && npx mocha tests/metrics-endpoint.test.js` *(terminated: process left open handles)*
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json` *(fails: missing type definitions)
- `cd client && npx tsc --noEmit --project tsconfig.json` *(fails: cannot read .svelte-kit tsconfig)
- `cd client && npm run build` *(fails: paraglide-js not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b66be6ed28832f8d7aab4fcc779946