### PR TITLE
Add integration test for homepage title

### DIFF
--- a/client/e2e/basic/rct-counter-increment-decrement-abc1def2.spec.ts
+++ b/client/e2e/basic/rct-counter-increment-decrement-abc1def2.spec.ts
@@ -7,8 +7,8 @@ import { TestHelpers } from "../utils/testHelpers";
 import "../utils/registerAfterEachSnapshot";
 
 test.describe("counter", () => {
-    test.beforeEach(async ({ page }) => {
-        await TestHelpers.prepareTestEnvironment(page);
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
         await page.goto("/counter");
     });
 

--- a/client/src/tests/integration/homepage-auth.integration.spec.ts
+++ b/client/src/tests/integration/homepage-auth.integration.spec.ts
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
+vi.mock("$app/navigation", () => ({ goto: vi.fn() }));
+import HomePage from "../../routes/+page.svelte";
+
+/**
+ * Integration test mirroring e2e/core/homepage-auth.spec.ts
+ * Verifies that the homepage renders the expected title.
+ */
+
+describe("homepage-auth", () => {
+    it("displays the Outliner App title", () => {
+        render(HomePage);
+        expect(
+            screen.getByRole("heading", { level: 1, name: "Outliner App" }),
+        ).toBeTruthy();
+    });
+});

--- a/docs/client-features/als-alias-node-58ad30d4.yaml
+++ b/docs/client-features/als-alias-node-58ad30d4.yaml
@@ -18,9 +18,9 @@ components:
 tests:
 - client/e2e/new/als-alias-keyboard-navigation.spec.ts
 - client/e2e/new/als-alias-node-58ad30d4.spec.ts
-- client/src/tests/integration/als-alias-node-58ad30d4.integration.spec.ts
 - client/e2e/new/als-alias-path-navigation.spec.ts
-- client/src/tests/integration/als-alias-path-navigation.integration.spec.ts
 - client/e2e/new/als-alias-self-reference-test.spec.ts
-- client/src/tests/integration/als-alias-self-reference-test.integration.spec.ts
 - client/e2e/new/als-alias-target-change-f508c5a9.spec.ts
+- client/src/tests/integration/als-alias-node-58ad30d4.integration.spec.ts
+- client/src/tests/integration/als-alias-path-navigation.integration.spec.ts
+- client/src/tests/integration/als-alias-self-reference-test.integration.spec.ts

--- a/docs/client-features/chk-universal-checklist-7290ab91.yaml
+++ b/docs/client-features/chk-universal-checklist-7290ab91.yaml
@@ -9,8 +9,8 @@ services:
 - src/services/checklistService.ts
 tests:
 - client/e2e/new/CHK-0001.spec.ts
-- src/tests/checklistService.test.ts
 - client/src/tests/integration/CHK-0001.integration.spec.ts
+- src/tests/checklistService.test.ts
 acceptance:
 - Habit lists auto reset based on RRule
 - Items can be added to the checklist

--- a/docs/client-features/fse-firestore-store-exposed-9d3f2b1c.yaml
+++ b/docs/client-features/fse-firestore-store-exposed-9d3f2b1c.yaml
@@ -4,4 +4,4 @@ title-ja: windowに公開されるFirestoreストア
 description: Firestoreストアがテスト環境でwindowオブジェクトに公開されることを確認する。
 status: implemented
 tests:
-  - client/e2e/core/fse-firestore-store-exposed-9d3f2b1c.spec.ts
+- client/e2e/core/fse-firestore-store-exposed-9d3f2b1c.spec.ts

--- a/docs/client-features/prs-real-time-presence-indicators-1f57a209.yaml
+++ b/docs/client-features/prs-real-time-presence-indicators-1f57a209.yaml
@@ -9,7 +9,7 @@ acceptance:
 - Colors remain consistent per user
 - Presence updates when users join or leave
 tests:
-- client/src/tests/integration/yjs/prs-real-time-presence-indicators-7b6a1ea8.integration.spec.ts
 - client/e2e/new/prs-real-time-presence-indicators-7b6a1ea8.spec.ts
 - client/src/tests/fluidPresence.test.ts
+- client/src/tests/integration/yjs/prs-real-time-presence-indicators-7b6a1ea8.integration.spec.ts
 - client/src/tests/presenceStore.test.ts

--- a/docs/client-features/prs-yjs-presence-cursors-4d2e1b6a.yaml
+++ b/docs/client-features/prs-yjs-presence-cursors-4d2e1b6a.yaml
@@ -5,5 +5,5 @@ description: Sync cursors via Yjs awareness and show remote avatars.
 category: yjs
 status: experimental
 tests:
-- client/src/tests/integration/yjs/prs-cursor-sync-4d2e1b6a.integration.spec.ts
 - client/e2e/new/prs-cursor-sync-4d2e1b6a.spec.ts
+- client/src/tests/integration/yjs/prs-cursor-sync-4d2e1b6a.integration.spec.ts

--- a/docs/client-features/rct-counter-increment-decrement-abc1def2.yaml
+++ b/docs/client-features/rct-counter-increment-decrement-abc1def2.yaml
@@ -5,8 +5,8 @@ description: Demonstrates Svelte 5 runes reactivity with a simple counter compon
 category: example
 status: implemented
 components:
-- client/src/tests/fixtures/Counter.svelte
 - client/src/routes/counter/+page.svelte
+- client/src/tests/fixtures/Counter.svelte
 tests:
-- client/src/tests/integration/rct-counter-increment-decrement-abc1def2.integration.spec.ts
 - client/e2e/basic/rct-counter-increment-decrement-abc1def2.spec.ts
+- client/src/tests/integration/rct-counter-increment-decrement-abc1def2.integration.spec.ts

--- a/docs/client-features/sea-page-title-search-box-a3674e4f-dce0-4543-9e85-1f1899f97f73.yaml
+++ b/docs/client-features/sea-page-title-search-box-a3674e4f-dce0-4543-9e85-1f1899f97f73.yaml
@@ -10,5 +10,5 @@ components:
 - client/src/routes/[project]/[page]/+page.svelte
 - client/src/stores/SearchHistoryStore.svelte.ts
 tests:
-- client/src/tests/integration/sea-page-title-search-box-a3674e4f-dce0-4543-9e85-1f1899f97f73.integration.spec.ts
 - client/e2e/core/sea-page-title-search-box-a3674e4f-dce0-4543-9e85-1f1899f97f73.spec.ts
+- client/src/tests/integration/sea-page-title-search-box-a3674e4f-dce0-4543-9e85-1f1899f97f73.integration.spec.ts

--- a/docs/client-features/tst-env-variable-check-09c9de20.yaml
+++ b/docs/client-features/tst-env-variable-check-09c9de20.yaml
@@ -5,5 +5,5 @@ category: testing
 description: Verify that VITE_IS_TEST from .env loads in the client runtime.
 status: implemented
 tests:
-- client/src/tests/integration/tst-env-variable-check-09c9de20.integration.spec.ts
 - client/e2e/basic/tst-env-variable-check-09c9de20.spec.ts
+- client/src/tests/integration/tst-env-variable-check-09c9de20.integration.spec.ts

--- a/docs/client-features/tst-initializing-and-preparing-the-test-environment-b55298f7.yaml
+++ b/docs/client-features/tst-initializing-and-preparing-the-test-environment-b55298f7.yaml
@@ -13,6 +13,7 @@ tests:
 - client/e2e/helpers.ts
 - client/e2e/utils/linkTestHelpers.ts
 - client/e2e/utils/testHelpers.ts
+- client/src/tests/integration/homepage-auth.integration.spec.ts
 notes:
 - テスト環境では要素の検出が不安定な場合があるため、再試行機能を持つヘルパー関数を使用してテストを安定化
 - テストデータの作成にはUI操作ではなくFluid APIを使用し、テストの安定性を向上

--- a/docs/client-features/txt-add-text-functionality-8c8218a3.yaml
+++ b/docs/client-features/txt-add-text-functionality-8c8218a3.yaml
@@ -7,5 +7,5 @@ status: implemented
 components:
 - client/src/components/OutlinerTree.svelte
 tests:
-- client/src/tests/integration/add-text-functionality.integration.spec.ts
 - client/e2e/basic/add-text-functionality.spec.ts
+- client/src/tests/integration/add-text-functionality.integration.spec.ts

--- a/docs/client-features/yjs-basic-sync-a1b2c3d4.yaml
+++ b/docs/client-features/yjs-basic-sync-a1b2c3d4.yaml
@@ -5,8 +5,8 @@ category: data
 description: Ensure Yjs client connects and exposes connection state.
 status: experimental
 acceptance:
-- Yjs store initializes after authentication
 - Connection state is accessible via __YJS_STORE__
+- Yjs store initializes after authentication
 tests:
-- client/src/tests/integration/yjs/yjs-basic-sync-a1b2c3d4.integration.spec.ts
 - client/e2e/new/yjs-basic-sync-a1b2c3d4.spec.ts
+- client/src/tests/integration/yjs/yjs-basic-sync-a1b2c3d4.integration.spec.ts

--- a/docs/client-features/yjs-service-operations-bd6b971b.yaml
+++ b/docs/client-features/yjs-service-operations-bd6b971b.yaml
@@ -5,5 +5,5 @@ description: Provides basic tree operations and presence helpers for Yjs.
 category: api
 status: implemented
 tests:
-- client/src/tests/integration/yjs-service-operations-bd6b971b.integration.spec.ts
 - client/e2e/new/yjs-service-operations-bd6b971b.spec.ts
+- client/src/tests/integration/yjs-service-operations-bd6b971b.integration.spec.ts

--- a/docs/client-features/yrr-room-token-refresh-reconnect-b4e2c1d0.yaml
+++ b/docs/client-features/yrr-room-token-refresh-reconnect-b4e2c1d0.yaml
@@ -7,6 +7,6 @@ acceptance:
 - Room paths are generated consistently across client
 - Token expiry mid-session recovers without manual reload
 tests:
-- client/src/tests/integration/yjs/yrr-token-refresh-reconnect-b4e2c1d0.integration.spec.ts
 - client/e2e/yjs/yrr-token-refresh-reconnect-b4e2c1d0.spec.ts
+- client/src/tests/integration/yjs/yrr-token-refresh-reconnect-b4e2c1d0.integration.spec.ts
 title-ja: YJSトークン更新後の自動再接続


### PR DESCRIPTION
## Summary
- add integration test for homepage title rendering
- document integration test in TST-0005 feature file
- fix counter e2e test to pass test info to environment helper

## Testing
- `npx tsc --noEmit --project client/e2e/tsconfig.json`
- `npx tsc --noEmit --project client/tsconfig.json` *(fails: Cannot find name 'service', etc.)*
- `npm run build`
- `npm run test:integration -- src/tests/integration/homepage-auth.integration.spec.ts`
- `scripts/codex-setup.sh`
- `npm run test:e2e -- e2e/core/homepage-auth.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf750bc80c832f83d6782e0cc180f5

## Related Issues

Related to #402
Related to #648
