### PR TITLE
YJS-5: Presence UX (participants + cursors) on page #613

### DIFF
--- a/client/e2e/new/prs-cursor-sync-4d2e1b6a.spec.ts
+++ b/client/e2e/new/prs-cursor-sync-4d2e1b6a.spec.ts
@@ -1,0 +1,34 @@
+/** @feature PRS-4d2e1b6a
+ *  Title   : Yjs cursor presence sync
+ *  Source  : docs/client-features/prs-yjs-presence-cursors-4d2e1b6a.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("PRS-4d2e1b6a: cursor presence", () => {
+    test("propagates cursor between clients", async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+        const projectId = `p-${Date.now()}`;
+        const received = await page.evaluate(async pid => {
+            // @ts-ignore
+            const { createProjectConnection } = await import("/src/lib/yjs/connection.ts");
+            // @ts-ignore
+            const { Project } = await import("/src/schema/app-schema.ts");
+            const c1 = await createProjectConnection(pid);
+            const c2 = await createProjectConnection(pid);
+            const project = Project.fromDoc(c1.doc);
+            const p = project.addPage("P", "u1");
+            await new Promise(r => setTimeout(r, 100));
+            const pc1 = c1.getPageConnection(p.id)!;
+            const pc2 = c2.getPageConnection(p.id)!;
+            pc1.awareness.setLocalState({
+                user: { userId: "u1", name: "A" },
+                presence: { cursor: { itemId: "root", offset: 0 } },
+            });
+            await new Promise(r => setTimeout(r, 500));
+            const states = pc2.awareness.getStates();
+            return Array.from(states.values()).some((s: any) => s.presence?.cursor?.itemId === "root");
+        }, projectId);
+        expect(received).toBe(true);
+    });
+});

--- a/client/src/components/EditorOverlay.svelte
+++ b/client/src/components/EditorOverlay.svelte
@@ -2,6 +2,7 @@
 import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 import type { CursorPosition, SelectionRange } from '../stores/EditorOverlayStore.svelte';
 import { editorOverlayStore as store } from '../stores/EditorOverlayStore.svelte';
+import { presenceStore } from '../stores/PresenceStore.svelte';
 
 // store API (関数のみ)
 const { stopCursorBlink } = store;
@@ -951,7 +952,7 @@ function handlePaste(event: ClipboardEvent) {
                     left: {cursorPos.left}px;
                     top: {cursorPos.top}px;
                     height: {isPageTitle ? '1.5em' : positionMap[cursor.itemId]?.lineHeight || '1.2em'};
-                    background-color: {cursor.color || '#0078d7'};
+                    background-color: {cursor.color || presenceStore.users[cursor.userId || '']?.color || '#0078d7'};
                     pointer-events: none;
                 "
                 title={cursor.userName || ''}

--- a/client/src/components/PresenceAvatars.svelte
+++ b/client/src/components/PresenceAvatars.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { presenceStore } from "../stores/PresenceStore.svelte";
 
-// プレゼンスストアのusersオブジェクトを直接監視
-let users = $derived(Object.values(presenceStore.users));
+// プレゼンスストアのユーザー一覧を取得
+let users = $derived(presenceStore.getUsers());
 </script>
 <div class="presence-row" data-testid="presence-row">
   {#each users as u (u.userId)}

--- a/client/src/lib/yjs/connection.ts
+++ b/client/src/lib/yjs/connection.ts
@@ -4,6 +4,7 @@ import { WebsocketProvider } from "y-websocket";
 import * as Y from "yjs";
 import { userManager } from "../../auth/UserManager";
 import { pageRoomPath, projectRoomPath } from "./roomPath";
+import { yjsService } from "./service";
 import { attachTokenRefresh } from "./tokenRefresh";
 
 export type PageConnection = {
@@ -65,8 +66,12 @@ export async function connectPageDoc(doc: Y.Doc, projectId: string, pageId: stri
             color: undefined,
         });
     }
+    const unbind = yjsService.bindPagePresence(awareness);
     const unsub = attachTokenRefresh(provider);
     const dispose = () => {
+        try {
+            unbind();
+        } catch {}
         try {
             unsub();
         } catch {}
@@ -101,6 +106,7 @@ export async function createProjectConnection(projectId: string): Promise<Projec
             color: undefined,
         });
     }
+    const unbind = yjsService.bindProjectPresence(awareness);
 
     // Refresh auth param on token refresh
     const unsub = attachTokenRefresh(provider);
@@ -119,6 +125,9 @@ export async function createProjectConnection(projectId: string): Promise<Projec
     });
 
     const dispose = () => {
+        try {
+            unbind();
+        } catch {}
         try {
             unsub();
         } catch {}

--- a/client/src/tests/integration/yjs/presence-cursor-3a9f5b2c.integration.spec.ts
+++ b/client/src/tests/integration/yjs/presence-cursor-3a9f5b2c.integration.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { createProjectConnection } from "../../../lib/yjs/connection";
+import { Project } from "../../../schema/app-schema";
+
+describe("yjs presence", () => {
+    it("propagates cursor between clients", async () => {
+        const projectId = `p-${Date.now()}`;
+        const c1 = await createProjectConnection(projectId);
+        const c2 = await createProjectConnection(projectId);
+        const project = Project.fromDoc(c1.doc);
+        const page = project.addPage("P1", "u1");
+        await new Promise(r => setTimeout(r, 100));
+        const p1c1 = c1.getPageConnection(page.id)!;
+        const p1c2 = c2.getPageConnection(page.id)!;
+        p1c1.awareness.setLocalState({
+            user: { userId: "u1", name: "A" },
+            presence: { cursor: { itemId: "root", offset: 0 } },
+        });
+        await new Promise(r => setTimeout(r, 500));
+        const states = p1c2.awareness.getStates();
+        const received = Array.from(states.values()).some(s => s.presence?.cursor?.itemId === "root");
+        expect(received).toBe(true);
+        c1.dispose();
+        c2.dispose();
+    });
+});

--- a/client/src/types/y-protocols.d.ts
+++ b/client/src/types/y-protocols.d.ts
@@ -5,5 +5,6 @@ declare module "y-protocols/awareness" {
         setLocalStateField(field: string, value: any): void;
         on(event: string, cb: (...args: any[]) => void): void;
         off(event: string, cb: (...args: any[]) => void): void;
+        getStates(): Map<number, any>;
     }
 }

--- a/docs/client-features/prs-yjs-presence-cursors-4d2e1b6a.yaml
+++ b/docs/client-features/prs-yjs-presence-cursors-4d2e1b6a.yaml
@@ -1,0 +1,8 @@
+id: PRS-4d2e1b6a
+title: Yjs cursor presence sync
+title-ja: Yjsカーソルプレゼンス同期
+description: Sync cursors via Yjs awareness and show remote avatars.
+category: yjs
+status: experimental
+tests:
+- client/e2e/new/prs-cursor-sync-4d2e1b6a.spec.ts

--- a/docs/client-features/yjs-outliner-yjs-migration-c7f9e2a1.yaml
+++ b/docs/client-features/yjs-outliner-yjs-migration-c7f9e2a1.yaml
@@ -2,8 +2,10 @@ id: YJS-c7f9e2a1
 title: Use yjsService in Outliner components
 title-ja: Outliner コンポーネントで yjsService を使用
 status: experimental
-spec: |
-  OutlinerTree, OutlinerItem, and Cursor remove fluidStore dependencies and rely on yjsService.
+spec: 'OutlinerTree, OutlinerItem, and Cursor remove fluidStore dependencies and rely on yjsService.
+
   User identity comes from UserManager.
+
+  '
 tests:
-  - client/src/tests/unit/cursor-is-page-item.spec.ts
+- client/src/tests/unit/cursor-is-page-item.spec.ts


### PR DESCRIPTION
## Summary
- sync Yjs awareness to presenceStore and editor overlay
- show remote user colors in cursor rendering
- add awareness presence tests and docs

## Testing
- `npm run test:unit -- src/lib/yjs/service.test.ts`
- `npm run test:integration -- src/tests/integration/yjs/presence-cursor-3a9f5b2c.integration.spec.ts` (fails: No Firebase ID token available)
- `npm run test:e2e -- e2e/new/prs-cursor-sync-4d2e1b6a.spec.ts` (fails: connection refused)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6e5e768d0832fba25afc60b1ae756

## Related Issues

Fixes #613
Related to #624
Related to #537
Related to #610
Related to #619
Related to #621
Related to #497
Related to #516
Related to #293
Related to #320
