### PR TITLE
🌐 Lingo: Translate cleanup-e2e-raw-coverage.js to English

### DIFF
--- a/client/scripts/cleanup-e2e-raw-coverage.js
+++ b/client/scripts/cleanup-e2e-raw-coverage.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * e2e/raw/ ディレクトリ内の重複したカバレッジファイルを整理します。
- * 同一テストのカバレッジファイルが複数ある場合、最新のものだけを残して他を削除します。
- * ファイル名形式: coverage-<TEST_NAME>-<TIMESTAMP>.json
+ * Cleans up duplicate coverage files in the e2e/raw/ directory.
+ * If multiple coverage files exist for the same test, it keeps only the newest one and deletes the rest.
+ * File name format: coverage-<TEST_NAME>-<TIMESTAMP>.json
  */
 
 import fs from "fs";


### PR DESCRIPTION
💡 **What:** Translated the Japanese JSDoc comment in `client/scripts/cleanup-e2e-raw-coverage.js` to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `pnpm lint`, `pnpm test`, and manually tested the modified script to ensure no functionality is affected. Checked that there are no remaining Japanese characters in the file.

---
*PR created automatically by Jules for task [1737137061127969031](https://jules.google.com/task/1737137061127969031) started by @kitamura-tetsuo*