### PR TITLE
Implement metaDoc-based container title resolution

### DIFF
--- a/client/src/stores/containerStore.svelte.ts
+++ b/client/src/stores/containerStore.svelte.ts
@@ -1,3 +1,4 @@
+import { getContainerTitleFromMetaDoc } from "../lib/metaDoc.svelte";
 import { getProjectTitle } from "../lib/projectTitleProvider";
 import { firestoreStore, type UserContainer } from "./firestoreStore.svelte";
 
@@ -28,12 +29,22 @@ export function containersFromUserContainer(
     const uniqueIds = Array.from(new Set(data.accessibleContainerIds));
     return uniqueIds
         .map(id => {
+            // Resolve container label with fallback chain:
+            // 1. Try getContainerTitleFromMetaDoc (metadata Y.Doc)
+            // 2. If empty, try getProjectTitle (live Yjs project)
+            // 3. If still empty, use the raw container ID
             let name: string;
             try {
-                name = getProjectTitle(id);
+                name = getContainerTitleFromMetaDoc(id);
+                if (!name || name.trim() === "") {
+                    name = getProjectTitle(id);
+                }
+                if (!name || name.trim() === "") {
+                    name = id;
+                }
             } catch (error) {
-                console.warn(`Failed to get project title for ${id}:`, error);
-                name = "";
+                console.warn(`Failed to get container title for ${id}:`, error);
+                name = id;
             }
             // テスト環境で名前が空の場合、デフォルト名を使用
             if (isTestEnv && (!name || name.trim() === "")) {


### PR DESCRIPTION
Closes #1078

Updated containerStore to use getContainerTitleFromMetaDoc with fallback to
getProjectTitle and container ID. This ensures container labels are properly
resolved from metadata Y.Doc first, improving consistency in the home dropdown.
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspace
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019ac628-3dee-76b1-a412-e6defb1907df
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #1078: [Sub-issue 3] Implement read logic and update containerStore to use metaDoc
Issue Description:
# [Sub-issue 3] Implement read logic and update containerStore to use metaDoc

## Summary
Implement the `getContainerTitleFromMetaDoc` function and update `containersFromUserContainer` in `containerStore.svelte.ts` to resolve container labels using the metadata Y.Doc, with fallback to `getProjectTitle` and then to the raw container ID.

## Description
This sub-issue implements the read path: when building the home dropdown, container labels should be resolved from `metaDoc` first, then from live

Changes Summary:
## Summary

I have successfully implemented the changes for **Issue #1078: [Sub-issue 3] Implement read logic and update containerStore to use metaDoc**.

### Changes Made

**1. Modified `/workspace/client/src/stores/containerStore.svelte.ts`:**
   - Added import for `getContainerTitleFromMetaDoc` from `metaDoc.svelte.ts`
   - Updated `containersFromUserContainer` function to implement a 3-tier fallback chain for resolving container labels:
     1. **First**: Try `getContainerTitleFromMetaDoc(id

Commit History Since Branch Creation:
Auto-Coder: Address issue #1078

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp startup: no servers
codex
Implement metaDoc-based container title resolution

Updated containerStore to use getContainerTitleFromMetaDoc with fallback to
getProjectTitle and container ID. This ensures container labels are properly
resolved from metadata Y.Doc first, improving consistency in the home dropdown.