### PR TITLE
Fix Firebase CI authentication for Dependabot workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,9 +62,11 @@ jobs:
           npm ci
 
       - name: Set Firebase project
+        if: github.actor != 'dependabot[bot]'
         run: firebase use outliner-d57b0 --token "${{ secrets.FIREBASE_TOKEN }}"
 
       - name: Clean up old Firebase Functions config
+        if: github.actor != 'dependabot[bot]'
         run: |
           # 既存のFirebase Functions環境変数を削除
           echo "Cleaning up old Firebase Functions config..."
@@ -76,5 +78,6 @@ jobs:
           npm run lint -- --fix
 
       - name: Deploy to Firebase
+        if: github.actor != 'dependabot[bot]'
         run: firebase deploy --project outliner-d57b0 --token "${{ secrets.FIREBASE_TOKEN }}" --non-interactive --force
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -302,6 +302,7 @@ jobs:
           npm run lint -- --fix
 
       - name: Firebase deployment dry run
+        if: github.actor != 'dependabot[bot]'
         run: |
           # Create temporary env file for functions (similar to deploy workflow)
           cat > functions/.env <<EOF


### PR DESCRIPTION
Closes #1040

Added conditional logic to skip Firebase operations in Dependabot-triggered workflows due to Dependabot's restricted access to repository secrets. This resolves authentication failures while maintaining normal Firebase functionality in regular GitHub Actions workflows.