### PR TITLE
🌐 Lingo: Translate slr-selected-long-text-356b853a.spec.ts to English

### DIFF
--- a/client/e2e/core/slr-selected-long-text-356b853a.spec.ts
+++ b/client/e2e/core/slr-selected-long-text-356b853a.spec.ts
@@ -4,7 +4,7 @@ import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 import { TestHelpers } from "../utils/testHelpers";
 registerCoverageHooks();
 
-test.describe("SLR-356b853a: 長いテキストの選択範囲", () => {
+test.describe("SLR-356b853a: Long text selection range", () => {
     // Actually, on second thought, I should modify `beforeEach` to seed the long text if it's the only test.
     // Yes, it is the only test in this file.
     test.beforeEach(async ({ page }, testInfo) => {
@@ -16,9 +16,9 @@ test.describe("SLR-356b853a: 長いテキストの選択範囲", () => {
         await TestHelpers.waitForOutlinerItems(page, 3, 10000);
     });
 
-    test("長いテキストを含むアイテムの選択範囲を作成できる", async ({ page }) => {
+    test("Can create selection range for item containing long text", async ({ page }) => {
         test.setTimeout(120000);
-        // 最初のアイテムをクリックしてフォーカス
+        // Click and focus on the first item
         const firstItem = page.locator(".outliner-item").first();
         await firstItem.locator(".item-content").click({ force: true });
         await TestHelpers.waitForCursorVisible(page);
@@ -28,34 +28,34 @@ test.describe("SLR-356b853a: 長いテキストの選択範囲", () => {
         expect(firstItemText).toContain("This is a very long text");
         expect(firstItemText).toContain("properly selected and copied");
 
-        // テキストの長さを確認
+        // Verify text length
         expect(firstItemText?.length || 0).toBeGreaterThan(200);
 
         console.log("Long text input test completed successfully");
 
-        // TODO: 選択範囲機能が完全に実装されたら、以下のテストを有効化
-        // // 長いテキストの一部を選択
+        // TODO: Enable the following tests once the selection range feature is fully implemented
+        // // Select part of the long text
         // await page.keyboard.down("Shift");
         // for (let i = 0; i < 50; i++) {
         //     await page.keyboard.press("ArrowRight");
         // }
         // await page.keyboard.up("Shift");
         //
-        // // 選択範囲が作成されたことを確認
+        // // Confirm that the selection range is created
         // const selection = page.locator(".editor-overlay .selection");
         // await expect(selection).toBeVisible({ timeout: 1000 });
         //
-        // // 選択範囲をコピー
+        // // Copy the selection
         // await page.keyboard.press("Control+c");
         // await page.waitForTimeout(200);
         //
-        // // 2つ目のアイテムに移動してペースト
+        // // Move to the second item and paste
         // await page.keyboard.press("ArrowDown");
         // await page.keyboard.press("End");
         // await page.keyboard.press("Control+v");
         // await page.waitForTimeout(300);
         //
-        // // ペーストされたテキストを確認
+        // // Check the pasted text
         // const secondItemText = await page.locator(".outliner-item").nth(1).locator(".item-text").textContent();
         // expect(secondItemText).toContain("Second item text");
         // expect(secondItemText).toContain("This is a very long text");


### PR DESCRIPTION
💡 **What:** Translated `client/e2e/core/slr-selected-long-text-356b853a.spec.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `npm run test:e2e -- e2e/core/slr-selected-long-text-356b853a.spec.ts` (passed) and `npm run lint` (no errors).

---
*PR created automatically by Jules for task [12118308858118151011](https://jules.google.com/task/12118308858118151011) started by @kitamura-tetsuo*