### PR TITLE
fix: ensure outline page loads after test setup

### DIFF
--- a/client/e2e/core/out-outline-page-visible-3f2d8a9c.spec.ts
+++ b/client/e2e/core/out-outline-page-visible-3f2d8a9c.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+let ids: { projectName: string; pageName: string; };
+
+test.beforeEach(async ({ page }, testInfo) => {
+    ids = await TestHelpers.prepareTestEnvironment(page, testInfo);
+});
+
+test("displays outline page after environment setup", async ({ page }) => {
+    const encodedProject = encodeURIComponent(ids.projectName);
+    const encodedPage = encodeURIComponent(ids.pageName);
+
+    await expect(page).toHaveURL(new RegExp(`/${encodedProject}/${encodedPage}$`));
+    await expect(page.locator('[data-testid="outliner-base"]').first()).toBeVisible();
+
+    await TestHelpers.waitForOutlinerItems(page);
+});

--- a/client/e2e/utils/testHelpers.ts
+++ b/client/e2e/utils/testHelpers.ts
@@ -635,21 +635,19 @@ export class TestHelpers {
         // ページルートの自動処理を待機（手動設定は行わない）
         console.log("TestHelper: Waiting for page route to automatically load project and page");
 
-        // Fast-path: if toolbar search box is already available, return early for speed
+        // Ensure toolbar search box is ready but continue waiting for project/page load
         try {
             // Prefer role-based lookup in the main toolbar for stability
             const input = page
                 .getByTestId("main-toolbar")
                 .getByRole("textbox", { name: "Search pages" });
             await input.waitFor({ timeout: 12000 });
-            console.log("TestHelper: Search box available early, skipping deep waits");
-            return { projectName, pageName };
+            console.log("TestHelper: Search box available");
         } catch {
             // Fallback to CSS selector for environments without testid plumbing
             try {
                 await page.waitForSelector(".page-search-box input", { timeout: 12000 });
-                console.log("TestHelper: Search box (CSS) available, skipping deep waits");
-                return { projectName, pageName };
+                console.log("TestHelper: Search box (CSS) available");
             } catch {}
         }
 

--- a/docs/client-features/out-outline-page-visible-3f2d8a9c.yaml
+++ b/docs/client-features/out-outline-page-visible-3f2d8a9c.yaml
@@ -1,0 +1,12 @@
+id: OUT-3f2d8a9c
+title: Outline page is displayed after environment setup
+description: Ensure that TestHelpers.prepareTestEnvironment navigates to the new project page and displays the outline view.
+category: core
+status: implemented
+acceptance:
+  - prepareTestEnvironment navigates to the created project page
+  - OutlinerBase element becomes visible
+  - Outliner items are rendered
+tests:
+  - client/e2e/core/out-outline-page-visible-3f2d8a9c.spec.ts
+title-ja: テスト環境準備後にアウトラインページが表示される


### PR DESCRIPTION
## Summary
- wait for project/page load instead of returning early when search box appears
- add e2e test validating outline page visibility after environment setup
- document outline page visibility feature

## Testing
- `npx dprint fmt`
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json`
- `cd client && npx tsc --noEmit --project tsconfig.json` *(fails: Cannot invoke an object which is possibly 'undefined', etc.)*
- `npm run build` *(passes)*
- `scripts/codex-setup.sh` *(terminated)*
- `cd client && npm run test:e2e -- e2e/core/out-outline-page-visible-3f2d8a9c.spec.ts` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00fe7010c832fb2c2d4b04ccced7b

## Related Issues

Related to #520
Related to #652
Related to #617
