### PR TITLE
🌐 Lingo: Translate client/src/lib/debug.ts to English

### DIFF
--- a/client/src/lib/debug.ts
+++ b/client/src/lib/debug.ts
@@ -31,7 +31,7 @@ export function setupGlobalDebugFunctions() {
                 delete win.__SVELTE_GOTO__;
             } catch {}
         }
-        // サービス / ストア / ユーザーマネージャ
+        // Service / Store / User Manager
         win.__FLUID_SERVICE__ = yjsHighService;
         win.__FLUID_STORE__ = yjsStore; // keep legacy name for helpers
         win.__USER_MANAGER__ = userManager;
@@ -65,7 +65,7 @@ if (process.env.NODE_ENV === "test") {
         testWin.__USER_MANAGER__ = userManager;
         testWin.__SNAPSHOT_SERVICE__ = snapshotService;
 
-        // SharedTreeのデータ構造を取得するデバッグ関数
+        // Debug function to get SharedTree data structure
         window.getFluidTreeDebugData = function(): Record<string, unknown> {
             if (!yjsStore.yjsClient) {
                 return { error: "YjsClient not initialized", items: [] };
@@ -73,7 +73,7 @@ if (process.env.NODE_ENV === "test") {
             return (yjsStore.yjsClient as { getAllData: () => Record<string, unknown>; }).getAllData();
         };
 
-        // 特定のパスのデータを取得するデバッグ関数
+        // Debug function to get data at a specific path
         window.getFluidTreePathData = function(path?: string): Record<string, unknown> {
             if (!yjsStore.yjsClient) {
                 return { error: "YjsClient not initialized", items: [] };


### PR DESCRIPTION
Translated Japanese comments in `client/src/lib/debug.ts` to English.
This file is used to expose debug functions to the `window` object, particularly useful during testing and development.
The translation makes the purpose of these debug helpers clearer for non-Japanese speakers.

Verified with `pnpm lint` and `npm run test:unit`.

---
*PR created automatically by Jules for task [17566413750987386862](https://jules.google.com/task/17566413750987386862) started by @kitamura-tetsuo*