### PR TITLE
YJS-4: Port treeValidation utils and add collaboration E2E (#612)

### DIFF
--- a/client/e2e/helpers.ts
+++ b/client/e2e/helpers.ts
@@ -1,6 +1,27 @@
 import type { Page } from "@playwright/test";
 
 /**
+ * 指定数のアウトライナーアイテムが表示されるまで待機
+ */
+export async function waitForOutlinerItems(page: Page, count: number, timeout = 10000): Promise<void> {
+    await page.waitForFunction(
+        (expected) => document.querySelectorAll(".outliner-item").length >= expected,
+        count,
+        { timeout },
+    );
+}
+
+/**
+ * アウトライナーアイテム数が不足していれば追加描画を待機
+ */
+export async function ensureOutlinerItemCount(page: Page, count: number, timeout = 10000): Promise<void> {
+    const current = await page.locator(".outliner-item").count();
+    if (current < count) {
+        await waitForOutlinerItems(page, count, timeout);
+    }
+}
+
+/**
  * カーソルが表示されるのを待つ
  * @param page Playwrightのページオブジェクト
  * @param timeout タイムアウト時間（ミリ秒）
@@ -54,6 +75,8 @@ declare global {
         mockFluidToken?: { token: string; user: { id: string; name: string; }; };
         getFluidTreeDebugData?: () => any;
         getFluidTreePathData?: (path?: string) => any;
+        getYjsTreeDebugData?: () => any;
+        getYjsTreePathData?: (path?: string) => any;
         getCursorDebugData?: () => any;
         getCursorPathData?: (path?: string) => any;
         fluidServerPort?: number;

--- a/client/e2e/new/col-typing-sync-a8219d57.spec.ts
+++ b/client/e2e/new/col-typing-sync-a8219d57.spec.ts
@@ -1,0 +1,23 @@
+/** @feature COL-a8219d57
+ *  Title   : Yjs collaboration typing sync
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test("typing sync between two browsers", async ({ browser }, testInfo) => {
+    const context1 = await browser.newContext();
+    const page1 = await context1.newPage();
+    const { projectName, pageName } = await TestHelpers.prepareTestEnvironment(page1, testInfo);
+    await page1.goto(`/${projectName}/${pageName}`);
+
+    const context2 = await browser.newContext();
+    const page2 = await context2.newPage();
+    await TestHelpers.prepareTestEnvironment(page2, testInfo);
+    await page2.goto(`/${projectName}/${pageName}`);
+
+    await page1.locator(".outliner-item .item-text").first().click();
+    await page1.keyboard.type("hello");
+    await page1.waitForTimeout(500);
+
+    await expect(page2.locator(".outliner-item .item-text").first()).toContainText("hello");
+});

--- a/client/e2e/utils/testHelpers.ts
+++ b/client/e2e/utils/testHelpers.ts
@@ -409,6 +409,10 @@ export class TestHelpers {
                     return { error: error instanceof Error ? error.message : "Unknown error" };
                 }
             };
+
+            // Yjs helpers mirror the Fluid versions
+            window.getYjsTreeDebugData = window.getFluidTreeDebugData;
+            window.getYjsTreePathData = window.getFluidTreePathData;
         });
     }
 

--- a/client/e2e/utils/tree-validator-examples.ts
+++ b/client/e2e/utils/tree-validator-examples.ts
@@ -66,6 +66,9 @@ export async function pathValidationExample(page: Page): Promise<void> {
 
     // 存在しないパスの検証
     const nonExistentPath = await page.evaluate(() => {
+        if (typeof window.getYjsTreePathData === "function") {
+            return window.getYjsTreePathData("items.0.nonexistent");
+        }
         if (typeof window.getFluidTreePathData === "function") {
             return window.getFluidTreePathData("items.0.nonexistent");
         }

--- a/client/e2e/utils/tree-validator-usage.md
+++ b/client/e2e/utils/tree-validator-usage.md
@@ -167,14 +167,15 @@ try {
 
 ## ブラウザでのデバッグ
 
-ブラウザのコンソールからもSharedTreeのデータを取得できます。
+ブラウザのコンソールからもYjsツリーのデータを取得できます。
 
 ```javascript
-// コンソールからSharedTreeのデータを取得
-const treeData = window.getFluidTreeDebugData();
+// コンソールからツリーデータを取得
+const treeData = window.getYjsTreeDebugData?.() ?? window.getFluidTreeDebugData?.();
 console.log(treeData);
 
 // 特定のパスのデータを取得
-const firstItemText = window.getFluidTreePathData("items.0.text");
+const firstItemText = window.getYjsTreePathData?.("items.0.text")
+    ?? window.getFluidTreePathData?.("items.0.text");
 console.log(firstItemText);
 ```

--- a/client/e2e/utils/treeValidation.ts
+++ b/client/e2e/utils/treeValidation.ts
@@ -11,7 +11,10 @@ export class TreeValidator {
     static async getTreeData(page: Page): Promise<any> {
         return page.evaluate(() => {
             // デバッグ関数の存在確認
-            if (typeof window.getFluidTreeDebugData !== "function") {
+            if (
+                typeof window.getYjsTreeDebugData !== "function"
+                && typeof window.getFluidTreeDebugData !== "function"
+            ) {
                 console.warn("getFluidTreeDebugData function is not available");
                 // フォールバック: AppStoreから基本的なデータを取得
                 const appStore = (window as any).appStore;
@@ -45,6 +48,9 @@ export class TreeValidator {
                 throw new Error("FluidClient is not initialized and no fallback data found");
             }
 
+            if (typeof window.getYjsTreeDebugData === "function") {
+                return window.getYjsTreeDebugData();
+            }
             return window.getFluidTreeDebugData();
         });
     }
@@ -76,7 +82,10 @@ export class TreeValidator {
     static async getTreePathData(page: Page, path?: string): Promise<any> {
         return page.evaluate(async path => {
             // デバッグ関数の存在確認
-            if (typeof window.getFluidTreePathData !== "function") {
+            if (
+                typeof window.getYjsTreePathData !== "function"
+                && typeof window.getFluidTreePathData !== "function"
+            ) {
                 console.warn("getFluidTreePathData function is not available");
                 // フォールバック: 基本的なパス解決を実装
                 if (!path) return undefined;
@@ -138,6 +147,9 @@ export class TreeValidator {
                 return undefined;
             }
 
+            if (typeof window.getYjsTreePathData === "function") {
+                return window.getYjsTreePathData(path);
+            }
             return window.getFluidTreePathData(path);
         }, path);
     }
@@ -382,6 +394,8 @@ declare global {
         mockUser?: { id: string; name: string; email?: string; };
         mockFluidToken?: { token: string; user: { id: string; name: string; }; };
         getFluidTreeDebugData?: () => any;
+        getYjsTreeDebugData?: () => any;
+        getYjsTreePathData?: (path?: string) => any;
         fluidServerPort?: number;
     }
 }

--- a/client/src/fluid/fluidClient.ts
+++ b/client/src/fluid/fluidClient.ts
@@ -289,7 +289,7 @@ export class FluidClient {
 
         const result: ItemData = {
             id: item.id,
-            text: item.text,
+            text: item.text?.toString() ?? "",
             author: item.author,
             votes: [...item.votes],
             created: item.created,

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -16,4 +16,6 @@ interface Window {
     _alertMessage?: string;
     __FLUID_CLIENT__?: any;
     getFluidTreeDebugData?: () => any;
+    getYjsTreeDebugData?: () => any;
+    getYjsTreePathData?: (path?: string) => any;
 }

--- a/docs/client-features/col-typing-sync-a8219d57.yaml
+++ b/docs/client-features/col-typing-sync-a8219d57.yaml
@@ -1,0 +1,6 @@
+id: COL-a8219d57
+title: Yjs collaboration typing sync
+title-ja: Yjs コラボレーションのタイピング同期
+status: experimental
+tests:
+- client/e2e/new/col-typing-sync-a8219d57.spec.ts

--- a/docs/client-features/yjs-outliner-yjs-migration-c7f9e2a1.yaml
+++ b/docs/client-features/yjs-outliner-yjs-migration-c7f9e2a1.yaml
@@ -2,8 +2,10 @@ id: YJS-c7f9e2a1
 title: Use yjsService in Outliner components
 title-ja: Outliner コンポーネントで yjsService を使用
 status: experimental
-spec: |
-  OutlinerTree, OutlinerItem, and Cursor remove fluidStore dependencies and rely on yjsService.
+spec: 'OutlinerTree, OutlinerItem, and Cursor remove fluidStore dependencies and rely on yjsService.
+
   User identity comes from UserManager.
+
+  '
 tests:
-  - client/src/tests/unit/cursor-is-page-item.spec.ts
+- client/src/tests/unit/cursor-is-page-item.spec.ts

--- a/scripts/codex-setup.sh
+++ b/scripts/codex-setup.sh
@@ -121,6 +121,14 @@ else
   fi
 fi
 
+# Ensure essential client CLI tools are available
+cd "${ROOT_DIR}/client"
+if [ ! -f node_modules/.bin/paraglide-js ] || [ ! -f node_modules/.bin/dotenvx ]; then
+  echo "Missing client CLI tools; reinstalling client dependencies..."
+  npm --proxy='' --https-proxy='' ci
+fi
+cd "${ROOT_DIR}"
+
 # Stop any existing servers to ensure clean restart
 echo "Stopping any existing servers..."
 kill_ports || echo "Warning: Some ports could not be killed"

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -409,7 +409,9 @@ start_yjs_server() {
   fi
   # Build TypeScript and start compiled server to avoid ts-node dependency issues
   echo "Building server..."
-  npm run build --silent || npm run build
+  if npm run | grep -q " build"; then
+    npm run build --silent || npm run build
+  fi
   echo "Launching compiled server..."
   npx dotenvx run --env-file=.env.test -- bash -lc "PORT=${TEST_YJS_PORT} LEVELDB_PATH='${ROOT_DIR}/yjs-data' npm start --silent" \
     </dev/null > "${ROOT_DIR}/server/logs/yjs-websocket.log" 2>&1 &


### PR DESCRIPTION
## Summary
- ensure codex setup reinstalls client CLI tools
- guard Yjs server build step when package script is missing
- add helper utilities for waiting on outliner items and update feature docs

## Testing
- `scripts/codex-setup.sh`
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json`
- `cd client && npx tsc --noEmit --project tsconfig.json` *(fails: Argument of type 'Error' is not assignable to parameter of type 'undefined')*
- `cd client && npm run build`
- `cd client && npm run test:e2e -- e2e/utils/tree-validation.spec.ts` *(fails: 5 failing tests)*
- `cd client && npm run test:e2e -- e2e/new/col-typing-sync-a8219d57.spec.ts` *(fails: page.waitForTimeout: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e59cd128832f884ea81188b93490

## Related Issues

Related to #612
