### PR TITLE
🌐 Lingo: Translate slr-paste-multiline test to English

### DIFF
--- a/client/e2e/core/slr-paste-multiline-f8740117.spec.ts
+++ b/client/e2e/core/slr-paste-multiline-f8740117.spec.ts
@@ -13,7 +13,7 @@ test.describe("SLR-0006: Copy and paste multiple item selection ranges", () => {
         await TestHelpers.prepareTestEnvironment(page, testInfo);
     });
 
-    test("複数行テキストをペーストすると適切に複数アイテムに分割される", async ({ page }) => {
+    test("Pasting multi-line text is appropriately split into multiple items", async ({ page }) => {
         const firstItem = page.locator(".outliner-item").nth(0);
         await firstItem.locator(".item-content").click({ force: true });
         const clipboardText = "line1\nline2\nline3";


### PR DESCRIPTION
💡 **What:** Translated the test description in `slr-paste-multiline` from Japanese to English.
🎯 **Why:** Improving codebase accessibility for non-Japanese speakers.
🛠 **Verification:** Verified by running the specific e2e test and linting.

---
*PR created automatically by Jules for task [14018451950600404366](https://jules.google.com/task/14018451950600404366) started by @kitamura-tetsuo*