### PR TITLE
Fix Codex setup script to run non-interactively

### DIFF
--- a/client/e2e/ws-connection-limit-3f7a0c9b.spec.ts
+++ b/client/e2e/ws-connection-limit-3f7a0c9b.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 import WebSocket from "ws";
-import { TestHelpers } from "./utils/TestHelpers";
+import { TestHelpers } from "./utils/testHelpers";
 
-test.beforeEach(async ({ page }) => {
-    await TestHelpers.prepareTestEnvironment(page);
+test.beforeEach(async ({ page }, testInfo) => {
+    await TestHelpers.prepareTestEnvironment(page, testInfo);
 });
 
 test("oversized websocket message closes connection", async () => {

--- a/scripts/codex-setup.sh
+++ b/scripts/codex-setup.sh
@@ -77,7 +77,7 @@ if [ "$SKIP_INSTALL" -eq 0 ]; then
 
   # Install Playwright browser (system dependencies should be handled by install_os_utilities)
   cd "${ROOT_DIR}/client"
-  npx -y playwright install chromium
+  npx --yes playwright install chromium
   cd "${ROOT_DIR}"
 
   # Ensure vitest and playwright packages are available for npm test

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -84,7 +84,11 @@ clear_log_files() {
 # Install npm dependencies if needed
 npm_ci_if_needed() {
   if [ ! -d node_modules ]; then
-    npm --proxy='' --https-proxy='' ci
+    if [ -f package-lock.json ]; then
+      npm --proxy='' --https-proxy='' ci
+    else
+      npm --proxy='' --https-proxy='' install
+    fi
   fi
 }
 
@@ -178,8 +182,8 @@ install_os_utilities() {
 
   # Install Playwright browser (system dependencies should be handled by install_os_utilities)
   cd "${ROOT_DIR}/client"
-  npx playwright install chromium || echo "Playwright install failed, continuing..."
-  npx playwright install-deps chromium || echo "Playwright deps install failed, continuing..."
+  npx --yes playwright install chromium || echo "Playwright install failed, continuing..."
+  npx --yes playwright install-deps chromium || echo "Playwright deps install failed, continuing..."
 
   cd "${ROOT_DIR}"
 }

--- a/scripts/tests/env-setup-script-caches-installation-edcef4b8.spec.ts
+++ b/scripts/tests/env-setup-script-caches-installation-edcef4b8.spec.ts
@@ -14,8 +14,7 @@ const repoRoot = path.resolve(__dirname, "../..");
 const setupScript = path.join(repoRoot, "scripts", "codex-setup.sh");
 const sentinel = path.join(repoRoot, ".codex-setup-installed");
 
-test.skip("setup script creates sentinel file", async () => {
-    // Skipped in Codex environment due to Playwright installation failure
+test("setup script creates sentinel file", async () => {
     if (fs.existsSync(sentinel)) fs.unlinkSync(sentinel);
     execSync(setupScript, {
         cwd: repoRoot,
@@ -29,8 +28,7 @@ test.skip("setup script creates sentinel file", async () => {
     expect(fs.existsSync(sentinel)).toBe(true);
 });
 
-test.skip("second run bypasses installation", async () => {
-    // Skipped in Codex environment due to Playwright installation failure
+test("second run bypasses installation", async () => {
     const output = execSync(setupScript + " 2>&1", {
         cwd: repoRoot,
         env: {


### PR DESCRIPTION
## Summary
- run Playwright install in `codex-setup.sh` with `--yes`
- avoid `npm ci` failure when `package-lock.json` is missing
- re-enable environment test for setup caching
- fix WebSocket limit E2E spec import and test setup

## Testing
- `npx dprint fmt`
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json`
- `cd client && npx tsc --noEmit --project tsconfig.json` *(fails: Argument of type 'Error' is not assignable to parameter of type 'undefined')*
- `cd client && npm run build` *(fails: Rollup failed to resolve import "y-indexeddb")*
- `cd scripts/tests && npx vitest run env-setup-script-caches-installation-edcef4b8.spec.ts` *(npm ci EUSAGE: missing package-lock)*


------
https://chatgpt.com/codex/tasks/task_e_68b6905d8104832fbb6b585d34ebc1de

## Related Issues

Fixes #605
Fixes #520
Fixes #521
Related to #534
Related to #184
Related to #588
Related to #378
Related to #607
Related to #581
Related to #516
Related to #514
Related to #490
Related to #612
Related to #519
Related to #518
Related to #602
Related to #558
Related to #206
Related to #198
Related to #211
Related to #21
Related to #492
Related to #494
Related to #176
Related to #172
Related to #267
Related to #442
Related to #441
