### PR TITLE
YJS-5: Presence UX (participants + cursors) on page (#613)

### DIFF
--- a/client/e2e/new/yjs-presence-avatars-9d5c942d.spec.ts
+++ b/client/e2e/new/yjs-presence-avatars-9d5c942d.spec.ts
@@ -1,0 +1,30 @@
+/** @feature YJS-9d5c942d
+ *  Title   : Show Yjs presence avatars
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test("shows avatars for two users", async ({ browser }, testInfo) => {
+    const context1 = await browser.newContext();
+    await context1.addInitScript(() => {
+        (window as any).__TEST_USER__ = { id: "user1", name: "User One" };
+    });
+    const page1 = await context1.newPage();
+    const ids = await TestHelpers.prepareTestEnvironment(page1, testInfo, ["first line"]);
+    const { projectName, pageName } = ids;
+    await page1.goto(`/${projectName}/${pageName}`);
+
+    const context2 = await browser.newContext();
+    await context2.addInitScript(() => {
+        (window as any).__TEST_USER__ = { id: "user2", name: "User Two" };
+    });
+    const page2 = await context2.newPage();
+    await page2.goto(`/${projectName}/${pageName}`);
+
+    const locator1 = page1.locator('[data-testid="presence-row"] .presence-avatar');
+    await expect(locator1).toHaveCount(2, { timeout: 10000 });
+
+    await context1.close();
+    await context2.close();
+});

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,7 +22,9 @@
                 "rrule": "^2.8.1",
                 "sql.js": "^1.13.0",
                 "uuid": "^11.1.0",
-                "wx-svelte-grid": "^2.2.0"
+                "wx-svelte-grid": "^2.2.0",
+                "y-protocols": "^1.0.6",
+                "yjs": "^13.6.27"
             },
             "devDependencies": {
                 "@dotenvx/dotenvx": "^1.48.1",
@@ -10147,6 +10149,16 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/isomorphic.js": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+            "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+            "license": "MIT",
+            "funding": {
+                "type": "GitHub Sponsors ❤",
+                "url": "https://github.com/sponsors/dmonad"
+            }
+        },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -10714,6 +10726,27 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lib0": {
+            "version": "0.2.114",
+            "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
+            "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+            "license": "MIT",
+            "dependencies": {
+                "isomorphic.js": "^0.2.4"
+            },
+            "bin": {
+                "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+                "0gentesthtml": "bin/gentesthtml.js",
+                "0serve": "bin/0serve.js"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "type": "GitHub Sponsors ❤",
+                "url": "https://github.com/sponsors/dmonad"
             }
         },
         "node_modules/lightningcss": {
@@ -15636,6 +15669,26 @@
                 "node": ">=0.4"
             }
         },
+        "node_modules/y-protocols": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+            "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+            "license": "MIT",
+            "dependencies": {
+                "lib0": "^0.2.85"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=8.0.0"
+            },
+            "funding": {
+                "type": "GitHub Sponsors ❤",
+                "url": "https://github.com/sponsors/dmonad"
+            },
+            "peerDependencies": {
+                "yjs": "^13.0.0"
+            }
+        },
         "node_modules/y18n": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
@@ -15762,6 +15815,23 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/yjs": {
+            "version": "13.6.27",
+            "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
+            "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+            "license": "MIT",
+            "dependencies": {
+                "lib0": "^0.2.99"
+            },
+            "engines": {
+                "node": ">=16.0.0",
+                "npm": ">=8.0.0"
+            },
+            "funding": {
+                "type": "GitHub Sponsors ❤",
+                "url": "https://github.com/sponsors/dmonad"
             }
         },
         "node_modules/yocto-queue": {

--- a/client/package.json
+++ b/client/package.json
@@ -103,6 +103,8 @@
         "rrule": "^2.8.1",
         "sql.js": "^1.13.0",
         "uuid": "^11.1.0",
-        "wx-svelte-grid": "^2.2.0"
+        "wx-svelte-grid": "^2.2.0",
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.27"
     }
 }

--- a/client/src/components/OutlinerBase.svelte
+++ b/client/src/components/OutlinerBase.svelte
@@ -8,6 +8,9 @@ import GlobalTextArea from "./GlobalTextArea.svelte";
 import OutlinerTree from "./OutlinerTree.svelte";
 import PresenceAvatars from "./PresenceAvatars.svelte";
 import SlashCommandPalette from "./SlashCommandPalette.svelte";
+import { onMount } from "svelte";
+import { userManager } from "../auth/UserManager";
+import { initYjsPresence } from "../lib/yjs/service";
 
 console.log("OutlinerBase imports completed");
 
@@ -37,6 +40,14 @@ console.log("OutlinerBase props received:", {
 });
 
 console.log("OutlinerBase script completed successfully");
+
+onMount(() => {
+    let user = userManager.getCurrentUser() || { id: "guest", name: "Guest" };
+    if (typeof window !== "undefined" && (window as any).__TEST_USER__) {
+        user = (window as any).__TEST_USER__;
+    }
+    initYjsPresence(`${projectName}/${pageName}`, { userId: user.id, userName: user.name });
+});
 </script>
 
 <div class="outliner-base" data-testid="outliner-base">

--- a/client/src/lib/yjs/service.ts
+++ b/client/src/lib/yjs/service.ts
@@ -1,0 +1,82 @@
+import * as awarenessProtocol from "y-protocols/awareness";
+import * as Y from "yjs";
+import { colorForUser, presenceStore, type PresenceUser } from "../../stores/PresenceStore.svelte";
+
+export class YjsPresenceService {
+    private doc: Y.Doc;
+    private awareness: awarenessProtocol.Awareness;
+    private channel: BroadcastChannel;
+    private clientUsers = new Map<number, string>();
+
+    constructor(room: string, user: { userId: string; userName: string; }) {
+        this.doc = new Y.Doc();
+        this.awareness = new awarenessProtocol.Awareness(this.doc);
+        this.channel = new BroadcastChannel(`yjs-${room}`);
+
+        this.channel.onmessage = (ev: MessageEvent) => {
+            const data = new Uint8Array(ev.data);
+            awarenessProtocol.applyAwarenessUpdate(this.awareness, data, "remote");
+        };
+
+        this.awareness.on("update", ({ added, updated, removed }, origin) => {
+            const states = this.awareness.getStates();
+            for (const clientId of added.concat(updated)) {
+                const state = states.get(clientId) as any;
+                const u = state?.user as PresenceUser | undefined;
+                if (u) {
+                    presenceStore.setUser(u);
+                    this.clientUsers.set(clientId, u.userId);
+                    if (state.cursor) {
+                        presenceStore.updateCursor(u.userId, state.cursor);
+                    }
+                }
+            }
+            for (const clientId of removed) {
+                const uid = this.clientUsers.get(clientId);
+                if (uid) {
+                    presenceStore.removeUser(uid);
+                    this.clientUsers.delete(clientId);
+                }
+            }
+            if (origin !== "remote") {
+                const changed = added.concat(updated).concat(removed);
+                const update = awarenessProtocol.encodeAwarenessUpdate(this.awareness, changed);
+                this.channel.postMessage(update);
+            }
+        });
+
+        this.awareness.setLocalStateField("user", {
+            userId: user.userId,
+            userName: user.userName,
+            color: colorForUser(user.userId),
+        } as PresenceUser);
+    }
+
+    updateCursor(pos: { left: number; top: number; }) {
+        this.awareness.setLocalStateField("cursor", pos);
+        const state = this.awareness.getLocalState() as any;
+        const u = state?.user as PresenceUser | undefined;
+        if (u) {
+            presenceStore.updateCursor(u.userId, pos);
+        }
+    }
+
+    destroy() {
+        this.awareness.destroy();
+        this.channel.close();
+        this.doc.destroy();
+    }
+}
+
+let service: YjsPresenceService | null = null;
+
+export function initYjsPresence(room: string, user: { userId: string; userName: string; }) {
+    if (!service) {
+        service = new YjsPresenceService(room, user);
+    }
+    return service;
+}
+
+export function getYjsService() {
+    return service;
+}

--- a/client/src/stores/PresenceStore.svelte.ts
+++ b/client/src/stores/PresenceStore.svelte.ts
@@ -2,6 +2,7 @@ export interface PresenceUser {
     userId: string;
     userName: string;
     color: string;
+    cursor?: { left: number; top: number; };
 }
 
 export class PresenceStore {
@@ -14,6 +15,13 @@ export class PresenceStore {
     removeUser(userId: string) {
         const { [userId]: _removed, ...rest } = this.users;
         this.users = rest;
+    }
+
+    updateCursor(userId: string, pos: { left: number; top: number; }) {
+        const user = this.users[userId];
+        if (user) {
+            this.users = { ...this.users, [userId]: { ...user, cursor: pos } };
+        }
     }
 
     getUsers(): PresenceUser[] {

--- a/client/src/tests/integration/yjsPresence.integration.spec.ts
+++ b/client/src/tests/integration/yjsPresence.integration.spec.ts
@@ -1,0 +1,19 @@
+import { BroadcastChannel } from "node:worker_threads";
+import { describe, expect, it } from "vitest";
+import { YjsPresenceService } from "../../lib/yjs/service";
+import { presenceStore } from "../../stores/PresenceStore.svelte";
+
+(globalThis as any).BroadcastChannel = BroadcastChannel;
+
+describe("yjs presence integration", () => {
+    it("removes users when disconnected", async () => {
+        presenceStore.users = {} as any;
+        const s1 = new YjsPresenceService("room2", { userId: "u1", userName: "U1" });
+        const s2 = new YjsPresenceService("room2", { userId: "u2", userName: "U2" });
+        await new Promise(r => setTimeout(r, 50));
+        s2.destroy();
+        await new Promise(r => setTimeout(r, 100));
+        expect(presenceStore.users["u2"]).toBeUndefined();
+        s1.destroy();
+    });
+});

--- a/client/src/tests/yjsService.test.ts
+++ b/client/src/tests/yjsService.test.ts
@@ -1,0 +1,17 @@
+import { BroadcastChannel } from "node:worker_threads";
+import { describe, expect, it } from "vitest";
+import { initYjsPresence, YjsPresenceService } from "../lib/yjs/service";
+import { presenceStore } from "../stores/PresenceStore.svelte";
+
+(globalThis as any).BroadcastChannel = BroadcastChannel;
+
+describe("yjs presence service", () => {
+    it("shares presence across instances", async () => {
+        presenceStore.users = {} as any;
+        initYjsPresence("room1", { userId: "u1", userName: "User1" });
+        new YjsPresenceService("room1", { userId: "u2", userName: "User2" });
+        await new Promise(r => setTimeout(r, 50));
+        expect(presenceStore.users["u1"]).toBeDefined();
+        expect(presenceStore.users["u2"]).toBeDefined();
+    });
+});

--- a/docs/client-features/yjs-presence-avatars-9d5c942d.yaml
+++ b/docs/client-features/yjs-presence-avatars-9d5c942d.yaml
@@ -1,0 +1,14 @@
+id: YJS-9d5c942d
+title: Show Yjs presence avatars
+title-ja: Yjsプレゼンスアバターの表示
+category: collaboration
+description: Display active users with avatars synchronized via Yjs awareness.
+status: experimental
+acceptance:
+- Avatars appear for all connected clients
+- Avatars update when users join or leave
+- Presence propagates via Yjs awareness
+tests:
+- client/e2e/new/yjs-presence-avatars-9d5c942d.spec.ts
+- client/src/tests/integration/yjsPresence.integration.spec.ts
+- client/src/tests/yjsService.test.ts


### PR DESCRIPTION
## Summary
- add YjsPresenceService using awareness and BroadcastChannel
- initialize Yjs presence in OutlinerBase and extend PresenceStore
- document and test avatar presence via unit/integration/E2E specs

## Testing
- `npx tsc --noEmit --project tsconfig.json` *(fails: Cannot read file '/workspace/outliner/client/.svelte-kit/tsconfig.json')*
- `npm run test:unit -- src/tests/yjsService.test.ts`
- `npm run test:integration -- src/tests/integration/yjsPresence.integration.spec.ts`
- `npm run test:e2e -- e2e/new/yjs-presence-avatars-9d5c942d.spec.ts` *(fails: browserType.launch: Executable doesn't exist)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6db5dde24832fbaeaeb17abe900a6

## Related Issues

Fixes #613
Related to #537
Related to #609
