### PR TITLE
🌐 Lingo: Translate QueryEditor placeholder to English

### DIFF
--- a/client/src/components/QueryEditor.svelte
+++ b/client/src/components/QueryEditor.svelte
@@ -18,6 +18,6 @@ async function run() {
 </script>
 
 <div class="query-editor">
-    <textarea bind:value={sql} rows="4" class="border p-2 w-full" placeholder="SQLクエリを入力してください"></textarea>
+    <textarea bind:value={sql} rows="4" class="border p-2 w-full" placeholder="Please enter an SQL query"></textarea>
     <button onclick={run} class="mt-2 px-4 py-1 bg-blue-500 text-white rounded hover:bg-blue-600">Run</button>
 </div>

--- a/client/src/components/QueryEditor.test.ts
+++ b/client/src/components/QueryEditor.test.ts
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
+import QueryEditor from "./QueryEditor.svelte";
+
+vi.mock("../services/sqlService");
+
+describe("QueryEditor", () => {
+    it("renders with correct placeholder", () => {
+        render(QueryEditor);
+        expect(screen.getByPlaceholderText("Please enter an SQL query")).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
💡 **What:** Translated the placeholder text in `client/src/components/QueryEditor.svelte` from Japanese ("SQLクエリを入力してください") to English ("Please enter an SQL query").
🎯 **Why:** Improving codebase accessibility and consistency by ensuring UI strings are in English.
🛠 **Verification:** 
- Created and ran a new unit test `client/src/components/QueryEditor.test.ts` which passed.
- Performed visual verification using a Playwright script to confirm the placeholder is visible and correct.


---
*PR created automatically by Jules for task [11581048988763771302](https://jules.google.com/task/11581048988763771302) started by @kitamura-tetsuo*