### PR TITLE
🌐 Lingo: Translate slr-selected-empty-item test to English

### DIFF
--- a/client/e2e/core/slr-selected-empty-item-bb3a9bf4.spec.ts
+++ b/client/e2e/core/slr-selected-empty-item-bb3a9bf4.spec.ts
@@ -2,26 +2,26 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature SLR-0008
- *  Title   : 選択範囲のエッジケース
+ *  Title   : Selection Range Edge Cases
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
-test.describe("SLR-0008: 選択範囲のエッジケース", () => {
+test.describe("SLR-0008: Selection Range Edge Cases", () => {
     test.beforeEach(async ({ page }, testInfo) => {
-        // デバッグモードを有効化
+        // Enable debug mode
         await page.evaluate(() => {
             (window as any).DEBUG_MODE = true;
         });
 
         await TestHelpers.prepareTestEnvironment(page, testInfo);
 
-        // 最初のアイテムを選択
+        // Select the first item
         const item = page.locator(".outliner-item").first();
         await item.locator(".item-content").click({ force: true });
 
-        // デバッグモードを有効化（ページ読み込み後）
+        // Enable debug mode (after page load)
         await page.evaluate(() => {
             (window as any).DEBUG_MODE = true;
         });
@@ -29,40 +29,40 @@ test.describe("SLR-0008: 選択範囲のエッジケース", () => {
         await page.waitForSelector("textarea.global-textarea:focus");
     });
 
-    test("空のアイテムを含む選択範囲を作成できる", async ({ page }) => {
-        // 最初のアイテムにテキストを入力
+    test("Can create a selection range including empty items", async ({ page }) => {
+        // Enter text into the first item
         await page.keyboard.type("First item text");
 
-        // 2つ目のアイテムを作成（空のアイテム）
+        // Create the second item (empty item)
         await page.keyboard.press("Enter");
 
-        // 3つ目のアイテムを作成
+        // Create the third item
         await page.keyboard.press("Enter");
         await page.keyboard.type("Third item text");
 
-        // 最初のアイテムに戻る
+        // Return to the first item
         await page.keyboard.press("Home");
         await page.keyboard.press("ArrowUp");
         await page.keyboard.press("ArrowUp");
         await page.keyboard.press("Home");
 
-        // デバッグモードを再度有効化
+        // Re-enable debug mode
         await page.evaluate(() => {
             (window as any).DEBUG_MODE = true;
             console.log("Debug mode enabled in test");
         });
 
-        // 最初のアイテムをクリックして選択
+        // Click and select the first item
         const firstItem = page.locator(".outliner-item").nth(0);
         await firstItem.locator(".item-content").click({ force: true });
         await page.waitForTimeout(300);
 
-        // 手動で選択範囲を作成（空のアイテムを含む）
+        // Manually create selection range (including empty items)
         await page.evaluate(() => {
             const store = (window as any).editorOverlayStore;
             if (!store) return;
 
-            // アイテムを取得
+            // Get items
             const items = document.querySelectorAll("[data-item-id]");
             if (items.length < 3) return;
 
@@ -71,7 +71,7 @@ test.describe("SLR-0008: 選択範囲のエッジケース", () => {
 
             if (!firstItemId || !thirdItemId) return;
 
-            // 選択範囲を設定
+            // Set selection range
             store.setSelection({
                 startItemId: firstItemId,
                 startOffset: 0,
@@ -84,10 +84,10 @@ test.describe("SLR-0008: 選択範囲のエッジケース", () => {
             console.log("Selection created manually");
         });
 
-        // 少し待機して選択が反映されるのを待つ
+        // Wait a bit for the selection to be reflected
         await page.waitForTimeout(300);
 
-        // 選択範囲が作成されたことを確認
+        // Confirm that the selection range was created
         try {
             await expect(page.locator(".editor-overlay .selection")).toBeVisible({ timeout: 1000 });
         } catch {
@@ -95,35 +95,35 @@ test.describe("SLR-0008: 選択範囲のエッジケース", () => {
             return;
         }
 
-        // 選択範囲のテキストを取得（アプリケーションの選択範囲管理システムから）
+        // Get the text of the selection range (from the application's selection range management system)
         const selectionText = await page.evaluate(() => {
             const store = (window as any).editorOverlayStore;
             if (!store) return "";
             return store.getSelectedText();
         });
 
-        // 選択範囲が存在することを確認
+        // Confirm that the selection range exists
         expect(selectionText).toBeTruthy();
 
-        // 選択範囲に最初のアイテムのテキストが含まれていることを確認
+        // Confirm that the first item's text is included in the selection range
         expect(selectionText).toContain("First item text");
-        // 環境によっては3つ目のアイテムのテキストが含まれない場合もあるため、条件付きでチェック
+        // Check conditionally as the third item's text might not be included depending on the environment
         if (selectionText.includes("Third")) {
             expect(selectionText).toContain("Third");
         } else {
             console.log("Third item text not included in selection, but test continues");
         }
 
-        // 選択範囲を削除
+        // Delete the selection range
         await page.keyboard.press("Delete");
 
-        // 少し待機して削除が反映されるのを待つ
+        // Wait a bit for the deletion to be reflected
         await page.waitForTimeout(300);
 
-        // 削除後のアイテム数を確認（環境によって異なる可能性がある）
+        // Confirm the item count after deletion (may vary depending on the environment)
         const itemCount = await page.locator(".outliner-item").count();
         console.log(`After deletion, item count: ${itemCount}`);
-        // 削除が行われたことを確認するのではなく、アイテムが存在することを確認
+        // Confirm that items exist, rather than confirming that deletion occurred
         expect(itemCount).toBeGreaterThan(0);
     });
 });


### PR DESCRIPTION
Translated `client/e2e/core/slr-selected-empty-item-bb3a9bf4.spec.ts` from Japanese to English to improve codebase accessibility. The logic remains unchanged. Verified by running the test.

---
*PR created automatically by Jules for task [1978264884340059735](https://jules.google.com/task/1978264884340059735) started by @kitamura-tetsuo*