### PR TITLE
🌐 Lingo: Translate UserManager.ts to English

### DIFF
--- a/client/src/auth/UserManager.ts
+++ b/client/src/auth/UserManager.ts
@@ -13,11 +13,11 @@ import {
 } from "firebase/auth";
 import { getEnv } from "../lib/env";
 import { getFirebaseApp } from "../lib/firebase-app";
-import { getLogger } from "../lib/logger"; // log関数をインポート
+import { getLogger } from "../lib/logger"; // Import log function
 
 const logger = getLogger() as any;
 
-// ユーザー情報の型定義
+// User information type definition
 export interface IUser {
     id: string;
     name: string;
@@ -26,16 +26,16 @@ export interface IUser {
     providerIds?: string[];
 }
 
-// 認証結果の型定義
+// Authentication result type definition
 export interface IAuthResult {
     user: IUser;
 }
 
-// 認証イベントリスナーの型定義
+// Authentication event listener type definition
 type AuthEventListener = (result: IAuthResult | null) => void;
 
 export class UserManager {
-    // Firebase 設定
+    // Firebase configuration
     private firebaseConfig = {
         apiKey: (typeof import.meta !== "undefined" && import.meta.env?.VITE_FIREBASE_API_KEY) || "demo-api-key",
         authDomain: (typeof import.meta !== "undefined" && import.meta.env?.VITE_FIREBASE_AUTH_DOMAIN)
@@ -65,12 +65,12 @@ export class UserManager {
     private listeners: AuthEventListener[] = [];
     private unsubscribeAuth: (() => void) | null = null;
 
-    // 開発環境かどうかの判定
+    // Determine if it is a development environment
     private isDevelopment = (typeof import.meta !== "undefined" && import.meta.env?.DEV) || false;
 
     /**
-     * Firebaseアプリインスタンスを遅延初期化で取得
-     * SSR環境での重複初期化を防ぐ
+     * Lazily initialize Firebase app instance
+     * Prevent duplicate initialization in SSR environment
      */
     private get app(): FirebaseApp {
         if (!this._app) {
@@ -80,7 +80,7 @@ export class UserManager {
     }
 
     /**
-     * Firebase Authインスタンスを遅延初期化で取得
+     * Lazily initialize Firebase Auth instance
      */
     get auth(): Auth {
         if (!this._auth) {
@@ -90,7 +90,7 @@ export class UserManager {
     }
 
     /**
-     * API Base URLを取得
+     * Get API Base URL
      */
     get functionsUrl(): string {
         return this.apiBaseUrl;
@@ -99,28 +99,28 @@ export class UserManager {
     constructor() {
         logger.debug("Initializing...");
 
-        // テスト環境でのアクセスのためにグローバルに設定
+        // Set globally for access in test environment
         if (typeof window !== "undefined") {
             (window as unknown as { __USER_MANAGER__: UserManager; }).__USER_MANAGER__ = this;
         }
 
-        // 認証リスナーを非同期で初期化
+        // Initialize auth listener asynchronously
         this.initAuthListenerAsync();
 
-        // テスト環境の検出
+        // Detect test environment
         const isTestEnv = (typeof import.meta !== "undefined" && import.meta.env?.MODE === "test")
             || (typeof process !== "undefined" && process.env?.NODE_ENV === "test")
             || (typeof import.meta !== "undefined" && import.meta.env?.VITE_IS_TEST === "true")
             || (typeof window !== "undefined" && window.localStorage?.getItem?.("VITE_IS_TEST") === "true")
             || (typeof window !== "undefined" && (window as any).__E2E__ === true);
 
-        // プロダクション環境では絶対にエミュレータを使用しない
+        // Never use emulator in production environment
         const isProduction = !(typeof import.meta !== "undefined" && import.meta.env?.DEV)
             && (typeof import.meta !== "undefined" && import.meta.env?.MODE) === "production";
         const useEmulatorInLocalStorage = typeof window !== "undefined"
             && window.localStorage?.getItem("VITE_USE_FIREBASE_EMULATOR") === "true";
 
-        // isTestEnv のいずれかが true の場合は useEmulator を true にする
+        // Set useEmulator to true if any of isTestEnv is true
         let useEmulator = isTestEnv
             || (typeof import.meta !== "undefined" && import.meta.env?.VITE_USE_FIREBASE_EMULATOR === "true")
             || useEmulatorInLocalStorage;
@@ -141,24 +141,24 @@ export class UserManager {
             useEmulator = false;
         }
 
-        // サーバーサイドレンダリング環境かどうかを判定
+        // Determine if it is a server-side rendering environment
         const isSSR = typeof window === "undefined";
 
-        // Firebase Auth Emulatorに接続
+        // Connect to Firebase Auth Emulator
         if (useEmulator) {
             logger.info("Connecting to Auth emulator");
             try {
                 const connected = this.connectToFirebaseEmulator();
                 if (connected) {
                     logger.info("Successfully connected to Auth emulator");
-                    // テスト環境では自動的にテストユーザーでログイン
+                    // Automatically login with test user in test environment
                     this._setupMockUser(useEmulator);
                 } else {
-                    // エミュレーター接続に失敗した場合
+                    // If emulator connection fails
                     const error = new Error("Failed to connect to Firebase Auth emulator");
                     logger.error({ error }, "Failed to connect to Auth emulator, authentication may not work");
 
-                    // SSR環境ではエラーをスローしない（クライアント側でリトライできるように）
+                    // Do not throw error in SSR environment (allow client-side retry)
                     if (!isSSR) {
                         if (isTestEnv) {
                             logger.warn(
@@ -173,10 +173,10 @@ export class UserManager {
                     }
                 }
             } catch (err) {
-                // エミュレーターに接続できない場合
+                // If unable to connect to emulator
                 logger.error({ error: err }, "Failed to connect to Auth emulator");
 
-                // SSR環境ではエラーをスローしない
+                // Do not throw error in SSR environment
                 if (!isSSR) {
                     if (isTestEnv) {
                         logger.warn(
@@ -193,10 +193,10 @@ export class UserManager {
         }
     }
 
-    // Firebase Auth Emulatorに接続
+    // Connect to Firebase Auth Emulator
     private connectToFirebaseEmulator(): boolean {
         try {
-            // 環境変数から接続情報を取得（デフォルトはlocalhost:59099）
+            // Get connection info from environment variables (default is localhost:59099)
             const host = (typeof import.meta !== "undefined" && import.meta.env?.VITE_FIREBASE_EMULATOR_HOST)
                 || "localhost";
             const port = parseInt(
@@ -214,7 +214,7 @@ export class UserManager {
         }
     }
 
-    // テスト環境用のユーザーをセットアップ
+    // Setup user for test environment
     private async _setupMockUser(useEmulator: boolean) {
         const isTestEnv = (typeof import.meta !== "undefined" && import.meta.env?.MODE === "test")
             || (typeof process !== "undefined" && process.env?.NODE_ENV === "test")
@@ -224,19 +224,19 @@ export class UserManager {
         const isProduction = !(typeof import.meta !== "undefined" && import.meta.env?.DEV)
             && (typeof import.meta !== "undefined" && import.meta.env?.MODE) === "production";
 
-        // E2Eテスト用にFirebaseメール/パスワード認証を使う
+        // Use Firebase email/password auth for E2E tests
         if (isTestEnv && !isProduction && useEmulator) {
             logger.info("[UserManager] E2E test environment detected, using Firebase auth emulator with test account");
             logger.info("[UserManager] Attempting E2E test login with test@example.com");
 
-            // テストユーザーでログイン
+            // Login with test user
             try {
                 await signInWithEmailAndPassword(this.auth, "test@example.com", "password");
                 logger.info("[UserManager] Test user login successful");
             } catch (error) {
                 logger.error({ error }, "[UserManager] Test user login failed");
 
-                // ユーザーが存在しない場合は作成を試みる
+                // Attempt to create user if not exists
                 try {
                     logger.info("[UserManager] Attempting to create test user");
                     await createUserWithEmailAndPassword(this.auth, "test@example.com", "password");
@@ -250,12 +250,12 @@ export class UserManager {
         }
     }
 
-    // ユーザーサインイン処理
+    // User sign-in process
     private async handleUserSignedIn(firebaseUser: FirebaseUser): Promise<void> {
         try {
             logger.debug("handleUserSignedIn started", { uid: firebaseUser.uid });
 
-            // ユーザーオブジェクトを作成
+            // Create user object
             const providerIds = firebaseUser.providerData
                 .map(info => info?.providerId)
                 .filter((id): id is string => !!id);
@@ -276,7 +276,7 @@ export class UserManager {
                 listenerCount: this.listeners.length,
             });
 
-            // 認証結果をリスナーに通知
+            // Notify listeners of authentication result
             this.notifyListeners({
                 user,
             });
@@ -284,12 +284,12 @@ export class UserManager {
             logger.debug("handleUserSignedIn completed successfully");
         } catch (error) {
             logger.error({ error }, "Error handling user sign in");
-            // エラーが発生した場合は認証失敗として扱う
+            // Treat as authentication failure if error occurs
             this.notifyListeners(null);
         }
     }
 
-    // ユーザーサインアウト処理
+    // User sign-out process
     private handleUserSignedOut(): void {
         logger.debug("User signed out");
         this.notifyListeners(null);
@@ -342,7 +342,7 @@ export class UserManager {
         }
 
         try {
-            // Firebase appとauthの初期化を確実に行う
+            // Ensure Firebase app and auth are initialized
             const auth = this.auth;
             // ... existing logic ...
             logger.debug("Firebase Auth initialized, setting up listener");
@@ -374,19 +374,19 @@ export class UserManager {
         }
     }
 
-    // Googleでログイン
+    // Login with Google
     public async loginWithGoogle(): Promise<void> {
         try {
             const provider = new GoogleAuthProvider();
             await signInWithPopup(this.auth, provider);
-            // 認証状態の変更はonAuthStateChangedで検知される
+            // Auth state changes are detected by onAuthStateChanged
         } catch (error) {
             logger.error({ error }, "[UserManager] Google login error");
             throw error;
         }
     }
 
-    // メールアドレスとパスワードでログイン（開発環境用）
+    // Login with email and password (for development)
     public async loginWithEmailPassword(email: string, password: string): Promise<void> {
         if (this.isMockMode) {
             logger.info("[UserManager] Mock Mode: Simulating email/password login");
@@ -400,10 +400,10 @@ export class UserManager {
                 `[UserManager] Current auth state: ${this.auth.currentUser ? "authenticated" : "not authenticated"}`,
             );
 
-            // 開発環境の場合
+            // In development environment
             if (this.isDevelopment) {
                 try {
-                    // まず通常のFirebase認証を試みる
+                    // Try standard Firebase authentication first
                     logger.debug("[UserManager] Calling signInWithEmailAndPassword");
                     const userCredential = await signInWithEmailAndPassword(this.auth, email, password);
                     logger.info("[UserManager] Email/password login successful via Firebase Auth", {
@@ -414,7 +414,7 @@ export class UserManager {
                     const errorObj = firebaseError as { message?: string; code?: string; };
                     logger.warn("[UserManager] Firebase Auth login failed:", errorObj.message);
 
-                    // ユーザーが存在しない場合は作成を試みる
+                    // Attempt to create user if not exists
                     if (errorObj.code === "auth/user-not-found") {
                         try {
                             logger.info("[UserManager] User not found, attempting to create user");
@@ -427,11 +427,11 @@ export class UserManager {
                             logger.error({ error: createError }, "[UserManager] Failed to create new user");
                         }
                     }
-                    // すべての方法が失敗した場合は元のエラーをスロー
+                    // Throw original error if all methods fail
                     throw firebaseError;
                 }
             } else {
-                // 本番環境では通常のFirebase認証のみを使用
+                // Use only standard Firebase authentication in production
                 logger.debug("[UserManager] Production environment, using Firebase Auth only");
                 await signInWithEmailAndPassword(this.auth, email, password);
             }
@@ -441,7 +441,7 @@ export class UserManager {
         }
     }
 
-    // ログアウト
+    // Logout
     public async logout(): Promise<void> {
         if (this.isMockMode) {
             this.notifyListeners(null);
@@ -449,18 +449,18 @@ export class UserManager {
         }
         try {
             await signOut(this.auth);
-            // ログアウト処理はonAuthStateChangedで検知される
+            // Logout process is detected by onAuthStateChanged
         } catch (error) {
             logger.error({ error }, "[UserManager] Logout error");
             throw error;
         }
     }
 
-    // 認証イベントのリスナーを追加
+    // Add authentication event listener
     public addEventListener(listener: AuthEventListener): () => void {
         this.listeners.push(listener);
 
-        // 既に認証済みの場合は即座に通知（FluidTokenは不要）
+        // Notify immediately if already authenticated (FluidToken not needed)
         if (this.isMockMode) {
             const user = this.getCurrentUser();
             if (user) listener({ user });
@@ -476,7 +476,7 @@ export class UserManager {
             }
         }
 
-        // リスナー削除用の関数を返す
+        // Return function to remove listener
         return () => {
             const index = this.listeners.indexOf(listener);
             if (index !== -1) {
@@ -485,14 +485,14 @@ export class UserManager {
         };
     }
 
-    // リスナーに認証状態の変更を通知
+    // Notify listeners of auth state change
     private notifyListeners(authResult: IAuthResult | null): void {
         for (const listener of this.listeners) {
             listener(authResult);
         }
     }
 
-    // 手動でリスナーに通知（デバッグ用）
+    // Manually notify listeners (for debug)
     public manualNotifyListeners(authResult: IAuthResult | null): void {
         this.notifyListeners(authResult);
     }
@@ -509,7 +509,7 @@ export class UserManager {
         this.listeners = [];
     }
 
-    // テストおよび開発用: 明示的にIDトークンを更新し、リスナーへ通知
+    // For test and dev: Explicitly refresh ID token and notify listeners
     public async refreshToken(): Promise<void> {
         try {
             const current = this.auth.currentUser;
@@ -521,7 +521,7 @@ export class UserManager {
             await current.getIdToken(true);
             const user = this.getCurrentUser();
             if (user) {
-                // 通知により attachTokenRefresh 経由でプロバイダの auth パラメータが更新される
+                // Notification updates provider auth params via attachTokenRefresh
                 this.notifyListeners({ user });
             }
         } catch (err) {


### PR DESCRIPTION
💡 **What:** Translated all Japanese comments in `client/src/auth/UserManager.ts` to English.
🎯 **Why:** Improving codebase accessibility and consistency for non-Japanese speakers, aligning with the "Lingo" mission.
🛠 **Verification:**
- Ran `npm run lint` in `client/` (verified no new errors).
- Ran `npm run test:unit src/tests/userManager-global.test.ts` (verified tests pass).
- Manually reviewed the file to ensure no code logic was altered.

---
*PR created automatically by Jules for task [4524363883076602033](https://jules.google.com/task/4524363883076602033) started by @kitamura-tetsuo*