### PR TITLE
🌐 Lingo: Translate NetworkErrorAlert to English

### DIFF
--- a/client/src/components/NetworkErrorAlert.svelte
+++ b/client/src/components/NetworkErrorAlert.svelte
@@ -19,13 +19,13 @@ function dismiss() {
     >
         <div class="error-icon" aria-hidden="true">⚠️</div>
         <div class="error-content">
-            <h3>サーバー接続エラー</h3>
+            <h3>Server Connection Error</h3>
             <p>{error}</p>
             <div class="error-actions">
                 {#if retryCallback}
-                    <button class="retry-btn" onclick={retryCallback}>再試行</button>
+                    <button class="retry-btn" onclick={retryCallback}>Retry</button>
                 {/if}
-                <button class="dismiss-btn" onclick={dismiss}>閉じる</button>
+                <button class="dismiss-btn" onclick={dismiss}>Close</button>
             </div>
         </div>
     </div>

--- a/client/src/components/NetworkErrorAlert.test.ts
+++ b/client/src/components/NetworkErrorAlert.test.ts
@@ -6,7 +6,7 @@ describe("NetworkErrorAlert", () => {
     it("should render error message when error prop is provided", () => {
         render(NetworkErrorAlert, { error: "Something went wrong" });
         expect(screen.getByText("Something went wrong")).toBeInTheDocument();
-        expect(screen.getByText("サーバー接続エラー")).toBeInTheDocument();
+        expect(screen.getByText("Server Connection Error")).toBeInTheDocument();
     });
 
     it("should have alert role for accessibility", () => {
@@ -20,7 +20,7 @@ describe("NetworkErrorAlert", () => {
         const retryCallback = vi.fn();
         render(NetworkErrorAlert, { error: "Error", retryCallback });
 
-        const retryBtn = screen.getByText("再試行");
+        const retryBtn = screen.getByText("Retry");
         await fireEvent.click(retryBtn);
 
         expect(retryCallback).toHaveBeenCalled();


### PR DESCRIPTION
💡 **What:** Translated `NetworkErrorAlert.svelte` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:**
- Ran `pnpm test:unit src/components/NetworkErrorAlert.test.ts` (Passed).
- Visually verified the component using a temporary Playwright script and screenshot.

---
*PR created automatically by Jules for task [7242281335211922070](https://jules.google.com/task/7242281335211922070) started by @kitamura-tetsuo*