### PR TITLE
🌐 Lingo: Translate `api-fixing-firebase-functions-api-server-9e65d78b.spec.ts` title to English

### DIFF
--- a/client/e2e/core/api-fixing-firebase-functions-api-server-9e65d78b.spec.ts
+++ b/client/e2e/core/api-fixing-firebase-functions-api-server-9e65d78b.spec.ts
@@ -2,7 +2,7 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature API-0001
- *  Title   : Firebase Functions APIサーバーの修正
+ *  Title   : Fixing Firebase Functions API Server
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";


### PR DESCRIPTION
💡 **What:** Translated the JSDoc title in `client/e2e/core/api-fixing-firebase-functions-api-server-9e65d78b.spec.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency by using English for technical documentation within the code.
🛠 **Verification:** Verified that the file content is correct and ran `npm run lint` in the `client` directory to ensure no syntax errors were introduced. Checked that no unrelated files were modified.

---
*PR created automatically by Jules for task [14065508897088503727](https://jules.google.com/task/14065508897088503727) started by @kitamura-tetsuo*