### PR TITLE
🌐 Lingo: Translate client/e2e/helpers/coverage.ts to English

### DIFF
--- a/client/e2e/helpers/coverage.ts
+++ b/client/e2e/helpers/coverage.ts
@@ -1,10 +1,9 @@
 /**
- * Playwright E2Eテストのカバレッジ収集ヘルパー
+ * Helper for collecting coverage in Playwright E2E tests
  *
- * monocart-coverage-reportsを使用してV8カバレッジを収集し、
- * Istanbulフォーマットに変換します。
+ * Collects V8 coverage using monocart-coverage-reports and converts it to Istanbul format.
  *
- * 注意: カバレッジは常に収集されます。
+ * Note: Coverage is always collected.
  */
 
 import type { Page } from "@playwright/test";
@@ -12,16 +11,16 @@ import fs from "fs";
 import path from "path";
 
 /**
- * カバレッジ収集が有効かどうかを確認
- * @deprecated カバレッジは常に収集されるため、この関数は不要です
+ * Check if coverage collection is enabled
+ * @deprecated Coverage is always collected, so this function is unnecessary
  */
 export function isCoverageEnabled(): boolean {
     return true;
 }
 
 /**
- * ページでカバレッジ収集を開始
- * @deprecated カバレッジは registerCoverageHooks.ts で自動的に収集されます
+ * Start coverage collection on the page
+ * @deprecated Coverage is automatically collected in registerCoverageHooks.ts
  */
 export async function startCoverage(page: Page): Promise<void> {
     try {
@@ -30,37 +29,37 @@ export async function startCoverage(page: Page): Promise<void> {
             reportAnonymousScripts: true,
         });
     } catch (error) {
-        console.warn("カバレッジ収集の開始に失敗しました:", error);
+        console.warn("Failed to start coverage collection:", error);
     }
 }
 
 /**
- * ページでカバレッジ収集を停止し、結果を保存
- * @deprecated カバレッジは registerCoverageHooks.ts で自動的に収集されます
+ * Stop coverage collection on the page and save the results
+ * @deprecated Coverage is automatically collected in registerCoverageHooks.ts
  */
 export async function stopCoverage(page: Page, testName: string): Promise<void> {
     try {
         const coverage = await page.coverage.stopJSCoverage();
 
-        // カバレッジデータを保存
+        // Save coverage data
         const coverageDir = path.join(process.cwd(), "..", "coverage", "e2e", "raw");
         fs.mkdirSync(coverageDir, { recursive: true });
 
-        // テスト名からファイル名を生成（特殊文字を除去）
+        // Generate filename from test name (remove special characters)
         const sanitizedTestName = testName.replace(/[^a-zA-Z0-9-_]/g, "_");
         const timestamp = Date.now();
         const coverageFile = path.join(coverageDir, `coverage-${sanitizedTestName}-${timestamp}.json`);
 
         fs.writeFileSync(coverageFile, JSON.stringify(coverage, null, 2));
     } catch (error) {
-        console.warn("カバレッジ収集の停止に失敗しました:", error);
+        console.warn("Failed to stop coverage collection:", error);
     }
 }
 
 /**
- * 注意:
- * E2Eテストのカバレッジは registerCoverageHooks.ts によって自動的に収集されます。
- * このファイルの関数は、手動でカバレッジを制御したい場合にのみ使用してください。
+ * Note:
+ * E2E test coverage is automatically collected by registerCoverageHooks.ts.
+ * Use the functions in this file only if you want to manually control coverage.
  *
- * 通常は、COVERAGE=true 環境変数を設定してテストを実行するだけで十分です。
+ * Usually, setting the COVERAGE=true environment variable and running the tests is sufficient.
  */


### PR DESCRIPTION
💡 **What:** Translated `client/e2e/helpers/coverage.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Run `npm run lint` in `client` directory. Verified that `client/e2e/helpers/coverage.ts` has no lint errors.

---
*PR created automatically by Jules for task [14934410380260300638](https://jules.google.com/task/14934410380260300638) started by @kitamura-tetsuo*