### PR TITLE
Add E2E test for double-input bug reproduction

### DIFF
--- a/client/e2e/basic/reproduce-double-input-3a7b1c2d.spec.ts
+++ b/client/e2e/basic/reproduce-double-input-3a7b1c2d.spec.ts
@@ -1,0 +1,42 @@
+import "../utils/registerAfterEachSnapshot";
+import { registerCoverageHooks } from "../utils/registerCoverageHooks";
+registerCoverageHooks();
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("Reproduction of double-input bug", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        // Prepare test environment with one empty line
+        await TestHelpers.prepareTestEnvironment(page, testInfo, [""]);
+    });
+
+    test("typing 'abc' results in 'abc' and not 'aabbcc'", async ({ page }) => {
+        // Wait for the item to be visible and editable
+        // prepareTestEnvironment creates page title + lines.
+        // We pass [""] so we expect 2 items (title + empty item).
+        await TestHelpers.waitForOutlinerItems(page, 2);
+
+        // Select the first regular item (not the page title)
+        const itemSelector = ".outliner-item:not(.page-title)";
+
+        // Wait for the item to be visible
+        await page.waitForSelector(itemSelector);
+
+        // Click to focus
+        await page.click(itemSelector);
+
+        // Wait for cursor to be ready (ensures focus and visibility)
+        await TestHelpers.ensureCursorReady(page);
+
+        // Type "abc"
+        const textToType = "abc";
+        await page.keyboard.type(textToType);
+
+        // Wait for UI to stabilize
+        await TestHelpers.waitForUIStable(page);
+
+        // Assert the text
+        const textElement = page.locator(`${itemSelector} .item-text`).first();
+        await expect(textElement).toHaveText(textToType);
+    });
+});


### PR DESCRIPTION
Added a new E2E test `client/e2e/basic/reproduce-double-input-3a7b1c2d.spec.ts` to reproduce and prevent regression of the double-input bug. The test simulates typing "abc" and asserts that the resulting text is "abc", not "aabbcc".

---
*PR created automatically by Jules for task [16245641915559557127](https://jules.google.com/task/16245641915559557127) started by @kitamura-tetsuo*

close #1992

Related issue: https://github.com/kitamura-tetsuo/outliner/issues/1992