### PR TITLE
🎨 Palette: Add aria-controls to Sidebar toggle buttons

### DIFF
--- a/client/src/components/Sidebar.svelte
+++ b/client/src/components/Sidebar.svelte
@@ -44,6 +44,7 @@
                 class="section-header"
                 onclick={() => (isProjectsCollapsed = !isProjectsCollapsed)}
                 aria-expanded={!isProjectsCollapsed}
+                aria-controls="sidebar-projects-list"
                 aria-label="Toggle projects section"
             >
                 <h3 class="sidebar-section-title">Projects</h3>
@@ -68,7 +69,7 @@
             </button>
 
             {#if !isProjectsCollapsed}
-                <ul class="project-list">
+                <ul id="sidebar-projects-list" class="project-list">
                     {#if projectStore.projects.length === 0}
                         <li class="sidebar-placeholder">No projects available</li>
                     {:else}
@@ -103,6 +104,7 @@
                 class="section-header"
                 onclick={() => (isPagesCollapsed = !isPagesCollapsed)}
                 aria-expanded={!isPagesCollapsed}
+                aria-controls="sidebar-pages-list"
                 aria-label="Toggle pages section"
             >
                 <h3 class="sidebar-section-title">Pages</h3>
@@ -127,7 +129,7 @@
             </button>
 
             {#if !isPagesCollapsed}
-                <ul class="page-list">
+                <ul id="sidebar-pages-list" class="page-list">
                     {#if !pages || pages.length === 0}
                         <li class="sidebar-placeholder">No pages available</li>
                     {:else}


### PR DESCRIPTION
💡 **What:** Added `aria-controls` to the project and page toggle buttons in the Sidebar, and added corresponding `id`s to the `ul` elements.
🎯 **Why:** To improve accessibility for screen reader users by explicitly associating the toggle buttons with the content they control (ARIA disclosure pattern).
♿ **Accessibility:**
- Added `aria-controls="sidebar-projects-list"` to Projects toggle button.
- Added `id="sidebar-projects-list"` to Projects list.
- Added `aria-controls="sidebar-pages-list"` to Pages toggle button.
- Added `id="sidebar-pages-list"` to Pages list.

Reference: Journal entry "2024-05-24 - Expanded State Accessibility".

---
*PR created automatically by Jules for task [844887519380512323](https://jules.google.com/task/844887519380512323) started by @kitamura-tetsuo*