### PR TITLE
Fix issue #1085: Ensure metadata Y.Doc integration consistency with #1061

### DIFF
--- a/client/src/lib/metaDoc.svelte.ts
+++ b/client/src/lib/metaDoc.svelte.ts
@@ -1,0 +1,95 @@
+// Metadata Y.Doc module for persisting container metadata (titles, etc.) locally
+import { IndexeddbPersistence } from "y-indexeddb";
+import * as Y from "yjs";
+
+// Singleton Y.Doc instance for container metadata
+export const metaDoc = new Y.Doc();
+
+// IndexedDB persistence for local-only storage
+// Use a separate database name from container Y.Docs to avoid conflicts
+const persistence = new IndexeddbPersistence("outliner-meta", metaDoc);
+
+// Y.Map structure for storing container metadata
+export const containersMap = metaDoc.getMap("containers");
+
+// Type for container metadata
+interface ContainerMetadata {
+    title: string;
+    lastOpenedAt?: number;
+}
+
+/**
+ * Get container title from metadata Y.Doc
+ * @param containerId - The container ID to look up
+ * @returns The container title or empty string if not found
+ */
+export function getContainerTitleFromMetaDoc(containerId: string): string {
+    const containerData = containersMap.get(containerId) as ContainerMetadata | undefined;
+    return containerData?.title || "";
+}
+
+/**
+ * Set container title in metadata Y.Doc
+ * @param containerId - The container ID to update
+ * @param title - The title to set
+ */
+export function setContainerTitleInMetaDoc(containerId: string, title: string): void {
+    containersMap.set(containerId, { title } as ContainerMetadata);
+}
+
+/**
+ * Update the last opened timestamp for a container
+ * @param containerId - The container ID to update
+ */
+export function updateLastOpenedAt(containerId: string): void {
+    const containerData = containersMap.get(containerId) as ContainerMetadata | undefined;
+    const currentTitle = containerData?.title || "";
+    containersMap.set(containerId, {
+        title: currentTitle,
+        lastOpenedAt: Date.now(),
+    } as ContainerMetadata);
+}
+
+/**
+ * Get last opened timestamp for a container
+ * @param containerId - The container ID to look up
+ * @returns The timestamp or undefined if not found
+ */
+export function getLastOpenedAt(containerId: string): number | undefined {
+    const containerData = containersMap.get(containerId) as ContainerMetadata | undefined;
+    return containerData?.lastOpenedAt;
+}
+
+// Log initialization status
+if (typeof window !== "undefined") {
+    console.log("[metaDoc] Initialized metadata Y.Doc with IndexedDB persistence");
+
+    // Optional: Log when IndexedDB data is loaded
+    persistence.once("synced", () => {
+        console.log("[metaDoc] IndexedDB data loaded");
+    });
+}
+
+// Expose metaDoc functions to window for E2E testing
+if (typeof window !== "undefined") {
+    const isTestEnv = import.meta.env.MODE === "test"
+        || process.env.NODE_ENV === "test"
+        || import.meta.env.VITE_IS_TEST === "true"
+        || window.location.hostname === "localhost";
+
+    if (isTestEnv) {
+        (window as Window & typeof globalThis & {
+            __META_DOC_MODULE__?: {
+                setContainerTitleInMetaDoc: typeof setContainerTitleInMetaDoc;
+                getContainerTitleFromMetaDoc: typeof getContainerTitleFromMetaDoc;
+                updateLastOpenedAt: typeof updateLastOpenedAt;
+                getLastOpenedAt: typeof getLastOpenedAt;
+            };
+        }).__META_DOC_MODULE__ = {
+            setContainerTitleInMetaDoc,
+            getContainerTitleFromMetaDoc,
+            updateLastOpenedAt,
+            getLastOpenedAt,
+        };
+    }
+}

