### PR TITLE
Remove double scrolling on project page

### DIFF
--- a/client/src/components/EditorOverlay.svelte
+++ b/client/src/components/EditorOverlay.svelte
@@ -172,8 +172,8 @@ function updateTextareaPosition() {
         const treeContainerRect = treeContainer.getBoundingClientRect();
 
         // Position the textarea using viewport coordinates
-        textareaRef.style.setProperty('left', `${treeContainerRect.left + pos.left}px`, 'important');
-        textareaRef.style.setProperty('top', `${treeContainerRect.top + pos.top}px`, 'important');
+        textareaRef.style.setProperty('left', `${treeContainerRect.left + pos.left + window.scrollX}px`, 'important');
+        textareaRef.style.setProperty('top', `${treeContainerRect.top + pos.top + window.scrollY}px`, 'important');
     } catch (e) {
         console.error("Error in updateTextareaPosition:", e);
     }

--- a/client/src/components/OutlinerTree.svelte
+++ b/client/src/components/OutlinerTree.svelte
@@ -61,18 +61,20 @@
     // Throttle scroll event to improve performance
     let scrollTimeout: number | null = null;
     function handleScroll() {
-        if (!treeContainer || scrollTimeout) return;
+        if (scrollTimeout) return;
 
         scrollTimeout = requestAnimationFrame(() => {
-            if (treeContainer) {
-                showScrollTop = treeContainer.scrollTop > 300;
+            if (typeof window !== "undefined") {
+                showScrollTop = window.scrollY > 300;
             }
             scrollTimeout = null;
         });
     }
 
     function scrollToTop() {
-        treeContainer?.scrollTo({ top: 0, behavior: "smooth" });
+        if (typeof window !== "undefined") {
+            window.scrollTo({ top: 0, behavior: "smooth" });
+        }
         // Move focus back to the tree container or first item for accessibility
         // For now, keeping focus management simple as scrolling doesn't change context significantly
     }
@@ -151,12 +153,19 @@
             currentUser = result?.user.id ?? "anonymous";
         });
         editorOverlayStore.setOnEditCallback(handleEdit);
+        if (typeof window !== "undefined") {
+            window.addEventListener("scroll", handleScroll);
+        }
     });
 
     // Remeasure height in response to changes in visible item count ($effect is unused)
     // Legacy hook assuming update trigger via observeDeep (__displayItemsTick)
 
     onDestroy(() => {
+        if (typeof window !== "undefined") {
+            window.removeEventListener("scroll", handleScroll);
+        }
+
         // Clear onEdit callback
         editorOverlayStore.setOnEditCallback(null);
 
@@ -1811,7 +1820,6 @@
             role="region"
             aria-label="Outliner Tree"
             bind:this={treeContainer}
-            onscroll={handleScroll}
         >
             <!-- Flat display items (static placement) -->
             {#each displayItems as display, index (display.model.id)}
@@ -2022,12 +2030,11 @@
         background: white;
         border: 1px solid #ddd;
         border-radius: 6px;
-        overflow: hidden;
         margin-bottom: 20px;
-        height: calc(100vh - 40px); /* Value calculated by subtracting margin from browser height */
         display: flex;
         flex-direction: column;
         position: relative;
+        min-height: calc(100vh - 140px);
     }
 
     .toolbar {
@@ -2063,8 +2070,6 @@
         padding: 8px 16px;
         position: relative; /* Reference point for absolute positioning of child elements */
         min-height: 100px; /* Set minimum height */
-        flex: 1; /* Use all remaining space */
-        overflow-y: auto; /* Enable scrolling */
     }
 
     .item-container {


### PR DESCRIPTION
- Removed `overflow: hidden` and fixed height from `OutlinerTree` to allow the page to scroll naturally.
- Removed `overflow-y: auto` from `.tree-container`.
- Updated `handleScroll` and `scrollToTop` logic to interact with the window scroll instead of the container scroll.
- Updated `EditorOverlay` to include `window.scrollX` and `window.scrollY` in `GlobalTextArea` positioning calculations, ensuring the IME input remains correctly aligned with the cursor during page scrolling.

---
*PR created automatically by Jules for task [16932151346247694860](https://jules.google.com/task/16932151346247694860) started by @kitamura-tetsuo*