### PR TITLE
fix: refresh search results as pages load

### DIFF
--- a/client/src/routes/[project]/[page]/+page.svelte
+++ b/client/src/routes/[project]/[page]/+page.svelte
@@ -169,9 +169,8 @@ async function loadProjectAndPage() {
                     logger.info(`Page ${i}: "${title}"`);
                 }
             }
-        }
             // 必要なら currentPage をここでフォールバック設定（+layout に依存しすぎない）
-            if (store.pages && !store.currentPage) {
+            if (!store.currentPage) {
                 try {
                     const arr: any = store.pages.current as any;
                     const len = arr?.length ?? 0;
@@ -188,8 +187,7 @@ async function loadProjectAndPage() {
                     console.error("Failed to set currentPage fallback:", e);
                 }
             }
-
-        else {
+        } else {
             pageNotFound = true;
             logger.error("No pages available - store.pages is null/undefined");
             logger.error(`store.project exists: ${!!store.project}`);

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,0 +1,25 @@
+import pino from "pino";
+
+export function createLogger(destination: pino.DestinationStream = pino.destination(1)) {
+    return pino(
+        {
+            level: process.env.LOG_LEVEL ?? "info",
+            redact: {
+                paths: [
+                    "req.headers.authorization",
+                    "req.body.token",
+                    "authorization",
+                    "token",
+                    "password",
+                    "email",
+                ],
+                censor: "[REDACTED]",
+            },
+            timestamp: pino.stdTimeFunctions.isoTime,
+        },
+        destination,
+    );
+}
+
+export const logger = createLogger();
+export default logger;

--- a/server/src/persistence.ts
+++ b/server/src/persistence.ts
@@ -1,0 +1,33 @@
+import type { Logger } from "pino";
+import { LeveldbPersistence } from "y-leveldb";
+import * as Y from "yjs";
+
+export function createPersistence(path: string) {
+    return new LeveldbPersistence(path);
+}
+
+export async function warnIfRoomTooLarge(
+    persistence: LeveldbPersistence,
+    room: string,
+    limitBytes: number,
+    logger: Logger,
+): Promise<void> {
+    const doc = await persistence.getYDoc(room);
+    const size = Y.encodeStateAsUpdate(doc).byteLength;
+    if (size > limitBytes) {
+        logger.warn({ event: "room_size_exceeded", room, bytes: size });
+    }
+}
+
+export async function logTotalSize(
+    persistence: LeveldbPersistence,
+    logger: Logger,
+): Promise<void> {
+    const names = await persistence.getAllDocNames();
+    let total = 0;
+    for (const n of names) {
+        const d = await persistence.getYDoc(n);
+        total += Y.encodeStateAsUpdate(d).byteLength;
+    }
+    logger.info({ event: "leveldb_total_size", bytes: total });
+}

--- a/server/src/room-validator.ts
+++ b/server/src/room-validator.ts
@@ -1,0 +1,24 @@
+const SEGMENT_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+export interface RoomInfo {
+    project: string;
+    page?: string;
+}
+
+export function parseRoom(path: string): RoomInfo | undefined {
+    const [pathname] = path.split("?");
+    const parts = pathname.split("/").filter(Boolean);
+    if (parts.length === 2 && parts[0] === "projects" && SEGMENT_RE.test(parts[1])) {
+        return { project: parts[1] };
+    }
+    if (
+        parts.length === 4
+        && parts[0] === "projects"
+        && SEGMENT_RE.test(parts[1])
+        && parts[2] === "pages"
+        && SEGMENT_RE.test(parts[3])
+    ) {
+        return { project: parts[1], page: parts[3] };
+    }
+    return undefined;
+}

--- a/server/src/update-listeners.ts
+++ b/server/src/update-listeners.ts
@@ -1,0 +1,41 @@
+import type { Logger } from "pino";
+import type { LeveldbPersistence } from "y-leveldb";
+import { warnIfRoomTooLarge } from "./persistence";
+
+interface ListenerInfo {
+    warn: () => void;
+    count: number;
+}
+
+const listeners = new Map<string, ListenerInfo>();
+
+export async function addRoomSizeListener(
+    persistence: LeveldbPersistence,
+    docName: string,
+    limitBytes: number,
+    logger: Logger,
+): Promise<void> {
+    let info = listeners.get(docName);
+    if (!info) {
+        const doc = await persistence.getYDoc(docName);
+        const warn = () => warnIfRoomTooLarge(persistence, docName, limitBytes, logger);
+        doc.on("update", warn);
+        info = { warn, count: 0 };
+        listeners.set(docName, info);
+    }
+    info.count++;
+}
+
+export async function removeRoomSizeListener(
+    persistence: LeveldbPersistence,
+    docName: string,
+): Promise<void> {
+    const info = listeners.get(docName);
+    if (!info) return;
+    info.count--;
+    if (info.count <= 0) {
+        const doc = await persistence.getYDoc(docName);
+        doc.off("update", info.warn);
+        listeners.delete(docName);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid false "page not found" by pairing fallback with outer page check
- restore deleted websocket server modules for logger, persistence, validation, and room size listeners

## Testing
- `npm run build` *(warnings: deprecated Svelte event directives, unused selectors, and externalized modules)*
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json`
- `cd client && npx tsc --noEmit --project tsconfig.json` *(failed: Property 'deleteNodeAndDescendants' does not exist on type 'YTree')*
- `npm run test:integration -- src/tests/integration/sea-page-title-search-box-late-load-7c89d6ef.integration.spec.ts` *(no tests executed)*
- `cd server && npm test` *(failed: MODULE_NOT_FOUND in connection-limits.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd2dbb118832f8d5bff16f89c09ad

## Related Issues

Related to #650
Related to #632
Related to #498
Related to #442
Related to #385
Related to #381
Related to #628
Related to #627
Related to #625
Related to #624
Related to #623
Related to #622
Related to #621
Related to #620
Related to #619
Related to #618
Related to #616
Related to #615
Related to #614
Related to #613
Related to #612
Related to #611
Related to #610
Related to #609
Related to #599
Related to #597
Related to #582
Related to #579
Related to #578
Related to #577
Related to #570
Related to #569
Related to #568
Related to #567
Related to #566
Related to #565
Related to #561
Related to #560
Related to #559
Related to #558
Related to #557
Related to #556
Related to #554
Related to #553
Related to #552
