### PR TITLE
🌐 Lingo: Translate slr-shrink-selection-99167b65.spec.ts to English

### DIFF
--- a/client/e2e/core/slr-shrink-selection-99167b65.spec.ts
+++ b/client/e2e/core/slr-shrink-selection-99167b65.spec.ts
@@ -2,13 +2,13 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature SLR-0012
- *  Title   : 選択範囲の縮小
+ *  Title   : Shrink Selection
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
-test.describe("SLR-0012: 選択範囲の縮小", () => {
+test.describe("SLR-0012: Shrink Selection", () => {
     test.beforeEach(async ({ page }, testInfo) => {
         await TestHelpers.prepareTestEnvironment(page, testInfo, [""]);
         const item = page.locator(".outliner-item").first();


### PR DESCRIPTION
Translated the Japanese feature title and test description in `client/e2e/core/slr-shrink-selection-99167b65.spec.ts` to English.

**Changes:**
- `Title   : 選択範囲の縮小` -> `Title   : Shrink Selection`
- `test.describe("SLR-0012: 選択範囲の縮小", ...` -> `test.describe("SLR-0012: Shrink Selection", ...`

Verified with lint, format, and type checks.

---
*PR created automatically by Jules for task [8081051206725466056](https://jules.google.com/task/8081051206725466056) started by @kitamura-tetsuo*