### PR TITLE
🎨 Palette: Accessible CommentThread buttons and inputs

### DIFF
--- a/client/src/components/CommentThread.svelte
+++ b/client/src/components/CommentThread.svelte
@@ -437,20 +437,20 @@ onMount(() => {
     {#each renderCommentsState as c (c.id)}
         <div class="comment" data-testid="comment-{c.id}">
             {#if editingId === c.id}
-                <input bind:value={editText} data-testid="edit-input-{c.id}" />
-                <button onclick={() => saveEdit(c.id)} data-testid="save-edit-{c.id}">Save</button>
-                <button onclick={() => (editingId = null)} data-testid="cancel-edit-{c.id}">Cancel</button>
+                <input bind:value={editText} data-testid="edit-input-{c.id}" aria-label="Edit comment text" />
+                <button onclick={() => saveEdit(c.id)} data-testid="save-edit-{c.id}" aria-label="Save edit" title="Save">Save</button>
+                <button onclick={() => (editingId = null)} data-testid="cancel-edit-{c.id}" aria-label="Cancel edit" title="Cancel">Cancel</button>
             {:else}
                 <span class="author">{c.author}:</span>
                 <span class="text">{c.text}</span>
-                <button onclick={() => startEdit(c)} class="edit">✎</button>
-                <button onclick={() => remove(c.id)} class="delete">×</button>
+                <button onclick={() => startEdit(c)} class="edit" aria-label="Edit comment" title="Edit">✎</button>
+                <button onclick={() => remove(c.id)} class="delete" aria-label="Delete comment" title="Delete">×</button>
             {/if}
         </div>
     {/each}
     <form onsubmit={(e) => { e.preventDefault(); try { add(); } catch (err) { logger.error('[CommentThread] submit add error', err); } }} data-testid="comment-form">
-        <input placeholder="Add comment" bind:value={newText} data-testid="new-comment-input" oninput={(e) => { try { e2eLog({ tag: 'input', value: (e.target as HTMLInputElement).value }); } catch {} }} />
-        <button type="submit" data-testid="add-comment-btn">Add</button>
+        <input placeholder="Add comment" bind:value={newText} data-testid="new-comment-input" aria-label="New comment text" oninput={(e) => { try { e2eLog({ tag: 'input', value: (e.target as HTMLInputElement).value }); } catch {} }} />
+        <button type="submit" data-testid="add-comment-btn" aria-label="Add comment">Add</button>
     </form>
 </div>
 


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only buttons (Edit, Delete) and the new comment input in `CommentThread.svelte`.

🎯 Why: To improve accessibility for screen reader users who previously encountered unlabelled buttons, and to provide tooltips for mouse users. This aligns with the "Palette" mission of micro-UX improvements.

📸 Before/After: Visual changes are minimal (tooltips on hover). Accessibility tree now shows meaningful names for buttons.

♿ Accessibility:
- Edit button: "Edit comment"
- Delete button: "Delete comment"
- New comment input: "New comment text"

---
*PR created automatically by Jules for task [11874206384997776519](https://jules.google.com/task/11874206384997776519) started by @kitamura-tetsuo*