### PR TITLE
Fix issue #769: Fix @typescript-eslint/no-unused-vars in test and utility files

### DIFF
--- a/client/scripts/fix-istanbul-function-counts.js
+++ b/client/scripts/fix-istanbul-function-counts.js
@@ -71,7 +71,7 @@ for (const file of coverageFiles) {
     let data;
     try {
         data = JSON.parse(text);
-    } catch (e) {
+    } catch (_e) {
         console.error(`JSON のパースに失敗しました: ${filePath}`);
         continue;
     }

--- a/client/scripts/generate-e2e-coverage.js
+++ b/client/scripts/generate-e2e-coverage.js
@@ -76,7 +76,7 @@ for (const file of coverageFiles) {
     let data;
     try {
         data = JSON.parse(text);
-    } catch (e) {
+    } catch (_e) {
         console.warn(`[MCR] JSON のパースに失敗したためスキップします: ${filePath}`);
         console.warn(`${e}`);
         continue;

--- a/client/src/services/sqlService.ts
+++ b/client/src/services/sqlService.ts
@@ -17,7 +17,7 @@ interface QueryResult {
 
 let SQL: any;
 let db: Database | null = null;
-let currentQuery = "";
+let _currentQuery = "";
 let currentSelect = "";
 let worker: SyncWorker | null = null;
 
@@ -51,7 +51,7 @@ export async function initDb() {
                 wasmBinary = fs.readFileSync(possiblePath);
                 wasmPath = possiblePath;
                 break;
-            } catch (e) {
+            } catch (_e) {
                 // Continue to next path
             }
         }
@@ -161,9 +161,9 @@ function extendQuery(sql: string): { sql: string; aliases: string[]; tableMap: R
 export function runQuery(sql: string) {
     console.log("Running query:", sql);
     if (!db) throw new Error("DB not initialized");
-    const { sql: extended, aliases, tableMap } = extendQuery(sql);
+    const { sql: extended, _aliases, tableMap } = extendQuery(sql);
     console.log("Extended query:", extended);
-    currentQuery = extended;
+    _currentQuery = extended;
     const idx = extended.toUpperCase().lastIndexOf("SELECT");
     currentSelect = idx >= 0 ? extended.slice(idx) : extended;
     const results = db.exec(extended);

--- a/client/src/stories/Page.stories.svelte
+++ b/client/src/stories/Page.stories.svelte
@@ -6,7 +6,6 @@ import {
     waitFor,
     within,
 } from "@storybook/test";
-import { fn } from "@storybook/test";
 import Page from "./Page.svelte";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories

--- a/client/src/tests/integration/als-alias-self-reference-test.integration.spec.ts
+++ b/client/src/tests/integration/als-alias-self-reference-test.integration.spec.ts
@@ -14,7 +14,7 @@ describe("ALS alias self reference", () => {
         const items = [{ id: "alias", text: "alias", items: [] }];
         generalStore.currentPage = { id: "root", text: "root", items } as any;
         render(AliasPicker);
-        const user = userEvent.setup();
+        const _user = userEvent.setup();
 
         aliasPickerStore.show("alias");
         const option = screen.queryByRole("button", { name: "root/alias" });

--- a/client/src/tests/integration/att-ui-rerender.integration.spec.ts
+++ b/client/src/tests/integration/att-ui-rerender.integration.spec.ts
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/svelte";
+import { render, waitFor } from "@testing-library/svelte";
 import { describe, expect, it } from "vitest";
 import OutlinerTree from "../../components/OutlinerTree.svelte";
 import { Project } from "../../schema/app-schema";

--- a/client/src/tests/integration/hdv-snapshot-diff-a11y-7b92c1de.integration.spec.ts
+++ b/client/src/tests/integration/hdv-snapshot-diff-a11y-7b92c1de.integration.spec.ts
@@ -7,7 +7,7 @@ vi.mock("../../services", () => {
     const now = Date.now();
     const data = [{ id: "s1", timestamp: now - 1000, author: "user1", content: "old" }];
     return {
-        listSnapshots: (project: string, page: string) => data,
+        listSnapshots: (_project: string, _page: string) => data,
         getSnapshot: (project: string, page: string, id: string) => data.find(d => d.id === id) ?? null,
         addSnapshot: vi.fn(),
         replaceWithSnapshot: vi.fn((project: string, page: string, id: string) => ({

--- a/client/src/tests/integration/setup.ts
+++ b/client/src/tests/integration/setup.ts
@@ -18,7 +18,7 @@ class MockWebsocketProvider {
         serverUrl: string,
         roomname: string,
         doc: Y.Doc,
-        options?: {
+        _options?: {
             connect?: boolean;
             params?: Record<string, string>;
         },
@@ -61,7 +61,7 @@ class MockWebsocketProvider {
                         this.emit("subdocs", [subdocsEvent]);
                     }
                 });
-            } catch (e) {
+            } catch (_e) {
                 // Ignore errors in test environment
             }
         };

--- a/client/src/tests/integration/yjs/prs-cursor-sync-4d2e1b6a.integration.spec.ts
+++ b/client/src/tests/integration/yjs/prs-cursor-sync-4d2e1b6a.integration.spec.ts
@@ -157,7 +157,7 @@ describe("yjs presence", () => {
         const states2 = p1c2.awareness.getStates();
         if (states2.size <= 1 && Array.from(states2.values()).every(s => !s.presence?.cursor?.itemId)) {
             // Find the presence state from first awareness and copy it to second if not synchronized
-            for (const [clientId, state] of states1.entries()) {
+            for (const [_clientId, state] of states1.entries()) {
                 if (state.presence?.cursor?.itemId === "root") {
                     // Manually set the presence state on the second client
                     p1c2.awareness.setLocalState(state);

--- a/client/src/tests/integration/yjs/yjs-basic-sync-a1b2c3d4.integration.spec.ts
+++ b/client/src/tests/integration/yjs/yjs-basic-sync-a1b2c3d4.integration.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { yjsStore } from "../../../stores/yjsStore.svelte";
+import "../../../stores/yjsStore.svelte";
 
 /**
  * Integration test mirroring e2e/new/yjs-basic-sync-a1b2c3d4.spec.ts

--- a/client/src/tests/logger.test.ts
+++ b/client/src/tests/logger.test.ts
@@ -17,7 +17,7 @@ vi.mock("../lib/logger", async (importOriginal: () => Promise<any>) => {
 
     return {
         ...actual,
-        getLogger: (componentName = "TestComponent", enableConsole = true) => {
+        getLogger: (componentName = "TestComponent", _enableConsole = true) => {
             // シンプルなロガーモックを作成
             const logger: LoggerMock = {
                 trace: vi.fn(),

--- a/client/src/tests/mocks/index.ts
+++ b/client/src/tests/mocks/index.ts
@@ -30,7 +30,7 @@ const mockUserManager = {
 
 // Setup all mocks at once
 export function setupMocks({
-    firebase = {},
+    _firebase = {},
     firestore = {},
 } = {}) {
     // Mock userManager instance

--- a/client/src/tests/production/setup.ts
+++ b/client/src/tests/production/setup.ts
@@ -23,7 +23,7 @@ beforeAll(async () => {
         } else {
             console.log("✓ SvelteKit server (Production) is running");
         }
-    } catch (error) {
+    } catch (_error) {
         console.warn("⚠️ SvelteKit server (Production) is not running - skipping proxy tests");
     }
 });

--- a/client/src/tests/unit/userDeletion.test.ts
+++ b/client/src/tests/unit/userDeletion.test.ts
@@ -72,7 +72,7 @@ class UserDeletionService {
         return await this.auth.verifyIdToken(idToken);
     }
 
-    async getUserContainers(userId: string): Promise<string[]> {
+    async getUserContainers(_userId: string): Promise<string[]> {
         const userDoc = await mockDocRef.get();
 
         if (!userDoc.exists) {
@@ -84,7 +84,7 @@ class UserDeletionService {
     }
 
     async removeUserFromContainers(userId: string, containerIds: string[]): Promise<void> {
-        for (const _containerId of containerIds) {
+        for (const _ of containerIds) {
             const containerDoc = await mockDocRef.get();
 
             if (containerDoc.exists) {
@@ -107,7 +107,7 @@ class UserDeletionService {
         }
     }
 
-    async deleteUserData(userId: string): Promise<void> {
+    async deleteUserData(_userId: string): Promise<void> {
         await mockDocRef.delete();
     }
 

--- a/client/src/utils/ScrapboxFormatter.ts
+++ b/client/src/utils/ScrapboxFormatter.ts
@@ -318,7 +318,7 @@ export class ScrapboxFormatter {
                                 existsClassTokens = this.checkPageExists(pageName, projectName)
                                     ? "page-exists"
                                     : "page-not-exists";
-                            } catch (e) {
+                            } catch (_e) {
                                 existsClassTokens = "page-not-exists";
                             }
 
@@ -558,7 +558,7 @@ export class ScrapboxFormatter {
                     let existsClass = "page-not-exists"; // default for safety
                     try {
                         existsClass = this.checkPageExists(pageName, projectName) ? "page-exists" : "page-not-exists";
-                    } catch (e) {
+                    } catch (_e) {
                         // In case of any error in checkPageExists, default to page-not-exists
                         existsClass = "page-not-exists";
                     }
@@ -894,7 +894,7 @@ export class ScrapboxFormatter {
             }
 
             return false;
-        } catch (e) {
+        } catch (_e) {
             // If there's an error, assume the page doesn't exist
             return false;
         }

--- a/client/src/yjs/YjsClient.ts
+++ b/client/src/yjs/YjsClient.ts
@@ -10,7 +10,7 @@ import { yjsService } from "../lib/yjs/service";
 import { Items, Project } from "../schema/yjs-schema";
 import { presenceStore } from "../stores/PresenceStore.svelte";
 
-const logger = getLogger();
+const _logger = getLogger();
 
 export interface YjsClientParams {
     clientId: string;


### PR DESCRIPTION
Closes #769

This PR addresses issue #769.

## 目的
テストファイルとユーティリティファイルの `@typescript-eslint/no-unused-vars` 違反を修正する。

## 対象ファイル
- src/utils/ScrapboxFormatter.ts (3件)
- src/tests/unit/userDeletion.test.ts (3件)
- src/services/sqlService.ts (3件)
- 

## Related Issues

Related to #769
Related to #751
Related to #768
Related to #767
Related to #766
Related to #762
Related to #764
Related to #765
Related to #733
Related to #737
