### PR TITLE
Fix issue #770: Remove @ts-nocheck from cursor-related files

### DIFF
--- a/client/src/lib/Cursor.test.ts
+++ b/client/src/lib/Cursor.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Item } from "../schema/app-schema";
 import { Cursor } from "./Cursor";

--- a/client/src/lib/Cursor.ts
+++ b/client/src/lib/Cursor.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Item } from "../schema/app-schema";
 import { editorOverlayStore as store } from "../stores/EditorOverlayStore.svelte";
 import { store as generalStore } from "../stores/store.svelte";

--- a/client/src/lib/KeyEventHandler.ts
+++ b/client/src/lib/KeyEventHandler.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { aliasPickerStore } from "../stores/AliasPickerStore.svelte";
 import { commandPaletteStore } from "../stores/CommandPaletteStore.svelte";
 import { editorOverlayStore as store } from "../stores/EditorOverlayStore.svelte";

--- a/client/src/lib/cursor/CursorEditor.ts
+++ b/client/src/lib/cursor/CursorEditor.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Item } from "../../schema/yjs-schema";
 import { Items } from "../../schema/yjs-schema";
 import type { SelectionRange } from "../../stores/EditorOverlayStore.svelte";

--- a/client/src/lib/cursor/CursorFormatting.ts
+++ b/client/src/lib/cursor/CursorFormatting.ts
@@ -1,13 +1,15 @@
-// @ts-nocheck
 import type { Item } from "../../schema/yjs-schema";
 import { editorOverlayStore as store } from "../../stores/EditorOverlayStore.svelte";
+import type { SelectionRange } from "../../stores/EditorOverlayStore.svelte";
 import { store as generalStore } from "../../stores/store.svelte";
 import { ScrapboxFormatter } from "../../utils/ScrapboxFormatter";