--- a/client/src/lib/metaDoc.test.ts
+++ b/client/src/lib/metaDoc.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+    containersMap,
+    getContainerTitleFromMetaDoc,
+    getLastOpenedAt,
+    setContainerTitleInMetaDoc,
+    updateLastOpenedAt,
+} from "./metaDoc.svelte";
+
+describe("metaDoc", () => {
+    beforeEach(() => {
+        // Clear the containers map before each test
+        containersMap.clear();
+    });
+
+    describe("getContainerTitleFromMetaDoc", () => {
+        it("returns empty string for non-existent container", () => {
+            const title = getContainerTitleFromMetaDoc("non-existent-id");
+            expect(title).toBe("");
+        });
+
+        it("returns title for existing container", () => {
+            setContainerTitleInMetaDoc("container-1", "Test Container");
+            const title = getContainerTitleFromMetaDoc("container-1");
+            expect(title).toBe("Test Container");
+        });
+
+        it("returns empty string when title is empty", () => {
+            setContainerTitleInMetaDoc("container-2", "");
+            const title = getContainerTitleFromMetaDoc("container-2");
+            expect(title).toBe("");
+        });
+    });
+
+    describe("setContainerTitleInMetaDoc", () => {
+        it("stores title for container", () => {
+            setContainerTitleInMetaDoc("container-3", "My Container");
+            const title = getContainerTitleFromMetaDoc("container-3");
+            expect(title).toBe("My Container");
+        });
+
+        it("overwrites existing title", () => {
+            setContainerTitleInMetaDoc("container-4", "First Title");
+            setContainerTitleInMetaDoc("container-4", "Second Title");
+            const title = getContainerTitleFromMetaDoc("container-4");
+            expect(title).toBe("Second Title");
+        });
+
+        it("handles special characters in title", () => {
+            setContainerTitleInMetaDoc("container-5", "Test [Bold] /Italic/");
+            const title = getContainerTitleFromMetaDoc("container-5");
+            expect(title).toBe("Test [Bold] /Italic/");
+        });
+    });
+
+    describe("updateLastOpenedAt", () => {
+        it("updates lastOpenedAt timestamp", () => {
+            const containerId = "container-6";
+            setContainerTitleInMetaDoc(containerId, "Test");
+            const beforeUpdate = Date.now();
+            updateLastOpenedAt(containerId);
+            const afterUpdate = Date.now();
+
+            const lastOpened = getLastOpenedAt(containerId);
+            expect(lastOpened).toBeDefined();
+            expect(lastOpened).toBeGreaterThanOrEqual(beforeUpdate);
+            expect(lastOpened).toBeLessThanOrEqual(afterUpdate);
+        });
+
+        it("creates metadata if container doesn't exist", () => {
+            updateLastOpenedAt("container-7");
+            const lastOpened = getLastOpenedAt("container-7");
+            expect(lastOpened).toBeDefined();
+        });
+
+        it("preserves title when updating lastOpenedAt", () => {
+            const containerId = "container-8";
+            setContainerTitleInMetaDoc(containerId, "Original Title");
+            updateLastOpenedAt(containerId);
+
+            const title = getContainerTitleFromMetaDoc(containerId);
+            const lastOpened = getLastOpenedAt(containerId);
+
+            expect(title).toBe("Original Title");
+            expect(lastOpened).toBeDefined();
+        });
+    });
+
+    describe("getLastOpenedAt", () => {
+        it("returns undefined for non-existent container", () => {
+            const lastOpened = getLastOpenedAt("non-existent-id");
+            expect(lastOpened).toBeUndefined();
+        });
+
+        it("returns timestamp when set", () => {
+            setContainerTitleInMetaDoc("container-9", "Test");
+            const timestamp = Date.now();
+            updateLastOpenedAt("container-9");
+            const lastOpened = getLastOpenedAt("container-9");
+            expect(lastOpened).toBeDefined();
+            expect(lastOpened!).toBeGreaterThanOrEqual(timestamp);
+        });
+    });
+
+    describe("Integration", () => {
+        it("stores and retrieves multiple containers", () => {
+            setContainerTitleInMetaDoc("container-a", "Container A");
+            setContainerTitleInMetaDoc("container-b", "Container B");
+            setContainerTitleInMetaDoc("container-c", "Container C");
+
+            expect(getContainerTitleFromMetaDoc("container-a")).toBe("Container A");
+            expect(getContainerTitleFromMetaDoc("container-b")).toBe("Container B");
+            expect(getContainerTitleFromMetaDoc("container-c")).toBe("Container C");
+        });
+
+        it("handles multiple updates to same container", async () => {
+            const containerId = "container-d";
+            setContainerTitleInMetaDoc(containerId, "Version 1");
+            updateLastOpenedAt(containerId);
+            const firstTimestamp = getLastOpenedAt(containerId);
+
+            // Wait a bit to ensure different timestamp
+            await new Promise(resolve => setTimeout(resolve, 10));
+            setContainerTitleInMetaDoc(containerId, "Version 2");
+            updateLastOpenedAt(containerId);
+            const secondTimestamp = getLastOpenedAt(containerId);
+
+            expect(getContainerTitleFromMetaDoc(containerId)).toBe("Version 2");
+            expect(secondTimestamp).toBeDefined();
+            expect(firstTimestamp).toBeDefined();
+            expect(secondTimestamp!).toBeGreaterThan(firstTimestamp!);
+        });
+    });
+});

--- a/client/src/lib/projectTitleProvider.ts
+++ b/client/src/lib/projectTitleProvider.ts
@@ -1,14 +1,19 @@
 // Neutral title provider used by unit tests to avoid direct backend references.
 // In application runtime, it delegates to the existing implementation.
 
+import { getContainerTitleFromMetaDoc } from "./metaDoc.svelte";
 import * as yjsService from "./yjsService.svelte";
 
 export function getProjectTitle(containerId: string): string {
     try {
         // Defer to existing implementation without exposing it in test code.
-        return typeof yjsService.getProjectTitle === "function" ? yjsService.getProjectTitle(containerId) : "";
+        if (typeof yjsService.getProjectTitle === "function") {
+            return yjsService.getProjectTitle(containerId);
+        }
+        // Fallback: try metaDoc directly
+        return getContainerTitleFromMetaDoc(containerId);
     } catch {
-        // Fallback for tests or when the module isn’t available.
+        // Final fallback for tests or when the module isn't available.
         return "";
     }
 }


### PR DESCRIPTION
Closes #1085

This PR addresses issue #1085.

# Ensure metadata Y.Doc integration consistency with #1061

## Summary

Verify that the full Y.Doc caching implementation is consistent with the metadata Y.Doc from #1061, ensuring container IDs are u