### PR TITLE
🤖

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,9 +48,14 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID=560407608873
           VITE_FIREBASE_APP_ID=1:560407608873:web:147817f4a93a4678606638
           VITE_FIREBASE_MEASUREMENT_ID=G-FKSFRCT7GR
+          VITE_YJS_WS_URL=${{ vars.YJS_WS_URL }}
+
           EOF2
 
       - name: Install client dependencies and build
+        env:
+          VITE_YJS_WS_URL: ${{ vars.YJS_WS_URL }}
+
         run: |
           cd client
           npm ci

--- a/docs/dev-features/env-yjs-ws-url-priority-7c3a1f2b.yaml
+++ b/docs/dev-features/env-yjs-ws-url-priority-7c3a1f2b.yaml
@@ -13,6 +13,7 @@ notes:
 - client/src/lib/yjs/connection.ts の getWsBase() を WS ベース URL の単一の取得元とする
 - E2E 環境では VITE_YJS_DISABLE_WS と VITE_IS_TEST/localStorage により WebSocket 接続を抑止
 - 既存のハードコード（ポート直指定等）は撤廃・抑制
+- Production sourcing: VITE_YJS_WS_URL is provided from GitHub Actions repository Variable (YJS_WS_URL) via .github/workflows/deploy.yml
 verification:
 - client/e2e/core/nav-outlinerbase-min-visibility-7a3c91e2.spec.ts で最低限の可視性と WS 誤接続なしを確認
 - getWsBase() の優先順位: VITE_YJS_WS_URL を最優先、無ければ VITE_YJS_PORT、最後に 7093 を既定


### PR DESCRIPTION
Closes #1048

Wire the repository variable YJS_WS_URL to VITE_YJS_WS_URL during the client production build in GitHub Actions. This ensures the app connects to the correct Yjs WSS endpoint in production instead of falling back to ws://localhost:7093. Updated the deploy workflow and docs to reflect the new environment sourcing.