### PR TITLE
fix: guard DOM access in KeyEventHandler

### DIFF
--- a/client/e2e/core/kbs-box-selection-visual-feedback-removal-1a2b3c4d.spec.ts
+++ b/client/e2e/core/kbs-box-selection-visual-feedback-removal-1a2b3c4d.spec.ts
@@ -1,0 +1,49 @@
+/** @feature KBS-1a2b3c4d
+ *  Title   : Box selection visual feedback removal
+ *  Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+/**
+ * 矩形選択の視覚フィードバックがタイムアウト後に削除されることを確認する
+ */
+
+test.describe("Box selection feedback", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.prepareTestEnvironment(page, testInfo);
+    });
+
+    test("selection-box-updating class removed after timeout", async ({ page }) => {
+        const firstItemId = await page.evaluate(() => {
+            const el = document.querySelector(".outliner-item");
+            return el?.getAttribute("data-item-id") || "";
+        });
+        expect(firstItemId).not.toBe("");
+
+        await page.evaluate((itemId) => {
+            const store = (window as any).editorOverlayStore;
+            if (store) {
+                store.clearCursorAndSelection("local");
+                store.setCursor({ itemId, offset: 0, isActive: true, userId: "local" });
+            }
+        }, firstItemId);
+
+        await page.evaluate(() => {
+            const KeyEventHandler = (window as any).__KEY_EVENT_HANDLER__;
+            const event = new KeyboardEvent("keydown", {
+                key: "ArrowRight",
+                altKey: true,
+                shiftKey: true,
+            });
+            KeyEventHandler.handleBoxSelection(event);
+        });
+
+        const updatingInitial = await page.locator(".selection-box-updating").count();
+        expect(updatingInitial).toBeGreaterThan(0);
+
+        await page.waitForTimeout(600);
+        const updatingAfter = await page.locator(".selection-box-updating").count();
+        expect(updatingAfter).toBe(0);
+    });
+});

--- a/client/src/lib/KeyEventHandler.ts
+++ b/client/src/lib/KeyEventHandler.ts
@@ -340,7 +340,11 @@ export class KeyEventHandler {
                     textareaElement.focus();
 
                     // デバッグ情報
-                    if (typeof window !== "undefined" && (window as any).DEBUG_MODE) {
+                    if (
+                        typeof window !== "undefined"
+                        && typeof document !== "undefined"
+                        && (window as any).DEBUG_MODE
+                    ) {
                         console.log(
                             `Focus set after input. Active element is textarea: ${
                                 document.activeElement === textareaElement
@@ -603,8 +607,10 @@ export class KeyEventHandler {
 
                 // 一定時間後にスタイルを削除
                 setTimeout(() => {
-                    const el = document.getElementById("box-selection-feedback");
-                    if (el) el.remove();
+                    if (typeof document !== "undefined") {
+                        const el = document.getElementById("box-selection-feedback");
+                        if (el) el.remove();
+                    }
                 }, 500);
             }
 
@@ -673,9 +679,11 @@ export class KeyEventHandler {
 
                     // 一定時間後にクラスを削除
                     setTimeout(() => {
-                        document.querySelectorAll(".selection-box-updating").forEach(el => {
-                            el.classList.remove("selection-box-updating");
-                        });
+                        if (typeof document !== "undefined") {
+                            document.querySelectorAll(".selection-box-updating").forEach(el => {
+                                el.classList.remove("selection-box-updating");
+                            });
+                        }
                     }, 300);
                 }
 

--- a/docs/client-features/kbs-box-selection-visual-feedback-removal-1a2b3c4d.yaml
+++ b/docs/client-features/kbs-box-selection-visual-feedback-removal-1a2b3c4d.yaml
@@ -1,0 +1,10 @@
+id: KBS-1a2b3c4d
+title: Box selection visual feedback removal
+title-ja: 矩形選択の視覚フィードバックが解除される
+description: When using box selection, temporary visual feedback is removed after a short delay.
+category: selection
+status: implemented
+components:
+  - client/src/lib/KeyEventHandler.ts
+tests:
+  - client/e2e/core/kbs-box-selection-visual-feedback-removal-1a2b3c4d.spec.ts


### PR DESCRIPTION
## Summary
- avoid `document` ReferenceError after tests by guarding DOM access in KeyEventHandler
- add E2E test covering box selection visual feedback timeout
- document box selection feedback removal feature

## Testing
- `npx dprint fmt`
- `cd client/e2e && npx tsc --noEmit --project tsconfig.json`
- `cd client && npx tsc --noEmit --project tsconfig.json`
- `cd client && npm run test:unit -- src/tests/keyEventHandler.test.ts`
- `cd client && npm run build`
- `cd client && npm run test:e2e -- e2e/core/kbs-box-selection-visual-feedback-removal-1a2b3c4d.spec.ts` *(fails: command not found: xvfb-run)*

------
https://chatgpt.com/codex/tasks/task_e_68c22a4f60f4832fa55b654585753702