### PR TITLE
🌐 Lingo: Translate lnk-temporary-page-edit-save-08bbbbfc.spec.ts to English

### DIFF
--- a/client/e2e/core/lnk-temporary-page-edit-save-08bbbbfc.spec.ts
+++ b/client/e2e/core/lnk-temporary-page-edit-save-08bbbbfc.spec.ts
@@ -2,18 +2,18 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature LNK-0004
- *  Title   : 仮ページ機能
+ *  Title   : Temporary Page Functionality
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
-test.describe("LNK-0004: 仮ページ編集保存", () => {
+test.describe("LNK-0004: Temporary Page Edit and Save", () => {
     test.beforeEach(async () => {
         // No global setup needed here, environment is handled per test
     });
 
-    test("仮ページを編集した場合に実際のページとして保存される", async ({ page }, testInfo) => {
+    test("When a temporary page is edited, it is saved as an actual page", async ({ page }, testInfo) => {
         const { projectName } = await TestHelpers.prepareTestEnvironment(page, testInfo);
         const sourceUrl = `/${encodeURIComponent(projectName)}/`;
         const nonExistentPage = "edit-temp-page-" + Date.now().toString().slice(-6);
@@ -42,7 +42,7 @@ test.describe("LNK-0004: 仮ページ編集保存", () => {
 
         const firstId = await firstItem.getAttribute("data-item-id");
         await TestHelpers.setCursor(page, firstId!);
-        await TestHelpers.insertText(page, firstId!, "これは編集された仮ページです。");
+        await TestHelpers.insertText(page, firstId!, "This is an edited temporary page.");
         await page.waitForTimeout(300);
 
         await page.waitForTimeout(300);

--- a/client/project.inlang/.meta.json
+++ b/client/project.inlang/.meta.json
@@ -1,3 +1,3 @@
 {
-  "highestSdkVersion": "2.6.2"
+  "highestSdkVersion": "2.7.0"
 }


### PR DESCRIPTION
💡 **What:** Translated Japanese content in `client/e2e/core/lnk-temporary-page-edit-save-08bbbbfc.spec.ts` to English.
🎯 **Why:** Improving codebase accessibility and consistency by translating test descriptions, JSDoc comments, and input text.
🛠 **Verification:** Ran `npx playwright test e2e/core/lnk-temporary-page-edit-save-08bbbbfc.spec.ts` to ensure the test passes, and `npm run lint` to check for syntax errors.

---
*PR created automatically by Jules for task [9168986058795369080](https://jules.google.com/task/9168986058795369080) started by @kitamura-tetsuo*