### PR TITLE
🌐 Lingo: Translate client/src/routes/api/list-schedules/+server.ts to English

### DIFF
--- a/client/src/routes/api/list-schedules/+server.ts
+++ b/client/src/routes/api/list-schedules/+server.ts
@@ -10,7 +10,7 @@ export const GET: RequestHandler = async ({ url }) => {
             return json({ error: "Missing required parameters" }, { status: 400 });
         }
 
-        // Firebase Functionsのエンドポイントにプロキシ
+        // Proxy to Firebase Functions endpoint
         const apiBaseUrl = process.env.VITE_FIREBASE_FUNCTIONS_URL || "http://localhost:57000";
         const response = await fetch(`${apiBaseUrl}/api/list-schedules`, {
             method: "POST",


### PR DESCRIPTION
💡 **What:** Translated `client/src/routes/api/list-schedules/+server.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `pnpm lint` and `npx vitest run src/tests/scheduleService.test.ts` in `client`.

---
*PR created automatically by Jules for task [6218191979707699145](https://jules.google.com/task/6218191979707699145) started by @kitamura-tetsuo*