### PR TITLE
🌐 Lingo: Translate chromium-debug.spec.ts to English

### DIFF
--- a/client/e2e/disabled/chromium-debug.spec.ts
+++ b/client/e2e/disabled/chromium-debug.spec.ts
@@ -85,7 +85,7 @@ test.describe("Chromium Debug Test", () => {
                 return (window as any).generalStore || (window as any).appStore;
             }, { timeout: 10000 });
 
-            // タイトルを確認 (expect any non-empty title rather than just truthy)
+            // Check the title (expect any non-empty title rather than just truthy)
             const title = await page.title();
             console.log("Debug: Page title:", title);
 


### PR DESCRIPTION
💡 **What:** Translated `// タイトルを確認` from Japanese to `// Check the title` in `client/e2e/disabled/chromium-debug.spec.ts`.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `npm run lint --prefix client`, `npm run test:unit --prefix client`, `npm run test:integration --prefix client`, and `npm run test:e2e --prefix client -- client/e2e/disabled/chromium-debug.spec.ts`.

---
*PR created automatically by Jules for task [12352804881936340745](https://jules.google.com/task/12352804881936340745) started by @kitamura-tetsuo*