### PR TITLE
🌐 Lingo: Translate Delete Projects page to English

### DIFF
--- a/client/e2e/basic/project-deletion.spec.ts
+++ b/client/e2e/basic/project-deletion.spec.ts
@@ -94,7 +94,7 @@ test.describe("Project Deletion", () => {
         await page.click("button:has-text('Delete')");
 
         // 7. Verify success message
-        await expect(page.locator("text=選択したプロジェクトを削除しました")).toBeVisible();
+        await expect(page.locator("text=Deleted selected projects")).toBeVisible();
 
         // 8. Verify target is removed and keeper remains (after reload)
         // The page reloads automatically after 1 second

--- a/client/e2e/new/DEL-0001.spec.ts
+++ b/client/e2e/new/DEL-0001.spec.ts
@@ -43,7 +43,7 @@ test.describe("DEL-0001: Project Deletion Page", () => {
                     await expect(errorElement).toBeVisible();
                 } else if (await successElement.count() > 0) {
                     await expect(
-                        page.getByText("選択したプロジェクトを削除しました"),
+                        page.getByText("Deleted selected projects"),
                     ).toBeVisible();
                 } else {
                     throw new Error("Neither error nor success message was displayed");

--- a/client/src/routes/projects/delete/+page.svelte
+++ b/client/src/routes/projects/delete/+page.svelte
@@ -61,18 +61,18 @@
                     selectedProjects.delete(p.id);
                     deletedCount++;
                 } else {
-                    error = `削除に失敗しました: ${p.name}`;
+                    error = `Failed to delete: ${p.name}`;
                     break;
                 }
             } catch (err) {
-                error = `削除エラー: ${p.name} - ${err instanceof Error ? err.message : String(err)}`;
+                error = `Deletion error: ${p.name} - ${err instanceof Error ? err.message : String(err)}`;
                 break;
             }
         }
 
         if (!error && deletedCount > 0) {
-            success = "選択したプロジェクトを削除しました";
-            // 削除後にプロジェクトリストを更新するため、少し待ってからページをリロード
+            success = "Deleted selected projects";
+            // Wait a bit before reloading the page to update the project list after deletion
             setTimeout(() => {
                 window.location.reload();
             }, 1000);
@@ -123,7 +123,7 @@
                                     } else {
                                         selectedProjects.delete(project.id);
                                     }
-                                    // Svelteのリアクティビティのために再代入
+                                    // Reassign to trigger Svelte reactivity
                                     selectedProjects = new Set(
                                         selectedProjects,
                                     );


### PR DESCRIPTION
💡 **What:** Translated the "Delete Projects" page (`client/src/routes/projects/delete/+page.svelte`) from Japanese to English.
- Translated error messages: "削除に失敗しました" -> "Failed to delete", "削除エラー" -> "Deletion error".
- Translated success message: "選択したプロジェクトを削除しました" -> "Deleted selected projects".
- Translated internal comments.

🎯 **Why:** Improving codebase accessibility and consistency by ensuring UI strings and comments are in English.

🛠 **Verification:**
- Ran `./scripts/test.sh client/e2e/basic/project-deletion.spec.ts` (Passed).
- Ran `./scripts/test.sh client/e2e/new/DEL-0001.spec.ts` (Passed).
- Visually verified the success message using a Playwright script.

---
*PR created automatically by Jules for task [9618298086374125283](https://jules.google.com/task/9618298086374125283) started by @kitamura-tetsuo*