### PR TITLE
Implement metadata Y.Doc skeleton with IndexedDB persistence

### DIFF
--- a/client/src/lib/metaDoc.svelte.ts
+++ b/client/src/lib/metaDoc.svelte.ts
@@ -1,0 +1,46 @@
+// Metadata Y.Doc module for persisting container metadata (titles, etc.) locally
+import { IndexeddbPersistence } from "y-indexeddb";
+import * as Y from "yjs";
+
+// Singleton Y.Doc instance for container metadata
+export const metaDoc = new Y.Doc();
+
+// IndexedDB persistence for local-only storage
+const persistence = new IndexeddbPersistence("outliner-meta", metaDoc);
+
+// Y.Map structure for storing container metadata
+export const containersMap = metaDoc.getMap("containers");
+
+// Type for container metadata
+interface ContainerMetadata {
+    title: string;
+}
+
+/**
+ * Get container title from metadata Y.Doc
+ * @param containerId - The container ID to look up
+ * @returns The container title or empty string if not found
+ */
+export function getContainerTitleFromMetaDoc(containerId: string): string {
+    const containerData = containersMap.get(containerId) as ContainerMetadata | undefined;
+    return containerData?.title || "";
+}
+
+/**
+ * Set container title in metadata Y.Doc
+ * @param containerId - The container ID to update
+ * @param title - The title to set
+ */
+export function setContainerTitleInMetaDoc(containerId: string, title: string): void {
+    containersMap.set(containerId, { title } as ContainerMetadata);
+}
+
+// Log initialization status
+if (typeof window !== "undefined") {
+    console.log("[metaDoc] Initialized metadata Y.Doc with IndexedDB persistence");
+
+    // Optional: Log when IndexedDB data is loaded
+    persistence.once("synced", () => {
+        console.log("[metaDoc] IndexedDB data loaded");
+    });
+}

--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -226,6 +226,8 @@ onMount(async () => {
         try {
             ({ userManager } = await import("../auth/UserManager"));
             yjsService = await import("../lib/yjsService.svelte");
+            // Initialize metadata Y.Doc with IndexedDB persistence
+            await import("../lib/metaDoc.svelte");
             await import("../services");
         } catch (e) {
             logger.error("Failed to load client-only modules", e);


### PR DESCRIPTION
Closes #1076

Created a new module `client/src/lib/metaDoc.svelte.ts` that initializes a 
singleton Y.Doc for container metadata and sets up IndexedDB persistence. 
This provides foundational infrastructure for persisting container metadata 
(titles, etc.) locally across page reloads.
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspace
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac616-a255-7292-8f28-8efcab7db2c1
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #1076: [Sub-issue 1] Create metadata Y.Doc skeleton and IndexedDB persistence
Issue Description:
# [Sub-issue 1] Create metadata Y.Doc skeleton and IndexedDB persistence

## Summary
Create a new module `client/src/lib/metaDoc.svelte.ts` that initializes a local-only Y.Doc for container metadata and sets up IndexedDB persistence using `y-indexeddb`.

## Description
This sub-issue creates the foundational infrastructure for persisting container metadata (titles, etc.) in a local-only Y.Doc that survives page reloads.

## Tasks
1. Create `client/src/lib/metaDoc.svelte.ts` with:
   - A singleto

Changes Summary:
Excellent! All tasks are complete. Let me provide a summary of the implementation:

## Summary

I've successfully implemented **Issue #1076: [Sub-issue 1] Create metadata Y.Doc skeleton and IndexedDB persistence**.

### Changes Made:

1. **Created `client/src/lib/metaDoc.svelte.ts`**:
   - Implemented a singleton Y.Doc instance (`metaDoc`)
   - Set up IndexedDB persistence using `IndexeddbPersistence("outliner-meta", metaDoc)`
   - Created a Y.Map structure (`containersMap`) for storing containe

Commit History Since Branch Creation:
Auto-Coder: Address issue #1076

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers
Reconnecting... 1/5
codex
Implement metadata Y.Doc skeleton with IndexedDB persistence

Created a new module `client/src/lib/metaDoc.svelte.ts` that initializes a 
singleton Y.Doc for container metadata and sets up IndexedDB persistence. 
This provides foundational infrastructure for persisting container metadata 
(titles, etc.) locally across page reloads.