### PR TITLE
Add argument-aware test runner script

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,38 @@
-cd client
-npm run test:unit && npm run test:integration && npm run test:e2e -- "$@"
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/../client"
+
+if [ $# -eq 0 ]; then
+  npm run test:unit
+  npm run test:integration
+  npm run test:e2e --
+  exit 0
+fi
+
+TEST_TYPE="$1"
+shift
+
+case "$TEST_TYPE" in
+  unit)
+    npm run test:unit -- "$@"
+    ;;
+  integration)
+    npm run test:integration -- "$@"
+    ;;
+  e2e)
+    if [ $# -eq 0 ]; then
+      npm run test:e2e --
+    else
+      for spec in "$@"; do
+        npm run test:e2e -- "$spec"
+      done
+    fi
+    ;;
+  *)
+    echo "Unknown test type: $TEST_TYPE" >&2
+    echo "Usage: $0 [unit|integration|e2e] [additional args...]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- convert `scripts/test.sh` into a guarded bash script that resolves its own directory before moving into the client workspace
- retain the default behavior of running unit, integration, and e2e tests sequentially when no arguments are provided
- add argument-aware branching so callers can run only unit, integration, or individual e2e specs (executed one file at a time)

## Testing
- not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5e23f2dd0832fba2958dcaea1b2bc