### PR TITLE
🌐 Lingo: Translate client/src/lib/yjs/tokenRefresh.ts to English

### DIFF
--- a/client/src/lib/yjs/tokenRefresh.ts
+++ b/client/src/lib/yjs/tokenRefresh.ts
@@ -21,7 +21,7 @@ export function refreshAuthAndReconnect(provider: TokenRefreshableProvider): () 
             console.log("[tokenRefresh] Got new token:", !!t);
             // HocuspocusProvider handles token via the token function passed at creation
             // To refresh, we can call sendToken() which will invoke the token function
-            // WS が無効化されている場合は再接続を行わない（テスト環境抑止）
+            // Do not reconnect if WS is disabled (suppressed in test environment)
             if (provider?.__wsDisabled === true) {
                 console.log("[tokenRefresh] WS disabled, skipping");
                 return;
@@ -102,7 +102,7 @@ export function refreshAuthAndReconnect(provider: TokenRefreshableProvider): () 
 
 export function attachTokenRefresh(provider: TokenRefreshableProvider): () => void {
     const handler = refreshAuthAndReconnect(provider);
-    // auth 状態通知にフックして再認証・再接続を行う（引数は未使用）
+    // Hook into auth state notification to perform re-authentication and reconnection (argument is unused)
     return userManager.addEventListener(() => {
         void handler();
     });


### PR DESCRIPTION
Translated Japanese comments in `client/src/lib/yjs/tokenRefresh.ts` to English.

💡 **What:** Translated internal comments in `client/src/lib/yjs/tokenRefresh.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:**
- Ran `npx eslint client/src/lib/yjs/tokenRefresh.ts` (passed).
- Ran `npx svelte-check` and confirmed no new errors were introduced in the file (existing errors in the file are pre-existing).

---
*PR created automatically by Jules for task [14063502807519495204](https://jules.google.com/task/14063502807519495204) started by @kitamura-tetsuo*