+import type { CursorEditingContext } from "./CursorEditor";
+import { searchItem } from "./CursorNavigationUtils";
 
 export class CursorFormatting {
-    private cursor: any; // Cursorクラスのインスタンスを保持
+    private cursor: CursorEditingContext;
 
-    constructor(cursor: any) {
+    constructor(cursor: CursorEditingContext) {
         this.cursor = cursor;
     }
 
@@ -113,7 +115,7 @@ export class CursorFormatting {
      * 複数アイテムにまたがる選択範囲にScrapbox構文のフォーマットを適用する
      */
     private applyScrapboxFormattingToMultipleItems(
-        selection: any,
+        selection: SelectionRange,
         formatType: "bold" | "italic" | "strikethrough" | "underline" | "code",
     ) {
         // 開始アイテムと終了アイテムのIDを取得
@@ -140,7 +142,7 @@ export class CursorFormatting {
         // 選択範囲内の各アイテムにフォーマットを適用
         for (let i = firstIdx; i <= lastIdx; i++) {
             const itemId = allItemIds[i];
-            const item = this.cursor.searchItem(generalStore.currentPage!, itemId);
+            const item = searchItem(generalStore.currentPage!, itemId);
 
             if (!item) continue;
 

--- a/client/src/lib/cursor/CursorSelection.ts
+++ b/client/src/lib/cursor/CursorSelection.ts
@@ -1,12 +1,13 @@
-// @ts-nocheck
 import type { Item } from "../../schema/yjs-schema";
 import { editorOverlayStore as store } from "../../stores/EditorOverlayStore.svelte";
 import { store as generalStore } from "../../stores/store.svelte";
+import type { Cursor } from "../Cursor";
+import { getCurrentLineIndex, getLineEndOffset, getLineStartOffset } from "./CursorTextUtils";
 
 export class CursorSelection {
-    private cursor: any; // Cursorクラスのインスタンスを保持
+    private cursor: Cursor;
 
-    constructor(cursor: any) {
+    constructor(cursor: Cursor) {
         this.cursor = cursor;
     }
 
@@ -520,10 +521,10 @@ export class CursorSelection {
         if (!target) return;
 
         const text = target.text || "";
-        const currentLineIndex = this.cursor.getCurrentLineIndex(text, this.cursor.offset);
+        const currentLineIndex = getCurrentLineIndex(text, this.cursor.offset);
 
         // 現在の行の開始位置に移動
-        this.cursor.offset = this.cursor.getLineStartOffset(text, currentLineIndex);
+        this.cursor.offset = getLineStartOffset(text, currentLineIndex);
         this.cursor.applyToStore();
 
         // カーソルが正しく更新されたことを確認
@@ -538,10 +539,10 @@ export class CursorSelection {
         if (!target) return;
 
         const text = target.text || "";
-        const currentLineIndex = this.cursor.getCurrentLineIndex(text, this.cursor.offset);
+        const currentLineIndex = getCurrentLineIndex(text, this.cursor.offset);
 
         // 現在の行の終了位置に移動
-        this.cursor.offset = this.cursor.getLineEndOffset(text, currentLineIndex);
+        this.cursor.offset = getLineEndOffset(text, currentLineIndex);
         this.cursor.applyToStore();
 
         // カーソルが正しく更新されたことを確認
@@ -570,8 +571,8 @@ export class CursorSelection {
 
         let startItemId, startOffset, endItemId, endOffset, isReversed;
         const text = target.text || "";
-        const currentLineIndex = this.cursor.getCurrentLineIndex(text, this.cursor.offset);
-        const lineStartOffset = this.cursor.getLineStartOffset(text, currentLineIndex);
+        const currentLineIndex = getCurrentLineIndex(text, this.cursor.offset);
+        const lineStartOffset = getLineStartOffset(text, currentLineIndex);
 
         // デバッグ情報
         if (typeof window !== "undefined" && (window as any).DEBUG_MODE) {
@@ -676,8 +677,8 @@ export class CursorSelection {
 
         let startItemId, startOffset, endItemId, endOffset, isReversed;
         const text = target.text || "";
-        const currentLineIndex = this.cursor.getCurrentLineIndex(text, this.cursor.offset);
-        const lineEndOffset = this.cursor.getLineEndOffset(text, currentLineIndex);
+        const currentLineIndex = getCurrentLineIndex(text, this.cursor.offset);
+        const lineEndOffset = getLineEndOffset(text, currentLineIndex);
 
         // デバッグ情報
         if (typeof window !== "undefined" && (window as any).DEBUG_MODE) {

--- a/client/src/tests/integration/cursor/cursor-navigation.integration.spec.ts
+++ b/client/src/tests/integration/cursor/cursor-navigation.integration.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Cursor } from "../../../lib/Cursor";
 import type { Item } from "../../../schema/yjs-schema";

--- a/client/src/tests/unit/cursor/cursor-core.spec.ts
+++ b/client/src/tests/unit/cursor/cursor-core.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Cursor } from "../../../lib/Cursor";
 import type { Item } from "../../../schema/yjs-schema";

--- a/client/src/tests/unit/cursor/cursor-formatting.spec.ts
+++ b/client/src/tests/unit/cursor/cursor-formatting.spec.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Cursor } from "../../../lib/Cursor";
 import type { Item } from "../../../schema/yjs-schema";


### PR DESCRIPTION
Closes #770

This PR addresses issue #770.

## 目的
カーソル関連ファイルから `@ts-nocheck` を削除し、型安全性を向上させる。

## 対象ファイル (9ファイル)
- `src/lib/cursor/CursorEditor.ts`
- `src/lib/cursor/CursorFormatting.ts`
- `src/lib/cursor/CursorSelection.ts`
- `src/lib/Cursor.t

## Related Issues

Fixes #770
Related to #772
Related to #771
Related to #773
Related to #752
Related to #712
Related to #669
Related to #668
Related to #497
Related to #714
Related to #660
Related to #516
Related to #416
Related to #613
Related to #611
Related to #625
Related to #609
