### PR TITLE
Handle Yjs socket cleanup and add cursor sync E2E test

### DIFF
--- a/client/e2e/basic/prs-cursor-sync-between-tabs-b13f9c1a.spec.ts
+++ b/client/e2e/basic/prs-cursor-sync-between-tabs-b13f9c1a.spec.ts
@@ -1,0 +1,31 @@
+/** @feature PRS-b13f9c1a
+ * Title   : Cursor sync between tabs
+ * Source  : docs/client-features.yaml
+ */
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+import "../utils/registerAfterEachSnapshot";
+
+test.describe("Cursor sync between tabs", () => {
+    test("typing in one tab shows in another", async ({ browser }, testInfo) => {
+        const context1 = await browser.newContext();
+        const page1 = await context1.newPage();
+        await TestHelpers.prepareTestEnvironment(page1, testInfo);
+
+        const context2 = await browser.newContext();
+        const page2 = await context2.newPage();
+        await TestHelpers.prepareTestEnvironment(page2, testInfo);
+
+        await TestHelpers.waitForElementVisible(page1, ".outliner-item", 10000);
+        const root1 = page1.locator(".outliner-item").first();
+        await root1.locator(".item-content").click({ force: true });
+        await page1.keyboard.type("hello");
+
+        await TestHelpers.waitForElementVisible(page2, ".outliner-item", 10000);
+        const root2 = page2.locator(".outliner-item").first();
+        await expect(root2.locator(".item-text")).toContainText("hello", { timeout: 20000 });
+
+        await context1.close();
+        await context2.close();
+    });
+});

--- a/client/src/tests/integration/yjs/prs-cursor-sync-4d2e1b6a.integration.spec.ts
+++ b/client/src/tests/integration/yjs/prs-cursor-sync-4d2e1b6a.integration.spec.ts
@@ -30,7 +30,10 @@ describe("yjs presence", () => {
         const states = p1c2.awareness.getStates();
         const received = Array.from(states.values()).some(s => s.presence?.cursor?.itemId === "root");
         expect(received).toBe(true);
+        p1c1.dispose();
+        p1c2.dispose();
         c1.dispose();
         c2.dispose();
+        await new Promise(r => setTimeout(r, 0));
     });
 });

--- a/docs/client-features/kbs-box-selection-visual-feedback-removal-1a2b3c4d.yaml
+++ b/docs/client-features/kbs-box-selection-visual-feedback-removal-1a2b3c4d.yaml
@@ -5,6 +5,6 @@ description: When using box selection, temporary visual feedback is removed afte
 category: selection
 status: implemented
 components:
-  - client/src/lib/KeyEventHandler.ts
+- client/src/lib/KeyEventHandler.ts
 tests:
-  - client/e2e/core/kbs-box-selection-visual-feedback-removal-1a2b3c4d.spec.ts
+- client/e2e/core/kbs-box-selection-visual-feedback-removal-1a2b3c4d.spec.ts

--- a/docs/client-features/prs-cursor-sync-between-tabs-b13f9c1a.yaml
+++ b/docs/client-features/prs-cursor-sync-between-tabs-b13f9c1a.yaml
@@ -1,0 +1,6 @@
+id: PRS-b13f9c1a
+title: Cursor sync between tabs
+title-ja: タブ間のカーソル同期
+status: proposed
+tests:
+- client/e2e/basic/prs-cursor-sync-between-tabs-b13f9c1a.spec.ts


### PR DESCRIPTION
## Summary
- dispose Yjs page/project connections and await cleanup to prevent lingering reconnection attempts
- add Playwright E2E test verifying text sync across tabs
- document cursor sync feature

## Testing
- `npx tsc --noEmit --project tsconfig.json` (e2e)
- `npx tsc --noEmit --project tsconfig.json`
- `npm run test:integration -- src/tests/integration/yjs/prs-cursor-sync-4d2e1b6a.integration.spec.ts`
- `npm run test:e2e -- e2e/basic/prs-cursor-sync-between-tabs-b13f9c1a.spec.ts` *(fails: Error Context: test-results/prs-cursor-sync-between-ta-f1215-in-one-tab-shows-in-another-basic/error-context.md)*


------
https://chatgpt.com/codex/tasks/task_e_68c237986a64832fbe6ce332c90db662

## Related Issues

Related to #625
Related to #27
Related to #613
