### PR TITLE
🌐 Lingo: Translate slr-shrink-selection-99167b65.spec.ts to English

### DIFF
--- a/client/e2e/core/slr-shrink-selection-99167b65.spec.ts
+++ b/client/e2e/core/slr-shrink-selection-99167b65.spec.ts
@@ -2,13 +2,13 @@ import "../utils/registerAfterEachSnapshot";
 import { registerCoverageHooks } from "../utils/registerCoverageHooks";
 registerCoverageHooks();
 /** @feature SLR-0012
- *  Title   : 選択範囲の縮小
+ *  Title   : Shrink selection
  *  Source  : docs/client-features.yaml
  */
 import { expect, test } from "@playwright/test";
 import { TestHelpers } from "../utils/testHelpers";
 
-test.describe("SLR-0012: 選択範囲の縮小", () => {
+test.describe("SLR-0012: Shrink selection", () => {
     test.beforeEach(async ({ page }, testInfo) => {
         await TestHelpers.prepareTestEnvironment(page, testInfo, [""]);
         const item = page.locator(".outliner-item").first();


### PR DESCRIPTION
💡 **What:** Translated the test title and description in `client/e2e/core/slr-shrink-selection-99167b65.spec.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency by aligning with the English documentation found in `docs/client-features/slr-shrink-selection-99167b65.yaml`.
🛠 **Verification:** Ran `npm run test:e2e -- e2e/core/slr-shrink-selection-99167b65.spec.ts` which passed. Ran `npm run lint` and confirmed no new lint errors were introduced in the modified file. Reverted unintentional changes to `firebase.emulator.json`.

---
*PR created automatically by Jules for task [18258718058160120489](https://jules.google.com/task/18258718058160120489) started by @kitamura-tetsuo*