### PR TITLE
🌐 Lingo: Translate client/scripts/cleanup-coverage.js to English

### DIFF
--- a/client/scripts/cleanup-coverage.js
+++ b/client/scripts/cleanup-coverage.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 /**
- * 古い coverage JSON ファイルを削除して、各テスト実行で fresh coverage データを取得できるようにします。
- * - unit_and_integration/ から coverage-final.json 以外の JSON ファイルを削除
- * - e2e/raw/ から全ての JSON ファイルを削除
- * - merged/ から古いマージされた coverage データを削除
+ * Delete old coverage JSON files so that fresh coverage data can be obtained for each test run.
+ * - Delete JSON files other than coverage-final.json from unit_and_integration/
+ * - Delete all JSON files from e2e/raw/
+ * - Delete old merged coverage data from merged/
  */
 
 import fs from "fs";
@@ -17,7 +17,7 @@ const __dirname = path.dirname(__filename);
 const workspaceDir = path.resolve(__dirname, "../..");
 const coverageDir = path.join(workspaceDir, "coverage");
 
-// 各サブディレクトリの設定
+// Configuration for each subdirectory
 const cleanupDirs = [
     {
         name: "unit_and_integration",
@@ -25,20 +25,20 @@ const cleanupDirs = [
     },
     {
         name: "e2e/raw",
-        keepFile: null, // 全てのJSONファイルを削除
+        keepFile: null, // Delete all JSON files
     },
     {
         name: "merged",
-        keepFile: null, // 全てのJSONファイルを削除
+        keepFile: null, // Delete all JSON files
     },
 ];
 
 /**
- * 指定されたディレクトリから古い JSON ファイルを削除します
+ * Delete old JSON files from the specified directory
  */
 function cleanupDirectory(dirPath, keepFile = null) {
     if (!fs.existsSync(dirPath)) {
-        return 0; // ディレクトリが存在しない場合はスキップ
+        return 0; // Skip if directory does not exist
     }
 
     let removedCount = 0;
@@ -47,19 +47,19 @@ function cleanupDirectory(dirPath, keepFile = null) {
         const entries = fs.readdirSync(dirPath, { withFileTypes: true });
 
         for (const entry of entries) {
-            // ディレクトリはスキップ
+            // Skip directories
             if (entry.isDirectory()) {
                 continue;
             }
 
             const filePath = path.join(dirPath, entry.name);
 
-            // keepFile が指定されている場合、そのファイルは削除しない
+            // If keepFile is specified, do not delete that file
             if (keepFile && entry.name === keepFile) {
                 continue;
             }
 
-            // JSON ファイルのみ削除
+            // Delete only JSON files
             if (entry.name.endsWith(".json")) {
                 fs.unlinkSync(filePath);
                 console.log(`[coverage:cleanup] deleted: ${path.relative(workspaceDir, filePath)}`);
@@ -78,12 +78,12 @@ function main() {
 
     console.log("[coverage:cleanup] cleaning up old coverage files...");
 
-    // 各ディレクトリを処理
+    // Process each directory
     for (const dirConfig of cleanupDirs) {
         const dirPath = path.join(coverageDir, dirConfig.name);
 
         if (!fs.existsSync(dirPath)) {
-            // ディレクトリが存在しない場合はスキップしてエラーにしない
+            // Skip without error if the directory does not exist
             continue;
         }
 
@@ -97,14 +97,14 @@ function main() {
 
     console.log("[coverage:cleanup] cleanup completed");
 
-    // 何もない場合は適切なメッセージ
+    // Appropriate message if nothing was found
     if (totalRemoved === 0) {
         console.log("[coverage:cleanup] no old coverage files found to delete");
     } else {
         console.log(`[coverage:cleanup] total: ${totalRemoved} file(s) removed`);
     }
 
-    // 常に成功ステータスで終了
+    // Always exit with success status
     process.exit(0);
 }
 


### PR DESCRIPTION
💡 **What:** Translated the JSDoc and inline comments in `client/scripts/cleanup-coverage.js` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** 
- Checked that only Japanese code comments were altered and the structure remained untouched.
- Checked for remaining Japanese text in `client/scripts/cleanup-coverage.js` using regex (`/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/`) via Node script. None found.
- Ran `npm run lint --prefix client` and `npm run test:unit --prefix client` and `npm run test:integration --prefix client` successfully, confirming no syntax errors or functional regressions were introduced.

---
*PR created automatically by Jules for task [1676268723711164336](https://jules.google.com/task/1676268723711164336) started by @kitamura-tetsuo*