### PR TITLE
🌐 Lingo: Translate CursorEditor.ts to English

### DIFF
--- a/client/src/lib/cursor/CursorEditor.ts
+++ b/client/src/lib/cursor/CursorEditor.ts
@@ -719,7 +719,7 @@ export class CursorEditor {
                 const newText = text.substring(0, start) + formattedText + text.substring(end);
                 (item as any).updateText(newText);
             } else {
-                // 複数アイテムにまたがる選択範囲の詳細なフォーマットは未対応
+                // Detailed formatting for selection ranges spanning multiple items is not supported
             }
         }
 


### PR DESCRIPTION
Translated a Japanese code comment in `client/src/lib/cursor/CursorEditor.ts` to English to improve accessibility.
No logic changes.
Verified that existing tests pass and no new lint errors were introduced.

---
*PR created automatically by Jules for task [16889013481200139156](https://jules.google.com/task/16889013481200139156) started by @kitamura-tetsuo*