### PR TITLE
Fix issue #811: #799-2: Fix no-explicit-any in src/tests/unit directory (7 files)

### DIFF
--- a/client/src/tests/unit/containerDeletion.test.ts
+++ b/client/src/tests/unit/containerDeletion.test.ts
@@ -19,14 +19,14 @@ interface MockUser {
 
 interface MockContainerData {
     accessibleUserIds: string[];
-    createdAt: any;
-    updatedAt: any;
+    createdAt: Date | Timestamp | undefined;
+    updatedAt: Date | Timestamp | undefined;
 }
 
 interface MockUserData {
     accessibleContainerIds: string[];
     defaultContainerId: string | null;
-    updatedAt: any;
+    updatedAt: Date | Timestamp | undefined;
 }
 
 // Firebase Admin SDK のモック
@@ -166,7 +166,7 @@ describe("Container Deletion Service - Unit Tests", () => {
         });
 
         it("コンテナIDがundefinedの場合、エラーを投げること", () => {
-            expect(() => service.validateContainerId(undefined as any)).toThrow("Container ID is required");
+            expect(() => service.validateContainerId(undefined as unknown)).toThrow("Container ID is required");
         });
     });
 

--- a/client/src/tests/unit/cursor/cursor-core.spec.ts
+++ b/client/src/tests/unit/cursor/cursor-core.spec.ts
@@ -47,7 +47,7 @@ describe("Cursor", () => {
         mockItem = {
             id: "test-item-1",
             text: "Test text content",
-            parent: null,
+            parent: null as Item | null,
             items: {
                 [Symbol.iterator]: function*() {
                     // Empty iterator
@@ -55,12 +55,12 @@ describe("Cursor", () => {
             },
             updateText: vi.fn(),
             delete: vi.fn(),
-        } as unknown as Item;
+        } as Item;
 
         mockParentItem = {
             id: "parent-item-1",
             text: "Parent text content",
-            parent: null,
+            parent: null as Item | null,
             items: {
                 [Symbol.iterator]: function*() {
                     yield mockItem;
@@ -70,13 +70,13 @@ describe("Cursor", () => {
             },
             updateText: vi.fn(),
             delete: vi.fn(),
-        } as unknown as Item;
+        } as Item;
 
         // Set up parent relationship
         mockItem.parent = mockParentItem;
 
         // Mock the general store
-        (generalStore as any).currentPage = mockParentItem;
+        (generalStore as { currentPage: Item | null; }).currentPage = mockParentItem;
     });
 
     afterEach(() => {

--- a/client/src/tests/unit/cursor/cursor-formatting.spec.ts
+++ b/client/src/tests/unit/cursor/cursor-formatting.spec.ts
@@ -58,7 +58,7 @@ describe("Cursor Formatting", () => {
         mockItem = {
             id: "test-item-1",
             text: "This is a test text for formatting",
-            parent: null,
+            parent: null as Item | null,
             items: {
                 [Symbol.iterator]: function*() {
                     // Empty iterator
@@ -66,17 +66,17 @@ describe("Cursor Formatting", () => {
             },
             updateText: vi.fn(),
             delete: vi.fn(),
-        } as unknown as Item;
+        } as Item;
 
         // Mock the general store
-        (generalStore as any).currentPage = {
+        (generalStore as { currentPage: Item | null; }).currentPage = {
             id: "page-1",
             items: {
                 [Symbol.iterator]: function*() {
                     yield mockItem;
                 },
             },
-        };
+        } as Item;
 
         // Setup editor overlay store mocks
         editorOverlayStore.setCursor.mockReturnValue("new-cursor-id");
@@ -91,7 +91,7 @@ describe("Cursor Formatting", () => {
             mockItem.updateText = vi.fn();
 
             // Mock a selection
-            (editorOverlayStore as any).selections = {
+            (editorOverlayStore as { selections: Record<string, unknown>; }).selections = {
                 "selection-1": {
                     userId: "user-1",
                     startItemId: "test-item-1",
@@ -122,7 +122,7 @@ describe("Cursor Formatting", () => {
             mockItem.updateText = vi.fn();
 
             // Mock a selection
-            (editorOverlayStore as any).selections = {
+            (editorOverlayStore as { selections: Record<string, unknown>; }).selections = {
                 "selection-1": {
                     userId: "user-1",
                     startItemId: "test-item-1",
@@ -153,7 +153,7 @@ describe("Cursor Formatting", () => {
             mockItem.updateText = vi.fn();
 
             // Mock a selection
-            (editorOverlayStore as any).selections = {
+            (editorOverlayStore as { selections: Record<string, unknown>; }).selections = {
                 "selection-1": {
                     userId: "user-1",
                     startItemId: "test-item-1",
@@ -184,7 +184,7 @@ describe("Cursor Formatting", () => {
             mockItem.updateText = vi.fn();
 
             // Mock a selection
-            (editorOverlayStore as any).selections = {
+            (editorOverlayStore as { selections: Record<string, unknown>; }).selections = {
                 "selection-1": {
                     userId: "user-1",
                     startItemId: "test-item-1",

--- a/client/src/tests/unit/cursor/cursor-utils.spec.ts
+++ b/client/src/tests/unit/cursor/cursor-utils.spec.ts
@@ -9,7 +9,7 @@ describe("Cursor Utilities", () => {
                 parent: {
                     parentKey: "root",
                 },
-            } as unknown as Item;
+            } as Item;
 
             expect(isPageItem(mockItem)).toBe(true);
         });
@@ -17,7 +17,7 @@ describe("Cursor Utilities", () => {
         it("should return false for items without parent", () => {
             const mockItem = {
                 parent: null,
-            } as unknown as Item;
+            } as Item;
 
             expect(isPageItem(mockItem)).toBe(false);
         });
@@ -27,7 +27,7 @@ describe("Cursor Utilities", () => {
                 parent: {
                     parentKey: "some-other-key",
                 },
-            } as unknown as Item;
+            } as Item;
 
             expect(isPageItem(mockItem)).toBe(false);
         });
@@ -35,7 +35,7 @@ describe("Cursor Utilities", () => {
         it("should return false for items with undefined parent", () => {
             const mockItem = {
                 parent: undefined,
-            } as unknown as Item;
+            } as Item;
 
             expect(isPageItem(mockItem)).toBe(false);
         });

--- a/client/src/tests/unit/userDeletion.test.ts
+++ b/client/src/tests/unit/userDeletion.test.ts
@@ -20,13 +20,13 @@ interface MockUser {
 interface MockUserData {
     accessibleContainerIds: string[];
     defaultContainerId: string | null;
-    updatedAt: any;
+    updatedAt: Date | Timestamp | undefined;
 }
 
 interface MockContainerData {
     accessibleUserIds: string[];
-    createdAt: any;
-    updatedAt: any;
+    createdAt: Date | Timestamp | undefined;
+    updatedAt: Date | Timestamp | undefined;
 }
 
 // Firebase Admin SDK のモック
@@ -185,7 +185,7 @@ describe("User Deletion Service - Unit Tests", () => {
         });
 
         it("ユーザーIDがundefinedの場合、エラーを投げること", () => {
-            expect(() => service.validateUserDeletion(undefined as any)).toThrow("User ID is required");
+            expect(() => service.validateUserDeletion(undefined as unknown)).toThrow("User ID is required");
         });
     });
 


### PR DESCRIPTION
Closes #811

This PR addresses issue #811.

Fix all @typescript-eslint/no-explicit-any violations in src/tests/unit/ directory and its subdirectories.\n\n## Scope\n7 files in src/tests/unit/ including:\n- Unit test files (*.test.ts, *.spec.ts)\

## Related Issues

Fixes #811
Related to #799
Related to #750
