### PR TITLE
Convert svelte/prefer-writable-derived rule from warn to error

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -52,7 +52,7 @@ export default ts.config(
             "no-irregular-whitespace": "error", // Gradually converting back to error - has only 1 violation
             "no-undef": "error", // Converted to error - all violations fixed
             "no-case-declarations": "error", // Gradually converting back to error - can be easily fixed
-            "svelte/prefer-writable-derived": "warn",
+            "svelte/prefer-writable-derived": "error", // Converted to error - all violations fixed
             "svelte/require-each-key": "warn",
             "svelte/no-at-html-tags": "error", // Gradually converting back to error - security concern
             "svelte/no-unused-svelte-ignore": "warn",

--- a/client/src/components/SearchBox.svelte
+++ b/client/src/components/SearchBox.svelte
@@ -135,11 +135,6 @@ let results = $derived.by(() => {
     return searchResults;
 });
 
-// 結果が変更されたときにselectedを更新
-$effect(() => {
-    selected = results.length ? 0 : -1;
-});
-
 function handleKeydown(e: KeyboardEvent) {
     if (e.isComposing) return;
     if (e.key === 'ArrowDown') {
@@ -293,7 +288,12 @@ onMount(() => {
         bind:value={query}
         onkeydown={handleKeydown}
         onfocus={() => { isFocused = true; shouldRefocus = true; }}
-        oninput={() => { isFocused = true; shouldRefocus = true; }}
+        oninput={() => {
+            isFocused = true;
+            shouldRefocus = true;
+            // Reset selection when query changes
+            selected = results.length ? 0 : -1;
+        }}
         onblur={() => {
             // Keep focus while user is interacting with the search suggestions in tests
             // Outliner may steal focus to the global textarea; when query is non-empty,


### PR DESCRIPTION
Closes #756

Changed the ESLint rule svelte/prefer-writable-derived from warning to error
to enforce proper Svelte 5 reactivity patterns using $state and $derived
instead of svelte/store. This helps maintain consistent reactive state
management across the codebase.
[ERROR] [ImportProcessor] Failed to import testing-library/svelte): ENOENT: no such file or directory, access '/workspace/testing-library/svelte)'