### PR TITLE
🌐 Lingo: Translate itm-title-child-aligned-x-position-ff843c45.spec.ts to English

### DIFF
--- a/client/e2e/core/itm-title-child-aligned-x-position-ff843c45.spec.ts
+++ b/client/e2e/core/itm-title-child-aligned-x-position-ff843c45.spec.ts
@@ -2,18 +2,18 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature ITM-ff843c45
- *  Title   : タイトルと子アイテムの水平位置を揃える
+ *  Title   : Title and child align horizontally
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
-test.describe("ITM-ff843c45: タイトルと子アイテムの位置", () => {
+test.describe("ITM-ff843c45: Position of title and child items", () => {
     test.beforeEach(async ({ page }, testInfo) => {
         await TestHelpers.prepareTestEnvironment(page, testInfo);
     });
 
-    test("タイトルと子アイテムのX座標が同じ", async ({ page }) => {
+    test("X coordinates of title and child items are the same", async ({ page }) => {
         await TestHelpers.waitForOutlinerItems(page);
         const titleId = await TestHelpers.getItemIdByIndex(page, 0);
         await TestHelpers.setCursor(page, titleId!);


### PR DESCRIPTION
💡 **What:** Translated Japanese text in `client/e2e/core/itm-title-child-aligned-x-position-ff843c45.spec.ts` to English.
- JSDoc Title: `Title : タイトルと子アイテムの水平位置を揃える` -> `Title : Title and child align horizontally`
- Test Describe: `ITM-ff843c45: タイトルと子アイテムの位置` -> `ITM-ff843c45: Position of title and child items`
- Test Case: `タイトルと子アイテムのX座標が同じ` -> `X coordinates of title and child items are the same`

🎯 **Why:** Improving codebase accessibility and consistency by translating Japanese comments and test descriptions into English.

🛠 **Verification:**
- `npm run lint` (passed with warnings unrelated to changes)
- `npx tsc --noEmit --project e2e/tsconfig.json` (passed with errors unrelated to changes)

---
*PR created automatically by Jules for task [8800682412165149916](https://jules.google.com/task/8800682412165149916) started by @kitamura-tetsuo*