### PR TITLE
🌐 Lingo: Translate client/e2e/new/als-alias-self-reference-test.spec.ts to English

### DIFF
--- a/client/e2e/new/als-alias-self-reference-test.spec.ts
+++ b/client/e2e/new/als-alias-self-reference-test.spec.ts
@@ -49,17 +49,17 @@ test.describe("ALS-0001: Alias self-reference prevention", () => {
         const optionCount = await page.locator(".alias-picker").first().locator("li").count();
         expect(optionCount).toBeGreaterThan(0);
 
-        // 自己参照エイリアスを試行（自分自身を選択）
+        // Attempt self-referencing alias (selecting itself)
         const selfButtonCount = await page.locator(".alias-picker").first().locator(`button[data-id="${aliasId}"]`)
             .count();
         expect(selfButtonCount).toBe(0);
         await TestHelpers.hideAliasPicker(page);
 
-        // aliasTargetIdが設定されていないことを確認（自己参照は防止される）
+        // Confirm aliasTargetId is not set (self-reference is prevented)
         const aliasTargetId = await TestHelpers.getAliasTargetId(page, aliasId);
         expect(aliasTargetId).toBeNull();
 
-        // エイリアスパスが表示されていないことを確認
+        // Confirm alias path is not displayed
         const isAliasPathVisible = await TestHelpers.isAliasPathVisible(page, aliasId);
         expect(isAliasPathVisible).toBe(false);
     });


### PR DESCRIPTION
💡 **What:** Translated Japanese comments in `client/e2e/new/als-alias-self-reference-test.spec.ts` to English.
🎯 **Why:** Improving codebase accessibility and consistency for non-Japanese speakers.
🛠 **Verification:**
- Ran `cd client && npx playwright test new/als-alias-self-reference-test.spec.ts` which passed.
- Ran `cd client && npm run lint` which showed no errors in the modified file.

---
*PR created automatically by Jules for task [9582024085312158309](https://jules.google.com/task/9582024085312158309) started by @kitamura-tetsuo*