### PR TITLE
Create cleanup-coverage.js script for removing old test coverage files

### DIFF
--- a/client/scripts/cleanup-coverage.js
+++ b/client/scripts/cleanup-coverage.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+/**
+ * 古い coverage JSON ファイルを削除して、各テスト実行で fresh coverage データを取得できるようにします。
+ * - unit_and_integration/ から coverage-final.json 以外の JSON ファイルを削除
+ * - e2e/raw/ から全ての JSON ファイルを削除
+ * - merged/ から古いマージされた coverage データを削除
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const workspaceDir = path.resolve(__dirname, "../..");
+const coverageDir = path.join(workspaceDir, "coverage");
+
+// 各サブディレクトリの設定
+const cleanupDirs = [
+    {
+        name: "unit_and_integration",
+        keepFile: "coverage-final.json",
+    },
+    {
+        name: "e2e/raw",
+        keepFile: null, // 全てのJSONファイルを削除
+    },
+    {
+        name: "merged",
+        keepFile: null, // 全てのJSONファイルを削除
+    },
+];
+
+/**
+ * 指定されたディレクトリから古い JSON ファイルを削除します
+ */
+function cleanupDirectory(dirPath, keepFile = null) {
+    if (!fs.existsSync(dirPath)) {
+        return 0; // ディレクトリが存在しない場合はスキップ
+    }
+
+    let removedCount = 0;
+
+    try {
+        const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+
+        for (const entry of entries) {
+            // ディレクトリはスキップ
+            if (entry.isDirectory()) {
+                continue;
+            }
+
+            const filePath = path.join(dirPath, entry.name);
+
+            // keepFile が指定されている場合、そのファイルは削除しない
+            if (keepFile && entry.name === keepFile) {
+                continue;
+            }
+
+            // JSON ファイルのみ削除
+            if (entry.name.endsWith(".json")) {
+                fs.unlinkSync(filePath);
+                console.log(`[coverage:cleanup] deleted: ${path.relative(workspaceDir, filePath)}`);
+                removedCount++;
+            }
+        }
+    } catch (e) {
+        console.error(`[coverage:cleanup] failed to cleanup ${dirPath}:`, e);
+    }
+
+    return removedCount;
+}
+
+function main() {
+    let totalRemoved = 0;
+
+    console.log("[coverage:cleanup] cleaning up old coverage files...");
+
+    // 各ディレクトリを処理
+    for (const dirConfig of cleanupDirs) {
+        const dirPath = path.join(coverageDir, dirConfig.name);
+
+        if (!fs.existsSync(dirPath)) {
+            // ディレクトリが存在しない場合はスキップしてエラーにしない
+            continue;
+        }
+
+        const removed = cleanupDirectory(dirPath, dirConfig.keepFile);
+        totalRemoved += removed;
+
+        if (removed > 0) {
+            console.log(`[coverage:cleanup] removed ${removed} file(s) from ${path.relative(workspaceDir, dirPath)}/`);
+        }
+    }
+
+    console.log("[coverage:cleanup] cleanup completed");
+
+    // 何もない場合は適切なメッセージ
+    if (totalRemoved === 0) {
+        console.log("[coverage:cleanup] no old coverage files found to delete");
+    } else {
+        console.log(`[coverage:cleanup] total: ${totalRemoved} file(s) removed`);
+    }
+
+    // 常に成功ステータスで終了
+    process.exit(0);
+}
+
+main();


### PR DESCRIPTION
Closes #1094

This script removes old coverage JSON files from unit/integration and E2E test directories to ensure fresh coverage data for each test run. It preserves coverage-final.json in unit_and_integration while cleaning all other JSON files in the specified directories.
OpenAI Codex v0.63.0 (research preview)
--------
workdir: /workspace
model: qwen/qwen3-coder:free
provider: openrouter
approval: never
sandbox: danger-full-access
session id: 019acfbf-83e6-71b1-abf9-123ac522e24a
--------
user
Read AGENTS.md before proceeding if you haven't read it yet.

Generate a concise pull request message for the following issue:

Issue #1094: Create cleanup-coverage.js Script
Issue Description:
# Create cleanup-coverage.js Script

## Description

Create a new script `client/scripts/cleanup-coverage.js` that removes old coverage JSON files from previous test runs to ensure fresh coverage data for each test execution.

## Requirements

The script should:
1. Remove old coverage JSON files from these directories:
   - `client/coverage/unit_and_integration/` (except `coverage-final.json` generated by Vitest)
   - `client/coverage/e2e/raw/` (all `.json` files from previous E2E tests)
   - `c

Changes Summary:
## Summary

I've successfully created the `cleanup-coverage.js` script as requested in issue #1094. The script has been implemented and thoroughly tested.

### What was done:

✅ **Created** `/workspace/client/scripts/cleanup-coverage.js` - A new script that removes old coverage JSON files

### Key Features:

1. **Removes old coverage JSON files** from three directories:
   - `coverage/unit_and_integration/` - deletes all `.json` files **except** `coverage-final.json` (preserved for Vitest)
   - 

Commit History Since Branch Creation:
Auto-Coder: Address issue #1094

Requirements:
- Title: A clear, concise title (max 72 characters) that describes the changes
- Body: A brief description of what was changed and why (2-3 sentences)
- Format: Return ONLY the title on the first line, followed by a blank line, then the body
- Do NOT include any markdown formatting, headers, or extra text

Example format:
Fix authentication bug in login flow

Updated the authentication logic to properly handle edge cases when users
have special characters in their passwords. This resolves the login failures
reported in the issue.
mcp: github starting
mcp: github ready
mcp startup: ready: github
Reconnecting... 1/5
codex
Create cleanup-coverage.js script for removing old test coverage files

This script removes old coverage JSON files from unit/integration and E2E test directories to ensure fresh coverage data for each test run. It preserves coverage-final.json in unit_and_integration while cleaning all other JSON files in the specified directories.