### PR TITLE
Fix issue #1087: Add E2E tests for offline editing and cache restoration

### DIFF
--- a/client/e2e/ydoc-persistence.spec.ts
+++ b/client/e2e/ydoc-persistence.spec.ts
@@ -1,7 +1,7 @@
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 import "./utils/registerAfterEachSnapshot";
-import { BrowserContext, expect, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { TestHelpers } from "./utils/testHelpers";
 
 /**
@@ -59,24 +59,6 @@ test.describe("Y.Doc persistence and offline editing", () => {
             try {
                 const gs = (window as any).generalStore || (window as any).appStore;
                 return gs?.project?.title ?? "";
-            } catch {
-                return "";
-            }
-        });
-    }
-
-    /**
-     * Helper to get container ID from project state
-     */
-    async function getContainerId(page: any): Promise<string> {
-        return await page.evaluate(() => {
-            try {
-                const yjsService = (window as any).__YJS_SERVICE__;
-                if (yjsService?.getClientByProjectTitle) {
-                    return ""; // Will be filled by registry
-                }
-                // Fallback: extract from URL or registry
-                return (window as any).__CURRENT_PROJECT__?.id || "";
             } catch {
                 return "";
             }
@@ -406,7 +388,7 @@ test.describe("Y.Doc persistence and offline editing", () => {
             const pageName1 = container1Info.pageName;
 
             // Verify content
-            let content1 = await getCurrentPageTexts(page);
+            const content1 = await getCurrentPageTexts(page);
             expect(content1[0]).toBe("Container 1 specific data");
 
             // Create second container

--- a/client/src/components/BacklinkPanel.svelte
+++ b/client/src/components/BacklinkPanel.svelte
@@ -57,13 +57,13 @@ function togglePanel() {
 }
 
 // バックリンク先のページに移動する
-function navigateToPage(_pageId: string, pageName: string) {
+async function navigateToPage(_pageId: string, pageName: string) {
     if (!projectName) {
         // プロジェクト名が指定されていない場合は現在のプロジェクトを使用
-        goto(`/${pageName}`);
+        await goto(`/${pageName}`);
     }
     else {
-        goto(`/${projectName}/${pageName}`);
+        await goto(`/${projectName}/${pageName}`);
     }
 }
 


### PR DESCRIPTION
Closes #1087

This PR addresses issue #1087.

# Add E2E tests for offline editing and cache restoration

## Summary

Add end-to-end (E2E) tests using Playwright to verify that:
1. Container content persists across page reloads
2. Offline editing 