### PR TITLE
🌐 Lingo: Translate slr-drag-drop-item-e889233a.spec.ts to English

### DIFF
--- a/client/e2e/core/slr-drag-drop-item-e889233a.spec.ts
+++ b/client/e2e/core/slr-drag-drop-item-e889233a.spec.ts
@@ -2,13 +2,13 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature SLR-0009
- *  Title   : ドラッグ＆ドロップによるテキスト移動
+ *  Title   : Text movement by drag and drop
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
-test.describe("SLR-0009: アイテムドラッグ＆ドロップ", () => {
+test.describe("SLR-0009: Item Drag and Drop", () => {
     test.beforeEach(async ({ page }, testInfo) => {
         await page.evaluate(() => {
             (window as any).DEBUG_MODE = true;
@@ -50,7 +50,7 @@ test.describe("SLR-0009: アイテムドラッグ＆ドロップ", () => {
         await page.keyboard.press("Home");
     });
 
-    test("アイテム全体をドラッグ＆ドロップで移動できる", async ({ page }) => {
+    test("Can move entire item by drag and drop", async ({ page }) => {
         const itemCount = await page.locator(".outliner-item").count();
         expect(itemCount).toBeGreaterThanOrEqual(3);
         const firstItemText = await page.locator(".outliner-item").nth(0).locator(".item-text").textContent();


### PR DESCRIPTION
💡 **What:** Translated `client/e2e/core/slr-drag-drop-item-e889233a.spec.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `npm run test:e2e e2e/core/slr-drag-drop-item-e889233a.spec.ts` which passed. Ran `npx dprint fmt` and `npx eslint`.

---
*PR created automatically by Jules for task [9250426187811145060](https://jules.google.com/task/9250426187811145060) started by @kitamura-tetsuo*