### PR TITLE
🌐 Lingo: Translate Japanese locator in env-polling-analysis-test-removability-a1b2c3d4.spec.ts to English

### DIFF
--- a/client/e2e/env/env-polling-analysis-test-removability-a1b2c3d4.spec.ts
+++ b/client/e2e/env/env-polling-analysis-test-removability-a1b2c3d4.spec.ts
@@ -104,7 +104,7 @@ test.describe("ENV-POLL-0001: Polling Removability Test", () => {
                 await commentInput.fill("Test comment");
 
                 // Click add button
-                const addButton = page.locator('button:has-text("追加")');
+                const addButton = page.locator('[data-testid="add-comment-btn"]');
                 await addButton.click();
 
                 // Verify comment is added


### PR DESCRIPTION
💡 What: Replaced page.locator('button:has-text("追加")') with page.locator('[data-testid="add-comment-btn"]').
🎯 Why: The test was using a Japanese text locator ("Add") which is incorrect for the English UI and less robust than using a data-testid. This improves test reliability and code accessibility.
🛠 Verification: Verified statically that the target component has the data-testid="add-comment-btn". Attempted to run the test but it fails due to environment setup issues (timeout loading page), which is unrelated to this change.

---
*PR created automatically by Jules for task [16387665514004884916](https://jules.google.com/task/16387665514004884916) started by @kitamura-tetsuo*