### PR TITLE
Fix issue #825: #810-2: Fix no-explicit-any in integration tests batch 2 (8 files)

### DIFF
--- a/client/src/tests/integration/cmt-derived-renders-9ab3c1d2.integration.spec.ts
+++ b/client/src/tests/integration/cmt-derived-renders-9ab3c1d2.integration.spec.ts
@@ -9,7 +9,7 @@ class ResizeObserver {
     unobserve() {}
     disconnect() {}
 }
-(globalThis as any).ResizeObserver = ResizeObserver;
+(globalThis as typeof globalThis & { ResizeObserver?: typeof ResizeObserver; }).ResizeObserver = ResizeObserver;
 
 /**
  * CMT-0001 派生状態のみで再描画が成立することを検証する軽量統合テスト

--- a/client/src/tests/integration/cnt-container-selector-reactivity-e3f1a9c2.integration.spec.ts
+++ b/client/src/tests/integration/cnt-container-selector-reactivity-e3f1a9c2.integration.spec.ts
@@ -10,8 +10,8 @@ import { firestoreStore } from "../../stores/firestoreStore.svelte";
 describe("CNT: ContainerSelector option count reflects accessibleContainerIds", () => {
     beforeEach(() => {
         // ContainerSelector 内の ensureUserLoggedIn が参照するオブジェクトを最小スタブ
-        (globalThis as any).window ||= globalThis as any;
-        (globalThis as any).window.__USER_MANAGER__ = {
+        (globalThis as typeof globalThis & { window?: typeof globalThis; }).window ||= globalThis;
+        (globalThis as typeof globalThis & { window?: typeof globalThis; }).window!.__USER_MANAGER__ = {
             addEventListener: vi.fn(() => vi.fn()),
             getCurrentUser: vi.fn(() => ({ id: "test-user" })),
             auth: { currentUser: { uid: "test-user" } },
@@ -25,7 +25,7 @@ describe("CNT: ContainerSelector option count reflects accessibleContainerIds", 
             defaultContainerId: "c-1",
             createdAt: new Date(),
             updatedAt: new Date(),
-        } as any);
+        });
     });
 
     it("option 数が accessibleContainerIds の増減に合わせて変化する", async () => {
@@ -36,7 +36,7 @@ describe("CNT: ContainerSelector option count reflects accessibleContainerIds", 
         expect(within(select).getAllByRole("option").length).toBe(1);
 
         // 2 件に増やす（配列の破壊的変更 -> Proxy 経由で setUserContainer + ucVersion 増分）
-        (firestoreStore.userContainer!.accessibleContainerIds as any).push("c-2");
+        (firestoreStore.userContainer!.accessibleContainerIds as string[]).push("c-2");
         // store integrity check
         expect(firestoreStore.userContainer?.accessibleContainerIds?.length ?? 0).toBe(2);
         await waitFor(() => {
@@ -44,7 +44,7 @@ describe("CNT: ContainerSelector option count reflects accessibleContainerIds", 
         });
 
         // 1 件に戻す（pop -> setUserContainer + ucVersion 増分）
-        (firestoreStore.userContainer!.accessibleContainerIds as any).pop();
+        (firestoreStore.userContainer!.accessibleContainerIds as string[]).pop();
         await waitFor(() => {
             expect(within(select).getAllByRole("option").length).toBe(1);
         });
@@ -58,7 +58,7 @@ firestoreStore.setUserContainer({
     defaultContainerId: "c-1",
     createdAt: new Date(),
     updatedAt: new Date(),
-} as any);
+});
 
 it("setUserContainer による差し替えでも option 数が即時に反映される", async () => {
     render(ContainerSelector);
@@ -73,7 +73,7 @@ it("setUserContainer による差し替えでも option 数が即時に反映さ
         defaultContainerId: "c-1",
         createdAt: new Date(),
         updatedAt: new Date(),
-    } as any);
+    });
     expect(firestoreStore.userContainer?.accessibleContainerIds?.length ?? 0).toBe(2);
     await waitFor(() => {
         expect(within(select).getAllByRole("option").length).toBe(2);
@@ -86,7 +86,7 @@ it("setUserContainer による差し替えでも option 数が即時に反映さ
         defaultContainerId: "c-1",
         createdAt: new Date(),
         updatedAt: new Date(),
-    } as any);
+    });
     await waitFor(() => {
         expect(within(select).getAllByRole("option").length).toBe(1);
     });

--- a/client/src/tests/integration/cnt-shared-container-store-12ee98aa.integration.spec.ts
+++ b/client/src/tests/integration/cnt-shared-container-store-12ee98aa.integration.spec.ts
@@ -9,14 +9,16 @@ import UserContainerDisplay from "../fixtures/UserContainerDisplay.svelte";
 describe("CNT shared container store", () => {
     it("reflects user container updates", async () => {
         render(UserContainerDisplay);
-        const storeGlobal: any = (globalThis as any).window?.__FIRESTORE_STORE__ ?? firestoreStore;
+        const storeGlobal =
+            (globalThis as typeof globalThis & { window?: { __FIRESTORE_STORE__?: typeof firestoreStore; }; })?.window
+                ?.__FIRESTORE_STORE__ ?? firestoreStore;
         storeGlobal.setUserContainer({
             userId: "u",
             accessibleContainerIds: ["a"],
             defaultContainerId: "a",
             createdAt: new Date(),
             updatedAt: new Date(),
-        } as any);
+        });
         await tick();
         await tick();
         // store 自体は更新されているか（デバッグ用アサーション）
@@ -32,7 +34,7 @@ describe("CNT shared container store", () => {
             defaultContainerId: "b",
             createdAt: new Date(),
             updatedAt: new Date(),
-        } as any);
+        });
         await tick();
         expect(screen.getByTestId("default").textContent).toBe("b");
         expect(screen.getAllByRole("listitem").map(li => li.textContent)).toEqual(["a", "b"]);

--- a/client/src/tests/integration/cursor/cursor-navigation.integration.spec.ts
+++ b/client/src/tests/integration/cursor/cursor-navigation.integration.spec.ts
@@ -76,7 +76,7 @@ describe("Cursor Integration", () => {
         mockItem.parent = mockParentItem;
 
         // Mock the general store
-        (generalStore as any).currentPage = mockParentItem;
+        generalStore.currentPage = mockParentItem;
 
         // Setup editor overlay store mocks
         editorOverlayStore.setCursor.mockReturnValue("new-cursor-id");
@@ -132,7 +132,7 @@ describe("Cursor Integration", () => {
                     if (item === secondItem) return 1;
                     return -1;
                 },
-            } as any;
+            } as unknown as Item["items"];
 
             const cursor = new Cursor("cursor-1", {
                 itemId: "test-item-1",
@@ -158,7 +158,7 @@ describe("Cursor Integration", () => {
             mockItem.updateText = vi.fn();
 
             // Mock a selection
-            (editorOverlayStore as any).selections = {
+            (editorOverlayStore as typeof editorOverlayStore & { selections?: Record<string, unknown>; }).selections = {
                 "selection-1": {
                     userId: "user-1",
                     startItemId: "test-item-1",
@@ -188,16 +188,19 @@ describe("Cursor Integration", () => {
 
             // Ensure parent has indexOf and addNode methods
             if (mockItem.parent) {
-                (mockItem.parent as any).indexOf = (item: Item) => {
+                (mockItem.parent as typeof mockItem.parent & { indexOf?: (item: Item) => number; }).indexOf = (
+                    item: Item,
+                ) => {
                     if (item === mockItem) return 0;
                     return -1;
                 };
-                (mockItem.parent as any).addNode = vi.fn().mockReturnValue({
-                    id: "new-item-1",
-                    text: "World",
-                    updateText: vi.fn(),
-                    delete: vi.fn(),
-                });
+                (mockItem.parent as typeof mockItem.parent & { addNode?: (item: string) => Item; }).addNode = vi.fn()
+                    .mockReturnValue({
+                        id: "new-item-1",
+                        text: "World",
+                        updateText: vi.fn(),
+                        delete: vi.fn(),
+                    });
             }
 
             mockParentItem.items.addNode = vi.fn().mockReturnValue({
@@ -220,7 +223,8 @@ describe("Cursor Integration", () => {
             expect(mockItem.updateText).toHaveBeenCalledWith("Hello");
             // Check if either parent.addNode or mockParentItem.items.addNode was called
             expect(
-                (mockItem.parent as any).addNode || mockParentItem.items.addNode,
+                (mockItem.parent as typeof mockItem.parent & { addNode?: () => unknown; })?.addNode
+                    || mockParentItem.items.addNode,
             ).toHaveBeenCalled();
         });
     });

--- a/client/src/tests/integration/globalStore.integration.spec.ts
+++ b/client/src/tests/integration/globalStore.integration.spec.ts
@@ -5,7 +5,7 @@ import { yjsStore } from "../../stores/yjsStore.svelte";
 
 describe("Yjs connection state (no facade)", () => {
     it("allows direct set/get on yjsStore", async () => {
-        yjsStore.isConnected = true as any;
+        yjsStore.isConnected = true;
         expect(yjsStore.getIsConnected()).toBe(true);
     });
 });

--- a/client/src/tests/integration/itm-add-new-items-with-enter-49d26e99.integration.spec.ts
+++ b/client/src/tests/integration/itm-add-new-items-with-enter-49d26e99.integration.spec.ts
@@ -14,9 +14,21 @@ class ResizeObserver {
     unobserve() {}
     disconnect() {}
 }
-(globalThis as any).ResizeObserver = ResizeObserver;
-(globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(cb, 0);
-(globalThis as any).YTree = YTree;
+(globalThis as typeof globalThis & {
+    ResizeObserver?: typeof ResizeObserver;
+    requestAnimationFrame?: (cb: FrameRequestCallback) => number;
+    YTree?: typeof YTree;
+}).ResizeObserver = ResizeObserver;
+(globalThis as typeof globalThis & {
+    ResizeObserver?: typeof ResizeObserver;
+    requestAnimationFrame?: (cb: FrameRequestCallback) => number;
+    YTree?: typeof YTree;
+}).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(cb, 0);
+(globalThis as typeof globalThis & {
+    ResizeObserver?: typeof ResizeObserver;
+    requestAnimationFrame?: (cb: FrameRequestCallback) => number;
+    YTree?: typeof YTree;
+}).YTree = YTree;
 
 describe("ITM-0001: Enterで新規アイテム追加", () => {
     it("splits the item at the cursor position", () => {


### PR DESCRIPTION
Closes #825

This PR addresses issue #825.

Fix @typescript-eslint/no-explicit-any violations in the second batch of integration test files.

## Files to Fix
9. src/tests/integration/cmt-derived-renders-9ab3c1d2.integration.spec.ts
10. src/test