### PR TITLE
Convert svelte/prefer-svelte-reactivity from warn to error

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -57,7 +57,7 @@ export default ts.config(
             "svelte/no-at-html-tags": "error", // Gradually converting back to error - security concern
             "svelte/no-unused-svelte-ignore": "warn",
             "svelte/no-unused-props": "warn",
-            "svelte/prefer-svelte-reactivity": "warn",
+            "svelte/prefer-svelte-reactivity": "error",
         },
     },
     {


### PR DESCRIPTION
Closes #760

Changed the ESLint rule svelte/prefer-svelte-reactivity from warning to error
to enforce proper Svelte reactivity practices and prevent direct DOM manipulation.
[ERROR] [ImportProcessor] Failed to import testing-library/svelte): ENOENT: no such file or directory, access '/workspace/testing-library/svelte)'

## Related Issues

Fixes #760
