### PR TITLE
🌐 Lingo: Translate sch-schedule-management-ui-cfe72703.spec.ts to English

### DIFF
--- a/client/e2e/core/sch-schedule-management-ui-cfe72703.spec.ts
+++ b/client/e2e/core/sch-schedule-management-ui-cfe72703.spec.ts
@@ -19,7 +19,7 @@ test.describe("Schedule Management UI", () => {
     });
 
     test("create and cancel schedule", async ({ page }) => {
-        // コンソールログを監視
+        // Monitor console logs
         page.on("console", msg => {
             if (msg.text().includes("Schedule page:")) {
                 console.log("Browser console:", msg.text());
@@ -29,10 +29,10 @@ test.describe("Schedule Management UI", () => {
         await page.locator("text=Schedule").click();
         await expect(page.locator("text=Schedule Management")).toBeVisible();
 
-        // ページが完全に読み込まれるまで少し待つ
+        // Wait a moment until the page is fully loaded
         await page.waitForTimeout(500);
 
-        // ページの状態をログ出力
+        // Log page state
         const pageId = await page.evaluate(() => {
             return (window as any).appStore?.currentPage?.id || "undefined";
         });
@@ -45,10 +45,10 @@ test.describe("Schedule Management UI", () => {
         console.log("Test: Clicking Add button with datetime:", future);
         await page.locator('button:has-text("Add")').click();
 
-        // スケジュール追加後、少し待つ
+        // Wait a moment after adding the schedule
         await page.waitForTimeout(500);
 
-        // スケジュール専用のセレクターを使用
+        // Use schedule-specific selectors
         const scheduleItems = page.locator('[data-testid="schedule-item"]');
         await expect(scheduleItems).toHaveCount(1);
 


### PR DESCRIPTION
💡 **What:** Translated pure inline Japanese comments in `client/e2e/core/sch-schedule-management-ui-cfe72703.spec.ts` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `npm run lint --prefix client`, `npm run test:unit --prefix client`, `npm run test:integration --prefix client`, and `npm run test:e2e --prefix client -- core/sch-schedule-management-ui-cfe72703.spec.ts`. All passed.

---
*PR created automatically by Jules for task [16173091199532488084](https://jules.google.com/task/16173091199532488084) started by @kitamura-tetsuo*