### PR TITLE
test: add container selector update e2e

### DIFF
--- a/client/e2e/new/cnt-container-selector-updates-after-new-container-cb2f94a1.spec.ts
+++ b/client/e2e/new/cnt-container-selector-updates-after-new-container-cb2f94a1.spec.ts
@@ -1,0 +1,42 @@
+/** @feature CNT-12ee98aa
+ *  Title   : Shared Container Store
+ *  Source  : docs/client-features/cnt-shared-container-store-12ee98aa.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+import "../utils/registerAfterEachSnapshot";
+
+/**
+ * @playwright
+ * @title Dropdown updates after new container is added
+ * @description After programmatically adding a container to the shared store, the ContainerSelector should show the new option.
+ */
+
+test.describe("CNT-12ee98aa: Shared Container Store", () => {
+    test("dropdown list updates when new container is added", async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+
+        const select = page.locator("select.container-select");
+        await expect(select).toBeVisible();
+        const initialCount = await select.locator("option").count();
+
+        // Programmatically add a new container to the store
+        await page.evaluate(() => {
+            const fs: any = (window as any).__FIRESTORE_STORE__;
+            if (fs?.userContainer) {
+                fs.userContainer.accessibleContainerIds.push("test-container-3");
+            }
+        });
+
+        // Wait for the dropdown to reflect the new container
+        await page.waitForFunction(
+            (count) => document.querySelectorAll("select.container-select option").length > count,
+            initialCount,
+            { timeout: 10000 },
+        );
+
+        const options = select.locator("option");
+        await expect(options).toHaveCount(initialCount + 1);
+        await expect(options.last()).toHaveText(/テストプロジェクト/);
+    });
+});

--- a/client/src/tests/integration/itm-add-new-items-with-enter-49d26e99.integration.spec.ts
+++ b/client/src/tests/integration/itm-add-new-items-with-enter-49d26e99.integration.spec.ts
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/svelte";
 import { describe, expect, it } from "vitest";
+// @ts-ignore yjs-orderedtree types expose YTree but runtime exports Tree
 import { Tree } from "yjs-orderedtree";
 import OutlinerTree from "../../components/OutlinerTree.svelte";
 import { Cursor } from "../../lib/Cursor";

--- a/docs/client-features/cnt-shared-container-store-12ee98aa.yaml
+++ b/docs/client-features/cnt-shared-container-store-12ee98aa.yaml
@@ -12,6 +12,7 @@ services:
 - src/lib/fluidService.svelte
 - src/stores/firestoreStore.svelte.ts
 tests:
+- client/e2e/new/cnt-container-selector-updates-after-new-container-cb2f94a1.spec.ts
 - client/e2e/new/cnt-shared-container-store-12ee98aa.spec.ts
 - client/src/stores/ContainerStore.test.ts
 - client/src/tests/integration/cnt-shared-container-store-12ee98aa.integration.spec.ts


### PR DESCRIPTION
## Summary
- add Playwright test verifying ContainerSelector reflects newly added containers
- document new container selector test in feature file
- align integration test with yjs-orderedtree types

## Testing
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json`
- `cd client && npx tsc --noEmit --project tsconfig.json`
- `cd client && npm run build`
- `./scripts/codex-setup.sh`
- `cd client && xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test:e2e -- e2e/new/cnt-container-selector-updates-after-new-container-cb2f94a1.spec.ts` *(failed: Timeout on navigation to /)*
- `cd client && npm run test:integration -- src/tests/integration/itm-add-new-items-with-enter-49d26e99.integration.spec.ts` *(failed: Firebase auth network-request-failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ffd61e8c832fbebe33cfdc8d6616

## Related Issues

Related to #457
Related to #320
Related to #111
