### PR TITLE
Fix Firestore import for build and add Firestore store E2E test

### DIFF
--- a/client/e2e/core/fse-firestore-store-exposed-9d3f2b1c.spec.ts
+++ b/client/e2e/core/fse-firestore-store-exposed-9d3f2b1c.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("FSE-9d3f2b1c: Firestore store exposes itself to window", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("firestoreStore is attached to window", async ({ page }) => {
+        await page.goto("/");
+        const exists = await page.evaluate(() => typeof (window as any).__FIRESTORE_STORE__ !== "undefined");
+        expect(exists).toBe(true);
+    });
+});
+import "../utils/registerAfterEachSnapshot";

--- a/client/src/routes/min/+page.svelte
+++ b/client/src/routes/min/+page.svelte
@@ -26,7 +26,8 @@ const firebaseConfig = {
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
-const db = getFirestore(app);
+// Initialize Firestore without storing the instance
+getFirestore(app);
 const functions = getFunctions(app);
 
 const auth = getAuth(app);

--- a/client/src/stores/firestoreStore.svelte.ts
+++ b/client/src/stores/firestoreStore.svelte.ts
@@ -1,5 +1,5 @@
 import { type FirebaseApp } from "firebase/app";
-import { connectFirestoreEmulator, doc, Firestore, getDoc, getFirestore, onSnapshot } from "firebase/firestore";
+import { connectFirestoreEmulator, doc, type Firestore, getDoc, getFirestore, onSnapshot } from "firebase/firestore";
 
 import { userManager } from "../auth/UserManager";
 import { getFirebaseApp } from "../lib/firebase-app";

--- a/docs/client-features/fse-firestore-store-exposed-9d3f2b1c.yaml
+++ b/docs/client-features/fse-firestore-store-exposed-9d3f2b1c.yaml
@@ -1,0 +1,7 @@
+id: FSE-9d3f2b1c
+title: Firestore store exposed on window
+title-ja: windowに公開されるFirestoreストア
+description: Firestoreストアがテスト環境でwindowオブジェクトに公開されることを確認する。
+status: implemented
+tests:
+  - client/e2e/core/fse-firestore-store-exposed-9d3f2b1c.spec.ts


### PR DESCRIPTION
## Summary
- import Firestore as a type and avoid unused instance in min page so build succeeds
- document and add E2E test verifying Firestore store is exposed on window in tests

## Testing
- `npx tsc --noEmit --project tsconfig.json` *(fails: Cannot find name 'service', etc.)*
- `npm run build`
- `NODE_ENV=test TEST_ENV=localhost npx playwright test e2e/core/fse-firestore-store-exposed-9d3f2b1c.spec.ts` *(fails: host system missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc92eca4c832fa56cec14db69aba4