### PR TITLE
🌐 Lingo: Translate fmt-multiple-internal-links-3a606671.spec.ts to English

### DIFF
--- a/client/e2e/core/fmt-multiple-internal-links-3a606671.spec.ts
+++ b/client/e2e/core/fmt-multiple-internal-links-3a606671.spec.ts
@@ -20,7 +20,7 @@ test.describe("FMT-0008: multiple internal links", () => {
     });
 
     test("multiple internal links are displayed", async ({ page }) => {
-        // prepareTestEnvironment の lines パラメータでデータを作成
+        // create data using the lines parameter of prepareTestEnvironment
         await TestHelpers.prepareTestEnvironment(page, test.info(), [
             "This is [test-page] and [/project/other-page]",
         ]);


### PR DESCRIPTION
💡 **What:** Translated `client/e2e/core/fmt-multiple-internal-links-3a606671.spec.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `npm run lint --prefix client` and `npm run test:e2e:basic --prefix client`. No errors introduced.

---
*PR created automatically by Jules for task [8816828248482697830](https://jules.google.com/task/8816828248482697830) started by @kitamura-tetsuo*