### PR TITLE
test: verify alias picker prevents self reference

### DIFF
--- a/client/e2e/new/als-alias-self-reference-test.spec.ts
+++ b/client/e2e/new/als-alias-self-reference-test.spec.ts
@@ -37,27 +37,16 @@ test.describe("ALS-0001: Alias self-reference prevention", () => {
         // 自己参照エイリアスを試行（自分自身を選択）
         const selfSelector = `.alias-picker button[data-id="${aliasId}"]`;
         const selfButton = page.locator(selfSelector);
+        await expect(selfButton).toHaveCount(0);
+        await TestHelpers.hideAliasPicker(page);
 
-        // 自分自身のボタンが存在するかチェック
-        const selfButtonExists = await selfButton.count() > 0;
-        if (selfButtonExists) {
-            await selfButton.click();
+        // aliasTargetIdが設定されていないことを確認（自己参照は防止される）
+        const aliasTargetId = await TestHelpers.getAliasTargetId(page, aliasId);
+        expect(aliasTargetId).toBeNull();
 
-            // エイリアスピッカーが閉じることを確認
-            await expect(page.locator(".alias-picker")).toBeHidden();
-
-            // aliasTargetIdが設定されていないことを確認（自己参照は防止される）
-            const aliasTargetId = await TestHelpers.getAliasTargetId(page, aliasId);
-            expect(aliasTargetId).toBeNull();
-
-            // エイリアスパスが表示されていないことを確認
-            const isAliasPathVisible = await TestHelpers.isAliasPathVisible(page, aliasId);
-            expect(isAliasPathVisible).toBe(false);
-        } else {
-            // 自分自身のボタンが存在しない場合（正常な動作）
-            console.log("Self-reference button not found in options (expected behavior)");
-            await TestHelpers.hideAliasPicker(page);
-        }
+        // エイリアスパスが表示されていないことを確認
+        const isAliasPathVisible = await TestHelpers.isAliasPathVisible(page, aliasId);
+        expect(isAliasPathVisible).toBe(false);
     });
 });
 import "../utils/registerAfterEachSnapshot";

--- a/client/src/tests/integration/als-alias-self-reference-test.integration.spec.ts
+++ b/client/src/tests/integration/als-alias-self-reference-test.integration.spec.ts
@@ -15,8 +15,9 @@ describe("ALS alias self reference", () => {
         const user = userEvent.setup();
 
         aliasPickerStore.show("alias");
-        const option = await screen.findByRole("button", { name: "root/alias" });
-        await user.click(option);
+        const option = screen.queryByRole("button", { name: "root/alias" });
+        expect(option).toBeNull();
+        aliasPickerStore.hide();
         expect((items[0] as any).aliasTargetId).toBeUndefined();
         expect(aliasPickerStore.isVisible).toBe(false);
     });


### PR DESCRIPTION
## Summary
- ensure alias picker self-reference options are hidden in integration test
- extend E2E test to assert self item is not selectable and no alias target is set

## Testing
- `npx tsc --noEmit --project tsconfig.json` *(failed: Property 'page' does not exist on type)*
- `npm run build`
- `npm run test:integration -- src/tests/integration/als-alias-self-reference-test.integration.spec.ts`
- `npm run test:e2e -- e2e/new/als-alias-self-reference-test.spec.ts` *(failed: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b26370e8832fa626c02202c5a1b1

## Related Issues

Related to #647
Related to #230
Related to #186
