### PR TITLE
🌐 Lingo: Translate ScrapboxFormatter.test.ts to English

### DIFF
--- a/client/src/utils/ScrapboxFormatter.test.ts
+++ b/client/src/utils/ScrapboxFormatter.test.ts
@@ -103,7 +103,7 @@ describe("ScrapboxFormatter", () => {
                 const input = "[test-page]";
                 const result = ScrapboxFormatter.formatToHtml(input);
 
-                // 内部リンクのHTMLが正しく生成されることを確認
+                // Verify that the HTML for internal links is generated correctly
                 // Test environment initializes project title as "Untitled Project" via store.svelte.ts
                 expect(result).toMatch(
                     /<a href="\/Untitled%20Project\/test-page"[^>]*class="[^"]*internal-link[^"]*"[^>]*>test-page<\/a>/,
@@ -126,7 +126,7 @@ describe("ScrapboxFormatter", () => {
                 const input = "[/project-name/page-name]";
                 const result = ScrapboxFormatter.formatToHtml(input);
 
-                // プロジェクト内部リンクのHTMLが正しく生成されることを確認
+                // Verify that the HTML for project internal links is generated correctly
                 expect(result).toMatch(
                     /<a href="\/project-name\/page-name"[^>]*class="[^"]*internal-link[^"]*project-link[^"]*"[^>]*>project-name\/page-name<\/a>/,
                 );
@@ -150,7 +150,7 @@ describe("ScrapboxFormatter", () => {
                 const input = "This is [test-page] and [/project/other-page]";
                 const result = ScrapboxFormatter.formatToHtml(input);
 
-                // 両方のリンクが正しく生成されることを確認
+                // Verify that both links are generated correctly
                 expect(result).toMatch(
                     /<a href="\/Untitled%20Project\/test-page"[^>]*class="[^"]*internal-link[^"]*"[^>]*>test-page<\/a>/,
                 );
@@ -209,8 +209,8 @@ describe("ScrapboxFormatter", () => {
                 console.log("Bold with internal link result:", result);
 
                 expect(result).toContain("<strong>");
-                // 太字の中に内部リンクがある場合、HTMLの構造が複雑になるため、
-                // より柔軟なマッチングを使用
+                // Since the HTML structure becomes complex when there is an internal link inside bold text,
+                // use more flexible matching
                 expect(result).toContain('href="/Untitled%20Project/internal-link');
                 expect(result).toContain('class="internal-link');
                 expect(result).toContain(">internal-link");
@@ -220,9 +220,9 @@ describe("ScrapboxFormatter", () => {
                 const input = "[/ italic] and [/project/page]";
                 const result = ScrapboxFormatter.formatToHtml(input);
 
-                // 斜体として処理される（スペースあり）
+                // Processed as italic (with space)
                 expect(result).toContain("<em>italic</em>");
-                // プロジェクト内部リンクとして処理される（スペースなし）
+                // Processed as project internal link (without space)
                 expect(result).toMatch(
                     /<a href="\/project\/page"[^>]*class="[^"]*internal-link[^"]*project-link[^"]*"[^>]*>project\/page<\/a>/,
                 );
@@ -236,20 +236,20 @@ describe("ScrapboxFormatter", () => {
             });
 
             it("should handle bold with italic combination", () => {
-                const input = "これは[[太字と[/ 斜体]の組み合わせ]]です";
+                const input = "This is [[bold and [/ italic] combination]].";
                 const result = ScrapboxFormatter.formatToHtml(input);
 
                 console.log("Bold with italic result:", result);
 
-                // 太字と斜体の組み合わせが正しく処理されることを確認
+                // Verify that the combination of bold and italic is processed correctly
                 expect(result).toContain("<strong>");
-                expect(result).toContain("太字と");
+                expect(result).toContain("bold and");
                 expect(result).toContain("<em>");
-                expect(result).toContain("斜体");
+                expect(result).toContain("italic");
                 expect(result).toContain("</em>");
-                expect(result).toContain("の組み合わせ");
+                expect(result).toContain(" combination");
                 expect(result).toContain("</strong>");
-                // 内部リンクとして認識されていないことを確認
+                // Verify that it is not recognized as an internal link
                 expect(result).not.toContain('class="internal-link');
             });
         });


### PR DESCRIPTION
💡 **What:** Translated Japanese comments and strings in `client/src/utils/ScrapboxFormatter.test.ts` to English.
🎯 **Why:** Improving codebase accessibility and consistency by ensuring all tests and comments are in English.
🛠 **Verification:** Ran `vitest run client/src/utils/ScrapboxFormatter.test.ts` to ensure tests pass. Verified that no unrelated changes were included.

---
*PR created automatically by Jules for task [8707318042075971952](https://jules.google.com/task/8707318042075971952) started by @kitamura-tetsuo*