### PR TITLE
Fix issue #768: Fix @typescript-eslint/no-unused-vars in route files

### DIFF
--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -39,7 +39,6 @@ const logger = getLogger("AppLayout");
 
 // 認証関連の状態
 let isAuthenticated = $state(false);
-let error: string | undefined = $state(undefined);
 
 // グローバルへのフォールバック公開（早期に window.generalStore を満たす）
 if (browser) {
@@ -138,7 +137,7 @@ async function rotateLogFiles() {
                 return;
             }
         }
-        catch (fetchError) {
+        catch (_fetchError) {
             // fetch失敗時はsendBeaconを試す - エラーは記録しない
             if (import.meta.env.DEV) {
                 logger.debug(
@@ -169,7 +168,7 @@ async function rotateLogFiles() {
                 const img = new Image();
                 img.src = `${API_URL}/api/rotate-logs?t=${Date.now()}`;
             }
-            catch (imgError) {
+            catch (_imgError) {
                 // 最後の試行なのでエラーは無視
             }
         }
@@ -224,11 +223,11 @@ onMount(async () => {
         // Dynamically import browser-only modules
         let userManager: any;
         let yjsService: any;
-        let services: any;
+        let _services: any;
         try {
             ({ userManager } = await import("../auth/UserManager"));
             yjsService = await import("../lib/yjsService.svelte");
-            services = await import("../services");
+            _services = await import("../services");
         } catch (e) {
             logger.error("Failed to load client-only modules", e);
         }

--- a/client/src/routes/[project]/+page.svelte
+++ b/client/src/routes/[project]/+page.svelte
@@ -39,7 +39,7 @@ function handleAuthLogout() {
 
 // ページを選択したときの処理
 function handlePageSelected(event: CustomEvent) {
-    const pageId = event.detail.pageId;
+    const _pageId = event.detail.pageId;
     const pageName = event.detail.pageName;
 
     if (pageName) {

--- a/client/src/routes/[project]/[page]/+page.svelte
+++ b/client/src/routes/[project]/[page]/+page.svelte
@@ -158,7 +158,7 @@ async function loadProjectAndPage() {
     } catch {}
 
             // 既存の暫定ページ内容（同一ドキュメント外）を保持（E2Eでの事前シードの引き継ぎ）
-            const preAttachPage: any = store.currentPage as any;
+            const _preAttachPage: any = store.currentPage as any;
 
         logger.info(`loadProjectAndPage: Set isLoading=true, calling getYjsClientByProjectTitle`);
 
@@ -210,8 +210,8 @@ async function loadProjectAndPage() {
                 const proj = client.getProject?.();
                 if (proj) {
                     let appliedPendingImport = false;
+                    let pendingImport: any[] | null = null;
                     try {
-                        let pendingImport: any[] | null = null;
                         try {
                             const win: any = window as any;
                             const byTitle = win?.__PENDING_IMPORTS__;
@@ -576,7 +576,7 @@ async function loadProjectAndPage() {
                         // Final safety: even if SKIP_TEST_CONTAINER_SEED is true, ensure at least some children exist for E2E stability
                         try {
                             const ref: any = (store.currentPage as any);
-                            const cpItems: any = ref?.items as any;
+                            const _cpItems: any = ref?.items as any;
                             const isTestEnv = (
                                 import.meta.env.MODE === "test"
                                 || import.meta.env.VITE_IS_TEST === "true"
@@ -644,7 +644,6 @@ async function loadProjectAndPage() {
                 if (snapshot) {
                     const hydrated = snapshotToProject(snapshot);
                     store.project = hydrated as any;
-                    project = hydrated as any;
                     if (!yjsStore.yjsClient) {
                         try {
                             yjsStore.yjsClient = createSnapshotClient(projectName, hydrated) as any;

--- a/client/src/routes/[project]/[page]/schedule/+page.svelte
+++ b/client/src/routes/[project]/[page]/schedule/+page.svelte
@@ -21,19 +21,6 @@ let editingId = $state("");
 let editingTime = $state("");
 let isDownloading = $state(false);
 
-function collectAllItemIds(node: any, out: string[]) {
-    if (!node) return;
-    const id = node?.id || "";
-    if (id) out.push(String(id));
-    const children: any = node?.items as any;
-    const len = children?.length ?? 0;
-    for (let i = 0; i < len; i++) {
-        const child = children?.at ? children.at(i) : children?.[i];
-        if (child) collectAllItemIds(child, out);
-    }
-}
-
-
 onMount(async () => {
     const params = $page.params as { project: string; page: string; };
     project = decodeURIComponent(params.project || "");

--- a/client/src/routes/api/rotate-logs/+server.ts
+++ b/client/src/routes/api/rotate-logs/+server.ts
@@ -1,7 +1,7 @@
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request: _request }) => {
     try {
         // ログローテーション要求をサーバーにプロキシ
         const apiBaseUrl = process.env.VITE_API_SERVER_URL || "http://localhost:7091";
@@ -26,7 +26,7 @@ export const POST: RequestHandler = async ({ request }) => {
     }
 };
 
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: RequestHandler = async ({ url: _url }) => {
     try {
         // GETリクエストの場合（Image src用のフォールバック）
         const apiBaseUrl = process.env.VITE_API_SERVER_URL || "http://localhost:7091";

--- a/client/src/routes/containers/+page.svelte
+++ b/client/src/routes/containers/+page.svelte
@@ -5,7 +5,6 @@ import {
     onMount,
 } from "svelte";
 import {
-    UserManager,
     userManager,
 } from "../../auth/UserManager";
 import AuthComponent from "../../components/AuthComponent.svelte";

--- a/client/src/routes/debug/+page.svelte
+++ b/client/src/routes/debug/+page.svelte
@@ -4,7 +4,7 @@ import {
     onDestroy,
     onMount,
 } from "svelte";
-import { UserManager } from "../../auth/UserManager";
+import { userManager } from "../../auth/UserManager";
 import AuthComponent from "../../components/AuthComponent.svelte";
 import EnvDebugger from "../../components/EnvDebugger.svelte";
 import NetworkErrorAlert from "../../components/NetworkErrorAlert.svelte";

--- a/client/src/routes/min/+page.svelte
+++ b/client/src/routes/min/+page.svelte
@@ -28,7 +28,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 // Initialize Firestore without storing the instance
 getFirestore(app);
-const functions = getFunctions(app);
+const _functions = getFunctions(app);
 
 const auth = getAuth(app);
 const provider = new GoogleAuthProvider();

--- a/client/src/routes/yjs-outliner/+page.svelte
+++ b/client/src/routes/yjs-outliner/+page.svelte
@@ -5,7 +5,7 @@ import { store as generalStore } from "../../stores/store.svelte";
 import * as Y from "yjs";
 import { onMount } from "svelte";
 
-let proj = $state<Project | undefined>(undefined);
+let _proj = $state<Project | undefined>(undefined);
 let pageItem = $state<any>(undefined);
 
 const PROJECT_ID = "yjs-outliner-test";
@@ -18,7 +18,7 @@ onMount(async () => {
     const pg = p.addPage("Untitled", "tester");
     while ((pg.items as any)?.length < 3) pg.items.addNode("tester");
   }
-  proj = p;
+  const _proj = p;
   pageItem = (p.items as any).at(0);
   generalStore.project = p as any;
   generalStore.currentPage = pageItem;


### PR DESCRIPTION
Closes #768

This PR addresses issue #768.

## 目的
ルートファイルの `@typescript-eslint/no-unused-vars` 違反を修正する。

## 対象ファイル
- src/routes/+layout.svelte (7件)
- src/routes/[project]/[page]/+page.svelte (2件)
- src/routes/api/rotate-logs/+server.ts (2件)
- s

## Related Issues

Fixes #768
