### PR TITLE
🌐 Lingo: Translate scheduleService.test.ts to English

### DIFF
--- a/client/src/tests/scheduleService.test.ts
+++ b/client/src/tests/scheduleService.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, expect, it, vi } from "vitest";
 import { cancelSchedule, createSchedule, listSchedules, updateSchedule } from "../services/scheduleService";
 
-// UserManagerをモックして、実際のAPIエンドポイントを使用
+// Mock UserManager to provide API endpoint configuration
 vi.mock("../auth/UserManager", () => ({
     userManager: {
         functionsUrl: "http://localhost:57000",
@@ -9,7 +9,7 @@ vi.mock("../auth/UserManager", () => ({
     },
 }));
 
-// fetchをモックして、実際のAPIレスポンスをシミュレート
+// Mock fetch to simulate actual API responses
 global.fetch = vi.fn();
 
 beforeEach(() => {
@@ -17,7 +17,7 @@ beforeEach(() => {
 });
 
 it("calls createSchedule API", async () => {
-    // fetchのモックレスポンスを設定
+    // Set up mock fetch response
     const mockResponse = { scheduleId: "test-schedule-id" };
     (global.fetch as any).mockResolvedValueOnce({
         ok: true,
@@ -30,7 +30,7 @@ it("calls createSchedule API", async () => {
     expect(result).toBeDefined();
     expect(result.scheduleId).toBe("test-schedule-id");
 
-    // fetchが正しいパラメータで呼ばれたことを確認
+    // Verify fetch was called with correct parameters
     expect(global.fetch).toHaveBeenCalledWith(
         "http://127.0.0.1:57070/outliner-d57b0/us-central1/createSchedule",
         {
@@ -46,7 +46,7 @@ it("calls createSchedule API", async () => {
 });
 
 it("calls listSchedules API", async () => {
-    // fetchのモックレスポンスを設定
+    // Set up mock fetch response
     const mockSchedules = [
         { id: "schedule1", strategy: "one_shot", params: {}, nextRunAt: Date.now() + 60000 },
         { id: "schedule2", strategy: "recurring", params: {}, nextRunAt: Date.now() + 120000 },
@@ -64,7 +64,7 @@ it("calls listSchedules API", async () => {
     expect(result[0].id).toBe("schedule1");
     expect(result[1].id).toBe("schedule2");
 
-    // fetchが正しいパラメータで呼ばれたことを確認
+    // Verify fetch was called with correct parameters
     expect(global.fetch).toHaveBeenCalledWith(
         "http://127.0.0.1:57070/outliner-d57b0/us-central1/listSchedules",
         {
@@ -79,7 +79,7 @@ it("calls listSchedules API", async () => {
 });
 
 it("calls cancelSchedule API", async () => {
-    // fetchのモックレスポンスを設定
+    // Set up mock fetch response
     const mockResponse = { success: true };
     (global.fetch as any).mockResolvedValueOnce({
         ok: true,
@@ -91,7 +91,7 @@ it("calls cancelSchedule API", async () => {
     expect(result).toBeDefined();
     expect(result.success).toBe(true);
 
-    // fetchが正しいパラメータで呼ばれたことを確認
+    // Verify fetch was called with correct parameters
     expect(global.fetch).toHaveBeenCalledWith(
         "http://127.0.0.1:57070/outliner-d57b0/us-central1/cancelSchedule",
         {


### PR DESCRIPTION
💡 **What:** Translated Japanese comments in `client/src/tests/scheduleService.test.ts` to English.
🎯 **Why:** Improving codebase accessibility and consistency for non-Japanese speakers.
🛠 **Verification:** Ran `npx vitest run src/tests/scheduleService.test.ts` to ensure tests pass.


---
*PR created automatically by Jules for task [11713827639109971049](https://jules.google.com/task/11713827639109971049) started by @kitamura-tetsuo*