### PR TITLE
🌐 Lingo: Translate client/src/app.css to English

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -10,7 +10,7 @@ html.dark {
     @apply bg-gray-900 text-gray-100;
 }
 
-/* 内部リンクのスタイル */
+/* Internal link styles */
 .internal-link {
     color: #1a73e8;
     text-decoration: none;
@@ -23,7 +23,7 @@ html.dark {
     text-decoration: underline;
 }
 
-/* 存在しないページへのリンクスタイル */
+/* Styles for links to non-existent pages */
 .internal-link.page-not-exists {
     color: #d32f2f;
     border-bottom: 1px dashed #d32f2f;
@@ -34,7 +34,7 @@ html.dark {
     border-bottom: 1px solid #b71c1c;
 }
 
-/* プロジェクト内部リンクのスタイル */
+/* Project internal link styles */
 .internal-link.project-link {
     color: #0288d1;
 }
@@ -43,7 +43,7 @@ html.dark {
     color: #01579b;
 }
 
-/* プロジェクト内部リンクで存在しないページへのリンクスタイル */
+/* Styles for project internal links to non-existent pages */
 .internal-link.project-link.page-not-exists {
     color: #d32f2f;
     border-bottom: 1px dashed #d32f2f;
@@ -54,7 +54,7 @@ html.dark {
     border-bottom: 1px solid #b71c1c;
 }
 
-/* リンクプレビューラッパー */
+/* Link preview wrapper */
 .link-preview-wrapper {
     display: inline-block;
     position: relative;


### PR DESCRIPTION
Translated Japanese comments in `client/src/app.css` to English to improve codebase accessibility.
Verified the changes by running `pnpm check` and `pnpm build` in the `client` directory.
Reverted unintended changes to `firebase.emulator.json`.

---
*PR created automatically by Jules for task [14948073001414766421](https://jules.google.com/task/14948073001414766421) started by @kitamura-tetsuo*