### PR TITLE
🌐 Lingo: Translate client/e2e/core/clm-cursor-blink-61a641e7.spec.ts to English

### DIFF
--- a/client/e2e/core/clm-cursor-blink-61a641e7.spec.ts
+++ b/client/e2e/core/clm-cursor-blink-61a641e7.spec.ts
@@ -13,7 +13,7 @@ test.describe("CLM-0001: Click to enter edit mode", () => {
         await TestHelpers.prepareTestEnvironment(page, testInfo);
     });
 
-    test("カーソルが点滅する", async ({ page }) => {
+    test("Cursor blinks", async ({ page }) => {
         await page.screenshot({ path: "client/test-results/CLM-0001-blink-start.png" });
         const item = page.locator(".outliner-item.page-title[data-item-id]");
         if (await item.count() === 0) {


### PR DESCRIPTION
💡 **What:** Translated the Japanese test title `"カーソルが点滅する"` to `"Cursor blinks"` in `client/e2e/core/clm-cursor-blink-61a641e7.spec.ts`.
🎯 **Why:** Improving codebase accessibility and consistency by ensuring test descriptions are in English.
🛠 **Verification:**
- Ran the specific test: `npx playwright test e2e/core/clm-cursor-blink-61a641e7.spec.ts` (Passed).
- Ran `npx tsc --noEmit` in `client/` (Passed).

---
*PR created automatically by Jules for task [814162185946863344](https://jules.google.com/task/814162185946863344) started by @kitamura-tetsuo*