### PR TITLE
Fix focus hijacking by editor when typing in Search Box

### DIFF
--- a/client/e2e/core/bug-repro-search-focus.spec.ts
+++ b/client/e2e/core/bug-repro-search-focus.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+import { registerCoverageHooks } from "../utils/registerCoverageHooks";
+import { TestHelpers } from "../utils/testHelpers";
+
+registerCoverageHooks();
+
+test.describe("Bug Reproduction: Search Box Focus", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        // Seed some data
+        await TestHelpers.prepareTestEnvironment(page, testInfo, ["Item 1"]);
+    });
+
+    test("Typing in search box should not input into editor item", async ({ page }) => {
+        // 1. Focus on the second item (the content item, not the title)
+        await TestHelpers.waitForOutlinerItems(page, 2);
+        const contentItem = page.locator(".outliner-item").nth(1);
+        // Click to focus the item
+        await contentItem.locator(".item-text").click();
+
+        // Ensure editor has focus (GlobalTextArea usually takes focus)
+        // We might need to wait a tiny bit for the focus logic to settle
+        await page.waitForTimeout(200);
+        await expect(page.locator("textarea.global-textarea")).toBeFocused();
+
+        // 2. Click/Focus the search box
+        const searchInput = page.locator('[data-testid="search-pages-input"]');
+        await searchInput.click();
+
+        // Ensure search box has focus
+        await expect(searchInput).toBeFocused();
+
+        // 3. Type text
+        const searchText = "test search";
+        await page.keyboard.type(searchText);
+
+        // 4. Verify text appears in search box
+        await expect(searchInput).toHaveValue(searchText);
+
+        // 5. Verify text does NOT appear in the editor item
+        // The item should still contain "Item 1"
+        const itemText = contentItem.locator(".item-text");
+        await expect(itemText).toHaveText("Item 1");
+    });
+});

--- a/client/src/components/GlobalTextArea.svelte
+++ b/client/src/components/GlobalTextArea.svelte
@@ -143,6 +143,17 @@ onMount(() => {
             // Leave to existing forwarders while alias picker/command palette is visible
             if (aliasPickerStore.isVisible || window.commandPaletteStore?.isVisible) return;
 
+            // Ignore if focus is on another interactive element (Search Box, etc.)
+            const ae = document.activeElement;
+            if (ae && ae !== textareaRef && (
+                ae.tagName === "INPUT" ||
+                ae.tagName === "TEXTAREA" ||
+                ae.tagName === "SELECT" ||
+                (ae as HTMLElement).isContentEditable
+            )) {
+                return;
+            }
+
             const activeId = store.getActiveItem();
             const ta = textareaRef;
             // If textarea is already focused, leave it to the normal process
@@ -263,6 +274,18 @@ onMount(() => {
             const isBoxSelectionKey = ev.altKey && ev.shiftKey &&
                 (ev.key === "ArrowUp" || ev.key === "ArrowDown" || ev.key === "ArrowLeft" || ev.key === "ArrowRight");
             if (ev.isComposing || (!isBoxSelectionKey && (ev.ctrlKey || ev.metaKey || ev.altKey))) return;
+
+            // Ignore if focus is on another interactive element (Search Box, etc.)
+            const ae = document.activeElement;
+            if (ae && ae !== textareaRef && (
+                ae.tagName === "INPUT" ||
+                ae.tagName === "TEXTAREA" ||
+                ae.tagName === "SELECT" ||
+                (ae as HTMLElement).isContentEditable
+            )) {
+                return;
+            }
+
             // Always delegate to KeyEventHandler (processed internally only when necessary)
             KeyEventHandler.handleKeyDown(ev);
         };


### PR DESCRIPTION
This PR fixes a bug where typing in the Search Box resulted in text being input into the editor instead. The issue was caused by `GlobalTextArea` aggressively capturing global key events and manually inserting text into the editor without checking if another input was focused.

Changes:
- Added a check in `GlobalTextArea.svelte` to bail out of global key handling if `document.activeElement` is an interactive element.
- Added an E2E test to verify that typing in the search box works correctly and does not affect the editor content.

---
*PR created automatically by Jules for task [10296683705296736398](https://jules.google.com/task/10296683705296736398) started by @kitamura-tetsuo*