### PR TITLE
🌐 Lingo: Translate tree-validation.spec.ts to English

### DIFF
--- a/client/e2e/utils/tree-validation.spec.ts
+++ b/client/e2e/utils/tree-validation.spec.ts
@@ -2,46 +2,46 @@ import "./registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature TST-0001
- *  Title   : SharedTreeデータ検証ユーティリティのテスト
+ *  Title   : SharedTree Data Validation Utility Tests
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "./testHelpers";
 import { TreeValidator } from "./treeValidation";
 
-test.describe("TreeValidator: SharedTreeデータ検証ユーティリティ", () => {
+test.describe("TreeValidator: SharedTree Data Validation Utility", () => {
     let actualPageTitle: string;
 
     test.beforeEach(async ({ page }, testInfo) => {
-        // テストページをセットアップ
+        // Setup test page
         const result = await TestHelpers.prepareTestEnvironment(page, testInfo, [
             "First item",
             "Second item",
             "Third item",
         ]);
 
-        // 実際のページタイトルを保存
+        // Save actual page title
         actualPageTitle = result.pageName;
 
-        // 少し待機してデータが反映されるのを待つ
+        // Wait a bit for data to reflect
         await page.waitForTimeout(500);
     });
 
-    test("getTreeData: SharedTreeのデータ構造を取得できる", async ({ page }) => {
-        // SharedTreeのデータ構造を取得（フォールバック機能付き）
+    test("getTreeData: Can retrieve SharedTree data structure", async ({ page }) => {
+        // Retrieve SharedTree data structure (with fallback functionality)
         const treeData = await TreeValidator.getTreeData(page);
 
-        // データが取得できていることを確認
+        // Confirm data is retrieved
         expect(treeData).toBeTruthy();
         expect(treeData.itemCount).toBeGreaterThan(0);
         expect(treeData.items).toBeTruthy();
         expect(Array.isArray(treeData.items)).toBe(true);
 
-        // 少なくとも1つのアイテムが含まれていることを確認
+        // Confirm at least one item is included
         const texts = treeData.items.map(item => item.text);
         expect(texts.length).toBeGreaterThan(0);
 
-        // 最初のアイテムのテキストを確認
+        // Confirm the text of the first item
         if (texts.length > 0) {
             expect(texts[0]).toBeTruthy();
         }
@@ -49,76 +49,76 @@ test.describe("TreeValidator: SharedTreeデータ検証ユーティリティ", (
         console.log("Tree data:", JSON.stringify(treeData, null, 2));
     });
 
-    test("assertTreeData: 期待値と比較できる（部分比較モード）", async ({ page }) => {
-        // ページの基本構造を検証（子アイテムはpageItemsマップに格納されるため、TreeValidatorでは直接検証しない）
+    test("assertTreeData: Can compare with expected value (Partial comparison mode)", async ({ page }) => {
+        // Verify basic page structure (child items are stored in pageItems map, so TreeValidator does not verify them directly)
         const expectedData = {
             itemCount: 1,
             items: [
                 {
-                    text: actualPageTitle, // 実際のページタイトルを使用
-                    // 注：子アイテムはpageItemsマップに格納されるため、TreeValidatorでは検証しない
-                    // 子アイテムの検証が必要な場合は、TreeValidator.getPageItems()を使用すること
+                    text: actualPageTitle, // Use actual page title
+                    // Note: Child items are stored in pageItems map, so TreeValidator does not verify them
+                    // If child item verification is needed, use TreeValidator.getPageItems()
                 },
             ],
         };
 
-        // 部分比較モードで検証（フォールバック機能付き）
+        // Verify in partial comparison mode (with fallback functionality)
         await TreeValidator.assertTreeData(page, expectedData);
     });
 
-    test("assertTreeData: 期待値と比較できる（厳密比較モード）", async ({ page }) => {
-        // 現在のデータを取得（フォールバック機能付き）
+    test("assertTreeData: Can compare with expected value (Strict comparison mode)", async ({ page }) => {
+        // Retrieve current data (with fallback functionality)
         const currentData = await TreeValidator.getTreeData(page);
 
-        // 同じデータで厳密比較
+        // Strict comparison with the same data
         await TreeValidator.assertTreeData(page, currentData, true);
     });
 
-    test("assertTreePath: 特定のパスのデータを検証できる", async ({ page }) => {
-        // 実際のデータ構造に合わせたパスで検証（フォールバック機能付き）
+    test("assertTreePath: Can verify data at specific path", async ({ page }) => {
+        // Verify with path matching actual data structure (with fallback functionality)
         await TreeValidator.assertTreePath(page, "itemCount", 1);
-        await TreeValidator.assertTreePath(page, "items.0.text", actualPageTitle); // 実際のページタイトルを使用
+        await TreeValidator.assertTreePath(page, "items.0.text", actualPageTitle); // Use actual page title
 
-        // 注：子アイテムはpageItemsマップに格納されるため、TreeValidatorのgetTreePathでは検証しない
-        // 子アイテムの検証が必要な場合は、TreeValidator.getPageItems()を使用すること
+        // Note: Child items are stored in pageItems map, so TreeValidator.getTreePath does not verify them
+        // If child item verification is needed, use TreeValidator.getPageItems()
 
-        // 存在しないパスの検証（undefinedが返されるはず）
+        // Verify non-existent path (should return undefined)
         const nonExistentPath = await TreeValidator.getTreePathData(page, "items.0.nonexistent");
         expect(nonExistentPath).toBeUndefined();
     });
 
-    test("takeTreeSnapshot & compareWithSnapshot: スナップショットを取得して比較できる", async ({ page }) => {
-        // スナップショットを取得（フォールバック機能付き）
+    test("takeTreeSnapshot & compareWithSnapshot: Can take snapshot and compare", async ({ page }) => {
+        // Take snapshot (with fallback functionality)
         const snapshot = await TreeValidator.takeTreeSnapshot(page);
 
-        // 何も変更せずに比較（一致するはず）
+        // Compare without changes (should match)
         await TreeValidator.compareWithSnapshot(page, snapshot);
 
-        // 新しいアイテムを追加
+        // Add a new item
         await page.locator(".outliner-item").first().click();
         await page.keyboard.press("End");
         await page.keyboard.press("Enter");
         await page.keyboard.type("Fourth item");
         await page.waitForTimeout(500);
 
-        // 変更後は一致しないはず
+        // Should not match after changes
         try {
             await TreeValidator.compareWithSnapshot(page, snapshot);
-            // ここに到達したら失敗
+            // Failure if reached here
             expect(false).toBeTruthy();
         } catch (error) {
-            // エラーが発生することを期待
+            // Expect an error to occur
             expect(error).toBeTruthy();
         }
 
-        // 特定のパスを無視して比較
+        // Compare ignoring specific path
         try {
-            // 新しく追加されたアイテムのパスを無視
+            // Ignore path of newly added item
             await TreeValidator.compareWithSnapshot(page, snapshot, ["items.0.items.2"]);
-            // ここに到達したら失敗
+            // Failure if reached here
             expect(false).toBeTruthy();
         } catch (error) {
-            // エラーが発生することを期待
+            // Expect an error to occur
             expect(error).toBeTruthy();
         }
     });


### PR DESCRIPTION
💡 **What:** Translated `client/e2e/utils/tree-validation.spec.ts` from Japanese to English.
- Translated feature title and descriptions in JSDoc.
- Translated `test.describe` and `test` titles.
- Translated inline comments explaining test logic and `SharedTree` data structures.

🎯 **Why:** Improving codebase accessibility and consistency by ensuring test documentation is in English.

🛠 **Verification:**
- Ran `cd client && npx playwright test e2e/utils/tree-validation.spec.ts` - All 5 tests passed.
- Ran `cd client && npm run lint` - No new linting errors introduced.

---
*PR created automatically by Jules for task [12229657086984480991](https://jules.google.com/task/12229657086984480991) started by @kitamura-tetsuo*