### PR TITLE
Fix issue #773: Remove @ts-nocheck from service and utility files

### DIFF
--- a/client/src/lib/search/projectSearch.ts
+++ b/client/src/lib/search/projectSearch.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Item, Items, Project } from "../../schema/app-schema";
 import { type ItemMatch, replaceAll, replaceFirst, searchItems, type SearchOptions } from "./index";
 

--- a/client/src/lib/yjs/service.test.ts
+++ b/client/src/lib/yjs/service.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, expect, it } from "vitest";
 import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";

--- a/client/src/services/importExportService.test.ts
+++ b/client/src/services/importExportService.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { describe, expect, it } from "vitest";
 import { Project } from "../schema/app-schema";
 import {

--- a/client/src/services/importExportService.ts
+++ b/client/src/services/importExportService.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Items, Project } from "../schema/app-schema";
 
 function escapeHtml(str: unknown): string {

--- a/client/src/yjs/YjsClient.ts
+++ b/client/src/yjs/YjsClient.ts
@@ -1,5 +1,4 @@
 // Yjs-based client class providing a FluidClient-like surface
-// @ts-nocheck
 import type { Awareness } from "y-protocols/awareness";
 import type { WebsocketProvider } from "y-websocket";
 import * as Y from "yjs";


### PR DESCRIPTION
Closes #773

This PR addresses issue #773.

## 目的
サービスとユーティリティファイルから `@ts-nocheck` を削除し、型安全性を向上させる。

## 対象ファイル (5ファイル)
- `src/services/importExportService.test.ts`
- `src/services/importExportService.ts`
- `src/lib/search/projectSearch.ts`
- `s