### PR TITLE
Add integration test for alias picker keyboard navigation

### DIFF
--- a/client/src/tests/integration/als-alias-keyboard-navigation.integration.spec.ts
+++ b/client/src/tests/integration/als-alias-keyboard-navigation.integration.spec.ts
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import AliasPicker from "../../components/AliasPicker.svelte";
+import { aliasPickerStore } from "../../stores/AliasPickerStore.svelte";
+import { store as generalStore } from "../../stores/store.svelte";
+
+// Mirrors e2e/new/als-alias-keyboard-navigation.spec.ts
+
+describe("ALS alias keyboard navigation", () => {
+    it("navigates options with arrow keys and selects target", async () => {
+        const items = [
+            { id: "1", text: "first", items: [] },
+            { id: "2", text: "second", items: [] },
+            { id: "alias", text: "alias", items: [] },
+        ];
+        generalStore.currentPage = { id: "root", text: "root", items } as any;
+        render(AliasPicker);
+
+        aliasPickerStore.show("alias");
+        const picker = await screen.findByRole("dialog");
+        picker.focus();
+        const user = userEvent.setup();
+
+        const options = await screen.findAllByRole("button");
+        expect(options[0].parentElement?.classList.contains("selected")).toBe(true);
+
+        await user.keyboard("{ArrowDown}");
+        expect(options[1].parentElement?.classList.contains("selected")).toBe(true);
+
+        await user.keyboard("{ArrowUp}");
+        expect(options[0].parentElement?.classList.contains("selected")).toBe(true);
+
+        await user.keyboard("{ArrowDown}{ArrowDown}");
+        expect(options[2].parentElement?.classList.contains("selected")).toBe(true);
+
+        await user.keyboard("{Enter}");
+        const pageItems = (generalStore.currentPage as any).items;
+        expect(pageItems[2].aliasTargetId).toBe("2");
+        expect(aliasPickerStore.isVisible).toBe(false);
+    });
+});

--- a/docs/client-features/als-alias-node-58ad30d4.yaml
+++ b/docs/client-features/als-alias-node-58ad30d4.yaml
@@ -17,6 +17,7 @@ components:
 - client/src/stores/CommandPaletteStore.svelte.ts
 tests:
 - client/e2e/new/als-alias-keyboard-navigation.spec.ts
+- client/src/tests/integration/als-alias-keyboard-navigation.integration.spec.ts
 - client/e2e/new/als-alias-node-58ad30d4.spec.ts
 - client/src/tests/integration/als-alias-node-58ad30d4.integration.spec.ts
 - client/e2e/new/als-alias-path-navigation.spec.ts


### PR DESCRIPTION
## Summary
- add integration test mirroring ALS alias picker keyboard navigation e2e scenario
- record integration test path in ALS-0001 feature docs

## Testing
- `npx tsc --noEmit --project e2e/tsconfig.json` (fails: Argument for 'testInfo' not provided)
- `npx tsc --noEmit --project tsconfig.json` (fails: type errors in schema and integration tests)
- `npm run test:integration -- src/tests/integration/als-alias-keyboard-navigation.integration.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf750bc80c832f83d6782e0cc180f5

## Related Issues

Related to #87
Related to #381
