### PR TITLE
🌐 Lingo: Translate ydoc-persistence.spec.ts to English

### DIFF
--- a/client/e2e/ydoc-persistence.spec.ts
+++ b/client/e2e/ydoc-persistence.spec.ts
@@ -9,8 +9,8 @@ import { TestHelpers } from "./utils/testHelpers";
  *  Title: Y.Doc persistence and offline editing
  *  Source: docs/client-features.yaml
  *
- * このテストスイートは、Y.Docのローカルキャッシュ機能とオフライン編集機能を検証します。
- * IndexedDBを使用した永続化により、ページリロード後もコンテンツが復元されることを確認します。
+ * This test suite validates Y.Doc's local caching and offline editing capabilities.
+ * It verifies that content is restored after a page reload through persistence using IndexedDB.
  */
 test.describe("Y.Doc persistence and offline editing", () => {
     /**


### PR DESCRIPTION
💡 **What:** Translated Japanese JSDoc comments in `client/e2e/ydoc-persistence.spec.ts` to English.
🎯 **Why:** To improve codebase accessibility and consistency for non-Japanese speakers.
🛠 **Verification:**
- Ran `npx tsc --noEmit --project e2e/tsconfig.json` in `client/` -> No new errors.
- Ran `npm run lint` in `client/` -> No new warnings (ignored existing `no-restricted-globals`).
- Attempted to run the test, but identified it is excluded from the current Playwright project configuration. Static analysis confirms code validity.

---
*PR created automatically by Jules for task [4173443355735169312](https://jules.google.com/task/4173443355735169312) started by @kitamura-tetsuo*