### PR TITLE
🌐 Lingo: Translate client/svelte.config.js to English

### DIFF
--- a/client/svelte.config.js
+++ b/client/svelte.config.js
@@ -22,7 +22,7 @@ const config = {
 
     kit: {
         adapter: adapter({
-            // Firebase Hostingのpublicディレクトリに出力
+            // Output to Firebase Hosting public directory
             pages: "../build",
             assets: "../build",
             fallback: "index.html",
@@ -30,14 +30,14 @@ const config = {
             strict: true,
         }),
         serviceWorker: {
-            register: false, // 手動でService Workerを登録するため無効化
+            register: false, // Disabled to register Service Worker manually
         },
     },
 
     extensions: [".svelte", ".svx"],
 };
 
-// SSRを無効化するにはroutes/+layout.jsで設定する
+// Configure in routes/+layout.js to disable SSR
 // export const ssr = false;
 
 export default config;


### PR DESCRIPTION
💡 **What:** Translated Japanese comments in `client/svelte.config.js` to English.
🎯 **Why:** Improving codebase accessibility and consistency for non-Japanese speakers.
🛠 **Verification:** Ran `pnpm lint` (passed) and `pnpm build` (passed) in `client`. Confirmed no new type errors were introduced (pre-existing errors persist).

---
*PR created automatically by Jules for task [9454609372683809169](https://jules.google.com/task/9454609372683809169) started by @kitamura-tetsuo*