### PR TITLE
Simplify TestHelpers and add coverage

### DIFF
--- a/client/e2e/basic/tst-testhelpers-page-lines-1c2d3e4f.spec.ts
+++ b/client/e2e/basic/tst-testhelpers-page-lines-1c2d3e4f.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test("TST-1c2d3e4f: prepare environment seeds lines", async ({ page }, testInfo) => {
+    const lines = ["alpha", "beta"];
+    const { pageName } = await TestHelpers.prepareTestEnvironment(page, testInfo, lines);
+    await TestHelpers.waitForOutlinerItems(page);
+
+    const uiTexts = await page.locator(".outliner-item:not(.page-title) .item-content").allTextContents();
+    expect(uiTexts.slice(0, lines.length)).toEqual(lines);
+
+    const storeTexts = await TestHelpers.getPageTexts(page);
+    expect(storeTexts.map((i) => i.text).slice(0, lines.length)).toEqual(lines);
+
+    const title = await page.locator(".page-title-content").innerText();
+    expect(title).toContain(pageName);
+});

--- a/client/e2e/utils/cursorValidation.ts
+++ b/client/e2e/utils/cursorValidation.ts
@@ -50,8 +50,9 @@ export class CursorValidator {
                         selectionCount: selections.length,
                     };
                 } catch (error) {
-                    console.error("Error getting cursor data:", error);
-                    return { error: error.message || "Unknown error" };
+                    const err = error as any;
+                    console.error("Error getting cursor data:", err);
+                    return { error: err?.message || "Unknown error" };
                 }
             };
         });

--- a/client/src/tests/integration/itm-add-new-items-with-enter-49d26e99.integration.spec.ts
+++ b/client/src/tests/integration/itm-add-new-items-with-enter-49d26e99.integration.spec.ts
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/svelte";
 import { describe, expect, it } from "vitest";
-import { Tree } from "yjs-orderedtree";
+import { YTree } from "yjs-orderedtree";
 import OutlinerTree from "../../components/OutlinerTree.svelte";
 import { Cursor } from "../../lib/Cursor";
 import { Project } from "../../schema/app-schema";
@@ -13,7 +13,7 @@ class ResizeObserver {
 }
 (globalThis as any).ResizeObserver = ResizeObserver;
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(cb, 0);
-(globalThis as any).Tree = Tree;
+(globalThis as any).Tree = YTree;
 
 describe("ITM-0001: Enterで新規アイテム追加", () => {
     it("splits the item at the cursor position", () => {

--- a/client/src/tests/integration/tst-create-project-page-via-api-1c2d3e4f.integration.spec.ts
+++ b/client/src/tests/integration/tst-create-project-page-via-api-1c2d3e4f.integration.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { TestHelpers } from "../../../e2e/utils/testHelpers";
+import { Project } from "../../schema/app-schema";
+import { store as generalStore } from "../../stores/store.svelte";
+
+class FakePage {
+    async evaluate(fn: any, args: any) {
+        return fn(args);
+    }
+}
+
+describe("TST-1c2d3e4f: createTestProjectAndPageViaAPI", () => {
+    it("creates a page with provided lines", async () => {
+        (globalThis as any).window = globalThis;
+        (globalThis as any).generalStore = generalStore;
+        const project = Project.createInstance("test");
+        generalStore.project = project;
+        const page: any = new FakePage();
+
+        await TestHelpers.createTestProjectAndPageViaAPI(page, "test", "page", ["first", "second"]);
+
+        const created = project.items.at(0)!;
+        const items = created.items;
+        expect(items.length).toBe(2);
+        expect(items.at(0)!.text).toBe("first");
+        expect(items.at(1)!.text).toBe("second");
+    });
+});

--- a/docs/client-features/tst-testhelpers-page-lines-1c2d3e4f.yaml
+++ b/docs/client-features/tst-testhelpers-page-lines-1c2d3e4f.yaml
@@ -1,0 +1,13 @@
+id: TST-1c2d3e4f
+title: TestHelpers seeds page with provided lines
+description: Ensure prepareTestEnvironment creates a page containing the given text lines.
+category: testing
+status: implemented
+acceptance:
+  - prepareTestEnvironment returns after creating a page with provided lines
+  - created items match the provided text in UI and store
+  - page title matches the created page name
+tests:
+  - client/e2e/basic/tst-testhelpers-page-lines-1c2d3e4f.spec.ts
+  - client/src/tests/integration/tst-create-project-page-via-api-1c2d3e4f.integration.spec.ts
+title-ja: TestHelpersで指定した行がページに追加される


### PR DESCRIPTION
## Summary
- fix TestHelpers integration test to import helpers correctly and verify seeded items
- ensure existing integration spec uses YTree type
- expand TestHelpers E2E spec to validate UI and store contents
- handle unknown errors in cursorValidation
- document page-title and store checks for TestHelpers scenario

## Testing
- `npx dprint fmt`
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json`
- `cd client && npx tsc --noEmit --project tsconfig.json`
- `npm run build`
- `scripts/codex-setup.sh` *(fails: process terminated)*
- `npm run test:integration -- src/tests/integration/tst-create-project-page-via-api-1c2d3e4f.integration.spec.ts`
- `npm run test:e2e -- e2e/basic/tst-testhelpers-page-lines-1c2d3e4f.spec.ts` *(fails: command not found: xvfb-run)*

------
https://chatgpt.com/codex/tasks/task_e_68c207049c28832faf287d9e88345997