### PR TITLE
Increase GlobalTextArea height to 40px

### DIFF
--- a/client/src/components/GlobalTextArea.svelte
+++ b/client/src/components/GlobalTextArea.svelte
@@ -440,7 +440,7 @@ function handleBlur(_event: FocusEvent) { // eslint-disable-line @typescript-esl
     top: 0;
     left: 0;
     width: 1px;
-    height: 1.5em;
+    height: 40px;
     padding: 0;
     border: 0;
     outline: none;


### PR DESCRIPTION
Increased the height of the hidden .global-textarea component from 1.5em to 40px to prevent the Japanese IME composition underline from being clipped due to overflow: hidden. Verified with a Playwright script.

---
*PR created automatically by Jules for task [1426921846340687863](https://jules.google.com/task/1426921846340687863) started by @kitamura-tetsuo*