### PR TITLE
Fix issue #771: Remove @ts-nocheck from E2E test files

### DIFF
--- a/client/e2e/core/MOB-0003.spec.ts
+++ b/client/e2e/core/MOB-0003.spec.ts
@@ -1,7 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
-// @ts-nocheck
 /** @feature MOB-0003
  *  Title   : Mobile Bottom Action Toolbar
  *  Source  : docs/client-features.yaml

--- a/client/e2e/core/debug-page-load.spec.ts
+++ b/client/e2e/core/debug-page-load.spec.ts
@@ -1,6 +1,5 @@
 import "../utils/registerAfterEachSnapshot";
 registerCoverageHooks();
-// @ts-nocheck
 
 import { test } from "@playwright/test";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";

--- a/client/e2e/core/sch-schedule-management-9e449ee3.spec.ts
+++ b/client/e2e/core/sch-schedule-management-9e449ee3.spec.ts
@@ -14,7 +14,7 @@ test.describe("Schedule Management", () => {
     });
 
     test("shows newly created schedule", async ({ page }, testInfo) => {
-        await TestHelpers.navigateToTestProjectPage(page, testInfo, []);
+        await TestHelpers.navigateToTestProjectPage(page, [], testInfo);
         const pageId = await TestHelpers.getItemIdByIndex(page, 0);
         const idToken = await page.evaluate(async () => {
             const userManager = (window as any).__USER_MANAGER__;

--- a/client/e2e/core/slr-expand-selection-7d15b501.spec.ts
+++ b/client/e2e/core/slr-expand-selection-7d15b501.spec.ts
@@ -1,7 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
-// @ts-nocheck
 /** @feature SLR-0011
  *  Title   : 選択範囲の拡張
  *  Source  : docs/client-features.yaml

--- a/client/e2e/core/slr-paste-copied-text-20a382d6.spec.ts
+++ b/client/e2e/core/slr-paste-copied-text-20a382d6.spec.ts
@@ -1,6 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 registerCoverageHooks();
-// @ts-nocheck
+
 import { expect, test } from "@playwright/test";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 import { TestHelpers } from "../utils/testHelpers";

--- a/client/e2e/core/slr-select-line-7e40ab64.spec.ts
+++ b/client/e2e/core/slr-select-line-7e40ab64.spec.ts
@@ -1,7 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
-// @ts-nocheck
 /** @feature SLR-0013
  *  Title   : 現在行を選択
  *  Source  : docs/client-features.yaml

--- a/client/e2e/core/slr-selected-direction-3724726f.spec.ts
+++ b/client/e2e/core/slr-selected-direction-3724726f.spec.ts
@@ -1,6 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 registerCoverageHooks();
-// @ts-nocheck
+
 import { expect, test } from "@playwright/test";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 import { TestHelpers } from "../utils/testHelpers";

--- a/client/e2e/core/slr-selection-spans-multiple-items-7374d150.spec.ts
+++ b/client/e2e/core/slr-selection-spans-multiple-items-7374d150.spec.ts
@@ -1,7 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
-// @ts-nocheck
 /** @feature SLR-0005
  *  Title   : 複数アイテムにまたがる選択
  *  Source  : docs/client-features.yaml

--- a/client/e2e/new/CMD-0001.spec.ts
+++ b/client/e2e/new/CMD-0001.spec.ts
@@ -1,7 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
-// @ts-nocheck
 /** @feature CMD-0001
  *  Title   : Inline Command Palette
  *  Source  : docs/client-features.yaml

--- a/client/e2e/new/GRV-003-layout-persistence.spec.ts
+++ b/client/e2e/new/GRV-003-layout-persistence.spec.ts
@@ -1,7 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
-// @ts-nocheck
 /** @feature GRV-0002
  *  Title   : Graph view layout persistence
  *  Source  : docs/client-features.yaml

--- a/client/e2e/new/SRP-0001.spec.ts
+++ b/client/e2e/new/SRP-0001.spec.ts
@@ -1,7 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
-// @ts-nocheck
 
 /** @feature SRP-0001
  *  Title   : Project-Wide Search & Replace

--- a/client/e2e/new/diff-view.spec.ts
+++ b/client/e2e/new/diff-view.spec.ts
@@ -1,7 +1,6 @@
 import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
-// @ts-nocheck
 /** @feature HDV-0001
  *  Title   : Page snapshot diff viewer
  *  Source  : docs/client-features.yaml
@@ -15,7 +14,7 @@ test.describe("snapshot diff viewer", () => {
     });
 
     test("display diff and revert", async ({ page }, testInfo) => {
-        const { projectName, pageName } = await TestHelpers.navigateToTestProjectPage(page, testInfo, []);
+        const { projectName, pageName } = await TestHelpers.navigateToTestProjectPage(page, [], testInfo);
         await page.evaluate(
             ({ projectName, pageName }) => {
                 (window as any).__SNAPSHOT_SERVICE__.setCurrentContent(

--- a/client/e2e/new/imp-opml-markdown-import-export-4b1c2f10.spec.ts
+++ b/client/e2e/new/imp-opml-markdown-import-export-4b1c2f10.spec.ts
@@ -15,7 +15,7 @@ test.describe("IMP-0001: OPML/Markdown import and export", () => {
     });
 
     test("export markdown and opml", async ({ page }, testInfo) => {
-        const { projectName } = await TestHelpers.navigateToTestProjectPage(page, testInfo, [
+        const { projectName } = await TestHelpers.navigateToTestProjectPage(page, [
             "Child item",
         ]);
         const encoded = encodeURIComponent(projectName);
@@ -44,7 +44,7 @@ test.describe("IMP-0001: OPML/Markdown import and export", () => {
     });
 
     test("import markdown", async ({ page }, testInfo) => {
-        const { projectName } = await TestHelpers.navigateToTestProjectPage(page, testInfo, []);
+        const { projectName } = await TestHelpers.navigateToTestProjectPage(page, []);
         const encoded = encodeURIComponent(projectName);
         await page.goto(`/${encoded}/settings`);
         await expect(page.getByText("Import / Export")).toBeVisible();
@@ -89,7 +89,7 @@ test.describe("IMP-0001: OPML/Markdown import and export", () => {
     });
 
     test("import opml", async ({ page }, testInfo) => {
-        const { projectName } = await TestHelpers.navigateToTestProjectPage(page, testInfo, []);
+        const { projectName } = await TestHelpers.navigateToTestProjectPage(page, []);
         const encoded = encodeURIComponent(projectName);
         await page.goto(`/${encoded}/settings`);
         await expect(page.getByText("Import / Export")).toBeVisible();
@@ -130,7 +130,7 @@ test.describe("IMP-0001: OPML/Markdown import and export", () => {
     });
 
     test("import nested markdown", async ({ page }, testInfo) => {
-        const { projectName } = await TestHelpers.navigateToTestProjectPage(page, testInfo, []);
+        const { projectName } = await TestHelpers.navigateToTestProjectPage(page, []);
         const encoded = encodeURIComponent(projectName);
         await page.goto(`/${encoded}/settings`);
         await expect(page.getByText("Import / Export")).toBeVisible();

--- a/client/e2e/utils/testHelpers.ts
+++ b/client/e2e/utils/testHelpers.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { type Browser, expect, type Page } from "@playwright/test";
 import { startCoverage, stopCoverage } from "../helpers/coverage.js";
 import { CursorValidator } from "./cursorValidation.js";
@@ -112,7 +111,7 @@ export class TestHelpers {
         // 事前待機は行わず、単一遷移の安定性を優先して直ちにターゲットへ遷移する
 
         // __YJS_STORE__ はプロジェクトページ遷移後に利用可能になるため、ここでは待機せず直接遷移
-        return await TestHelpers.navigateToTestProjectPage(page, testInfo, lines, browser);
+        return await TestHelpers.navigateToTestProjectPage(page, lines, testInfo, browser);
     }
 
     /**
@@ -656,8 +655,8 @@ export class TestHelpers {
      */
     public static async navigateToTestProjectPage(
         page: Page,
-        testInfo?: any,
         lines: string[],
+        testInfo?: any,
         browser?: Browser,
     ): Promise<{ projectName: string; pageName: string; }> {
         // Derive worker index for unique naming; default to 1 when testInfo is absent
@@ -1640,7 +1639,7 @@ export class TestHelpers {
                 const currentPage = gs?.currentPage;
                 if (!currentPage) return null;
 
-                function find(node: any, target: string): any | null {
+                const find = function(node: any, target: string): any | null {
                     if (!node) return null;
                     if (node.id === target) {
                         return node;
@@ -1655,7 +1654,7 @@ export class TestHelpers {
                         if (found) return found;
                     }
                     return null;
-                }
+                };
 
                 const node = find(currentPage, id);
                 if (node) {


### PR DESCRIPTION
Closes #771

This PR addresses issue #771.

## 目的
E2Eテストファイルから `@ts-nocheck` を削除し、型安全性を向上させる。

## 対象ファイル (12ファイル)
- `e2e/core/debug-page-load.spec.ts`
- `e2e/core/MOB-0003.spec.ts`
- `e2e/core/slr-expand-selection-7d15b501.spec.ts`
- `e2e/core/