### PR TITLE
🌐 Lingo: Translate client/e2e/core/lnk-temporary-page-display-08bbbbfc.spec.ts to English

### DIFF
--- a/client/e2e/core/lnk-temporary-page-display-08bbbbfc.spec.ts
+++ b/client/e2e/core/lnk-temporary-page-display-08bbbbfc.spec.ts
@@ -2,18 +2,18 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature LNK-0004
- *  Title   : 仮ページ機能
+ *  Title   : Temporary Page Feature
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
-test.describe("LNK-0004: 仮ページ表示", () => {
+test.describe("LNK-0004: Temporary Page Display", () => {
     test.beforeEach(async ({ page }, testInfo) => {
         await TestHelpers.prepareTestEnvironment(page, testInfo);
     });
 
-    test("存在しないページへのリンクをクリックした場合に仮ページが表示される", async ({ page }) => {
+    test("Temporary page is displayed when clicking a link to a non-existent page", async ({ page }) => {
         const sourceUrl = page.url();
         const nonExistentPage = "non-existent-page-" + Date.now().toString().slice(-6);
         await page.goto(`${sourceUrl}${nonExistentPage}`);


### PR DESCRIPTION
💡 **What:** Translated JSDoc comments and test descriptions in `client/e2e/core/lnk-temporary-page-display-08bbbbfc.spec.ts` from Japanese to English.
🎯 **Why:** To improve codebase accessibility and consistency for non-Japanese developers.
🛠 **Verification:** Ran `npm run lint` and `npm run check` in the `client` directory to ensure no syntax or type errors were introduced. The Japanese selector `button:has-text('開発者ログイン')` was preserved to prevent regression in test execution.

---
*PR created automatically by Jules for task [15994765308027721160](https://jules.google.com/task/15994765308027721160) started by @kitamura-tetsuo*