### PR TITLE
🌐 Lingo: Translate client/e2e/core/lnk-create-internal-af8f309a.spec.ts to English

### DIFF
--- a/client/e2e/core/lnk-create-internal-af8f309a.spec.ts
+++ b/client/e2e/core/lnk-create-internal-af8f309a.spec.ts
@@ -2,24 +2,24 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature LNK-0003
- *  Title   : 内部リンクのナビゲーション機能
+ *  Title   : Internal link navigation feature
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
-test.describe("LNK-0003: 内部リンクのナビゲーション機能", () => {
+test.describe("LNK-0003: Internal link navigation feature", () => {
     test.beforeEach(async ({ page }, testInfo) => {
         await TestHelpers.prepareTestEnvironment(page, testInfo);
     });
 
-    test("実際のアプリケーションで内部リンクを作成する", async ({ page }) => {
-        // 最初のアイテムを選択
+    test("Create an internal link in the actual application", async ({ page }) => {
+        // Select the first item
         const firstItem = page.locator(".outliner-item").first();
         await firstItem.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 
-        // フォーカス状態を確認
+        // Check focus state
         const focusState = await page.evaluate(() => {
             const textarea = document.querySelector(".global-textarea") as HTMLTextAreaElement;
             return {


### PR DESCRIPTION
💡 **What:** Translated Japanese text in `client/e2e/core/lnk-create-internal-af8f309a.spec.ts` to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `npm run test:e2e -- client/e2e/core/lnk-create-internal-af8f309a.spec.ts` and confirmed it passes. Verified no unrelated files were modified.

---
*PR created automatically by Jules for task [15072615089236888816](https://jules.google.com/task/15072615089236888816) started by @kitamura-tetsuo*