### PR TITLE
Fix issue #772: Remove @ts-nocheck from store files

### DIFF
--- a/client/src/stores/AliasPickerStore.svelte.ts
+++ b/client/src/stores/AliasPickerStore.svelte.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import type { Item, Items } from "../schema/app-schema";
 import { store as generalStore } from "./store.svelte";
 

--- a/client/src/stores/CommandPaletteStore.svelte.ts
+++ b/client/src/stores/CommandPaletteStore.svelte.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { aliasPickerStore } from "./AliasPickerStore.svelte";
 import { editorOverlayStore } from "./EditorOverlayStore.svelte";
 

--- a/client/src/stores/OutlinerViewModel.test.ts
+++ b/client/src/stores/OutlinerViewModel.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { beforeEach, describe, expect, it } from "vitest";
 import { Comments, Item, Items } from "../schema/app-schema";
 import { OutlinerViewModel } from "./OutlinerViewModel";

--- a/client/src/stores/OutlinerViewModel.ts
+++ b/client/src/stores/OutlinerViewModel.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { getLogger } from "../lib/logger";
 import { Item, Items } from "../schema/app-schema";
 


### PR DESCRIPTION
Closes #772

This PR addresses issue #772.

## 目的
ストア関連ファイルから `@ts-nocheck` を削除し、型安全性を向上させる。

## 対象ファイル (4ファイル)
- `src/stores/AliasPickerStore.svelte.ts`
- `src/stores/CommandPaletteStore.svelte.ts`
- `src/stores/OutlinerViewModel.test.ts`
- `s

## Related Issues

Fixes #772
