### PR TITLE
Refactor integration tests to target OutlinerBase component

### DIFF
--- a/client/src/components/OutlinerTree.svelte
+++ b/client/src/components/OutlinerTree.svelte
@@ -10,6 +10,7 @@ import { editorOverlayStore } from "../stores/EditorOverlayStore.svelte";
 import type { DisplayItem } from "../stores/OutlinerViewModel";
 import { OutlinerViewModel } from "../stores/OutlinerViewModel";
 import { YjsSubscriber } from "../stores/YjsSubscriber";
+import { userManager } from "../auth/UserManager";
 import EditorOverlay from "./EditorOverlay.svelte";
 import OutlinerItem from "./OutlinerItem.svelte";
 
@@ -39,7 +40,8 @@ interface Props {
 
 let { pageItem, projectName, pageName, isReadOnly = false, onEdit }: Props = $props();
 
-let currentUser = $state('anonymous');
+let currentUser = $state("anonymous");
+let unsubscribeUser: (() => void) | null = null;
 
 // ビューストアを作成
 const viewModel = new OutlinerViewModel();
@@ -130,7 +132,10 @@ function handleItemResize(event: CustomEvent) {
 }
 
 onMount(() => {
-    currentUser = "local";
+    currentUser = userManager.getCurrentUser()?.id ?? "anonymous";
+    unsubscribeUser = userManager.addEventListener((result) => {
+        currentUser = result?.user.id ?? "anonymous";
+    });
     editorOverlayStore.setOnEditCallback(handleEdit);
     itemHeights = new Array(displayItems.current.length).fill(0);
     requestAnimationFrame(() => {
@@ -176,6 +181,10 @@ onDestroy(() => {
 
     // リソースを解放
     viewModel.dispose();
+    if (unsubscribeUser) {
+        unsubscribeUser();
+        unsubscribeUser = null;
+    }
 });
 
 function handleAddItem() {


### PR DESCRIPTION
## Summary
- ensure OutlinerBase renders global components for textarea, slash commands, aliases, and presence
- fetch authenticated user from UserManager inside OutlinerTree instead of hard-coding "local"

## Testing
- `npx dprint fmt`
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json` *(fails: Cannot find type definition file for '@playwright/test', 'node', 'vitest')*
- `cd client && npx tsc --noEmit --project tsconfig.json` *(fails: Cannot read file '.svelte-kit/tsconfig.json'; Option 'bundler' can only be used when 'module' is set to 'preserve' or 'es2015' or later)*
- `cd client && npm run test:integration -- src/tests/integration/add-text-functionality.integration.spec.ts` *(fails: vitest not found)*
- `cd client && npm run build` *(fails: paraglide-js not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce9c1f538832fa401e1ddaf0c958d