### PR TITLE
🌐 Lingo: Translate client/e2e/core/lnk-create-internal-af8f309a.spec.ts to English

### DIFF
--- a/client/e2e/core/lnk-create-internal-af8f309a.spec.ts
+++ b/client/e2e/core/lnk-create-internal-af8f309a.spec.ts
@@ -2,24 +2,24 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature LNK-0003
- *  Title   : 内部リンクのナビゲーション機能
+ *  Title   : Internal link navigation feature
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
-test.describe("LNK-0003: 内部リンクのナビゲーション機能", () => {
+test.describe("LNK-0003: Internal link navigation feature", () => {
     test.beforeEach(async ({ page }, testInfo) => {
         await TestHelpers.prepareTestEnvironment(page, testInfo);
     });
 
-    test("実際のアプリケーションで内部リンクを作成する", async ({ page }) => {
-        // 最初のアイテムを選択
+    test("Create internal link in actual application", async ({ page }) => {
+        // Select the first item
         const firstItem = page.locator(".outliner-item").first();
         await firstItem.locator(".item-content").click();
         await TestHelpers.waitForCursorVisible(page);
 
-        // フォーカス状態を確認
+        // Check focus state
         const focusState = await page.evaluate(() => {
             const textarea = document.querySelector(".global-textarea") as HTMLTextAreaElement;
             return {


### PR DESCRIPTION
Translated `client/e2e/core/lnk-create-internal-af8f309a.spec.ts` from Japanese to English.
Verified that the test passes with `npm run test:e2e -- e2e/core/lnk-create-internal-af8f309a.spec.ts`.
Ensured `firebase.emulator.json` is not modified.

---
*PR created automatically by Jules for task [17514991934957324187](https://jules.google.com/task/17514991934957324187) started by @kitamura-tetsuo*