### PR TITLE
🌐 Lingo: Translate client/playwright.config.ts to English

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -4,14 +4,14 @@ import { defineConfig, devices } from "@playwright/test";
 import path from "path";
 import { fileURLToPath } from "url";
 
-// ESモジュールで__dirnameを使うための設定
+// Configuration to use __dirname in ES modules
 const __filename = fileURLToPath(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const __dirname = path.dirname(__filename);
 
-// -- 単一 spec 実行かどうかを推定 -------------------------
+// -- Estimate whether it is a single spec run -------------------------
 function detectSingleSpec() {
-    // 環境変数が既に設定されている場合はそれを使用
+    // Use environment variable if already set
     if (process.env.PLAYWRIGHT_SINGLE_SPEC_RUN !== undefined) {
         return process.env.PLAYWRIGHT_SINGLE_SPEC_RUN === "true";
     }
@@ -20,7 +20,7 @@ function detectSingleSpec() {
     const patterns = idx === -1 ? [] : process.argv.slice(idx + 1).filter(a => !a.startsWith("-"));
     const isSingle = patterns.length === 1;
 
-    // 環境変数に設定してワーカープロセスに伝達
+    // Set to environment variable to propagate to worker processes
     process.env.PLAYWRIGHT_SINGLE_SPEC_RUN = isSingle.toString();
 
     return isSingle;
@@ -28,17 +28,17 @@ function detectSingleSpec() {
 
 export const isSingleSpecRun = detectSingleSpec();
 
-// テスト環境の設定
-// 環境変数TEST_ENVが'localhost'の場合はlocalhost環境、それ以外はデフォルト環境
-// VSCode Playwright拡張から実行する場合は環境変数が正しく渡らないことがあるため、
-// 必要に応じて直接trueに設定してください
-const isLocalhostEnv = process.env.TEST_ENV === "localhost" || true; // デフォルトでlocalhostを使用
+// Test environment configuration
+// Use localhost environment if TEST_ENV is 'localhost', otherwise use default environment
+// Since environment variables may not be passed correctly when running from VSCode Playwright extension,
+// set to true directly if necessary
+const isLocalhostEnv = process.env.TEST_ENV === "localhost" || true; // Default to localhost
 
-// テスト用ポートを定義 - これを明示的に指定
-// Tinylicious サーバーのポートを定義
+// Define test port - specify explicitly
+// Define Tinylicious server port
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const TINYLICIOUS_PORT = isLocalhostEnv ? "7092" : "7082";
-// ホストを定義
+// Define host
 const VITE_HOST = process.env.VITE_HOST || "localhost";
 const TEST_PORT = 7090;
 
@@ -63,7 +63,7 @@ const commonArgs = [
     "--disable-plugins",
     "--run-all-compositor-stages-before-draw",
     "--disable-ipc-flooding-protection",
-    // 共有メモリサイズを明示的に指定
+    // Explicitly specify shared memory size
     "--shm-size=1gb",
     "--allow-file-access-from-files",
     "--enable-clipboard-read",
@@ -97,73 +97,73 @@ export default defineConfig({
             ? [["json", { outputFile: process.env.PLAYWRIGHT_JSON_OUTPUT_NAME }]]
             : []),
     ] as any,
-    // テスト実行時のタイムアウトを延長（環境初期化の揺らぎに対応）
-    // Hocuspocusへの接続とYjs同期に時間がかかることがあるため、120秒に延長
+    // Extend test execution timeout (to accommodate environment initialization fluctuations)
+    // Extended to 120 seconds because connection to Hocuspocus and Yjs synchronization may take time
     timeout: 120 * 1000,
     expect: {
-        // 要素の検出待機のタイムアウト設定を延長
+        // Extend element detection timeout
         timeout: 90 * 1000,
     },
 
     use: {
         headless: true,
         ...devices["Desktop Chrome"],
-        // Chromium用のタイムアウト設定を延長
+        // Extend timeout setting for Chromium
         launchOptions: {
-            // 共有メモリの問題を回避するためのオプション
+            // Option to avoid shared memory issues
             args: [...commonArgs, ...debugArgs],
         },
-        // Clipboard APIを有効にするためにlocalhostを使用
+        // Use localhost to enable Clipboard API
         baseURL: `http://${VITE_HOST}:${process.env.TEST_PORT || TEST_PORT}`,
-        // クリップボードへのアクセスを許可
+        // Allow clipboard access
         permissions: ["clipboard-read", "clipboard-write"],
     },
 
     projects: [
         {
-            // 基本テスト: 環境確認や最小構成の検証用
+            // Basic tests: For environment check and minimal configuration verification
             name: "basic",
             testDir: "./e2e/basic",
         },
         {
-            // コアテスト1: a-c (excl clm), f
+            // Core tests 1: a-c (excl clm), f
             name: "core-1",
             testDir: "./e2e/core",
             testMatch: ["[abcf]*.spec.ts"],
             testIgnore: ["**/clm*.spec.ts"],
         },
         {
-            // コアテスト2: clm only
+            // Core tests 2: clm only
             name: "core-2",
             testDir: "./e2e/core",
             testMatch: ["**/clm*.spec.ts"],
         },
         {
-            // コアテスト3: l only
+            // Core tests 3: l only
             name: "core-3",
             testDir: "./e2e/core",
             testMatch: ["**/l*.spec.ts"],
         },
         {
-            // コアテスト4: slr only
+            // Core tests 4: slr only
             name: "core-4",
             testDir: "./e2e/core",
             testMatch: ["**/slr*.spec.ts"],
         },
         {
-            // コアテスト5: n, o, p
+            // Core tests 5: n, o, p
             name: "core-5",
             testDir: "./e2e/core",
             testMatch: ["**/[nop]*.spec.ts"],
         },
         {
-            // コアテスト6: sbd, sch
+            // Core tests 6: sbd, sch
             name: "core-6",
             testDir: "./e2e/core",
             testMatch: ["**/sbd*.spec.ts", "**/sch*.spec.ts"],
         },
         {
-            // コアテスト7: sea, sec, server, snapshot
+            // Core tests 7: sea, sec, server, snapshot
             name: "core-7",
             testDir: "./e2e/core",
             testMatch: [
@@ -175,52 +175,52 @@ export default defineConfig({
             ],
         },
         {
-            // コアテスト8: d, e, g, h, i, j, k, m, q, t, u, v, w, x, y, z, M
+            // Core tests 8: d, e, g, h, i, j, k, m, q, t, u, v, w, x, y, z, M
             name: "core-8",
             testDir: "./e2e/core",
             testMatch: ["**/[deghijkmtuvwxyzM]*.spec.ts"],
         },
         {
-            // 新機能テスト1: a, b
+            // New feature tests 1: a, b
             name: "new-1",
             testDir: "./e2e/new",
             testMatch: ["**/[ab]*.spec.ts"],
         },
         {
-            // 新機能テスト2: c
+            // New feature tests 2: c
             name: "new-2",
             testDir: "./e2e/new",
             testMatch: ["**/c*.spec.ts"],
         },
         {
-            // 新機能テスト3: d, e, f, g, h, i
+            // New feature tests 3: d, e, f, g, h, i
             name: "new-3",
             testDir: "./e2e/new",
             testMatch: ["**/[defghi]*.spec.ts"],
         },
         {
-            // 新機能テスト4: j-z
+            // New feature tests 4: j-z
             name: "new-4",
             testDir: "./e2e/new",
             testMatch: ["**/[j-z]*.spec.ts"],
         },
         {
-            // 認証テスト: 本番環境でのみ実行
+            // Auth tests: Run only in production environment
             name: "auth",
             testDir: "./e2e/auth",
         },
         {
-            // ユーティリティテスト: 共通機能のテスト
+            // Utility tests: Common functionality tests
             name: "utils",
             testDir: "./e2e/utils",
         },
         {
-            // サーバーテスト: バックエンド接続の検証用
+            // Server tests: For backend connection verification
             name: "server",
             testDir: "./e2e/server",
         },
         {
-            // Yjsテスト: Yjs同期機能のテスト
+            // Yjs tests: Yjs synchronization functionality tests
             name: "yjs",
             testDir: "./e2e/yjs",
         },


### PR DESCRIPTION
💡 **What:** Translated `client/playwright.config.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `npm run lint` and `npx playwright test --list` in `client` directory.

---
*PR created automatically by Jules for task [16551859125568571959](https://jules.google.com/task/16551859125568571959) started by @kitamura-tetsuo*