### PR TITLE
🌐 Lingo: Translate client/e2e/core/lnk-temporary-page-display-08bbbbfc.spec.ts to English

### DIFF
--- a/client/e2e/core/lnk-temporary-page-display-08bbbbfc.spec.ts
+++ b/client/e2e/core/lnk-temporary-page-display-08bbbbfc.spec.ts
@@ -3,7 +3,7 @@ import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature LNK-0004
  *  Title   : Temporary Page Feature
- *  Source  : docs/client-features.yaml
+ *  Source  : docs/client-features/lnk-temporary-page-function-08bbbbfc.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
@@ -19,7 +19,7 @@ test.describe("LNK-0004: Temporary Page Display", () => {
         await page.goto(`${sourceUrl}${nonExistentPage}`);
         await page.waitForSelector("body", { timeout: 10000 });
 
-        const loginButton = page.locator("button:has-text('開発者ログイン')");
+        const loginButton = page.locator("button:has-text('Developer Login')");
         if (await loginButton.isVisible()) {
             await loginButton.click();
             await page.waitForTimeout(300);


### PR DESCRIPTION
💡 **What:** Translated `client/e2e/core/lnk-temporary-page-display-08bbbbfc.spec.ts` from Japanese to English.
- Replaced `page.locator("button:has-text('開発者ログイン')")` with `page.locator("button:has-text('Developer Login')")`.
- Updated `Source` metadata to `docs/client-features/lnk-temporary-page-function-08bbbbfc.yaml`.

🎯 **Why:** Improving codebase accessibility and consistency. The Japanese locator was incorrect for the English UI ("Developer Login").

🛠 **Verification:**
- Ran `npm run test:e2e -- e2e/core/lnk-temporary-page-display-08bbbbfc.spec.ts` which passed.
- Verified that `client/src/components/AuthComponent.svelte` uses "Developer Login".
- Ran `npm run lint` in `client`.

---
*PR created automatically by Jules for task [9931819854663479425](https://jules.google.com/task/9931819854663479425) started by @kitamura-tetsuo*