### PR TITLE
🌐 Lingo: Translate create-stryker-summary.mjs output to English

### DIFF
--- a/client/scripts/create-stryker-summary.mjs
+++ b/client/scripts/create-stryker-summary.mjs
@@ -83,7 +83,7 @@ function renderStatusTable(statusMap) {
 
 function renderSurvivorList(survivors, limit = 5) {
     if (survivors.length === 0) {
-        return "すべてのミューテーションが検出されました。";
+        return "All mutations were detected.";
     }
 
     const top = survivors.slice(0, limit);
@@ -96,7 +96,7 @@ function renderSurvivorList(survivors, limit = 5) {
     });
 
     if (survivors.length > limit) {
-        lines.push(`- ...他 ${survivors.length - limit} 件`);
+        lines.push(`- ...and ${survivors.length - limit} others`);
     }
 
     return lines.join("\n");
@@ -111,14 +111,14 @@ async function main() {
     const summary = collectMutants(report);
     const mdLines = [
         "### Mutation Score",
-        `- スコア: ${summary.score.toFixed(2)}%`,
-        `- 総ミューテーション数: ${summary.total}`,
-        `- 対象外 (Ignored): ${summary.ignored}`,
+        `- Score: ${summary.score.toFixed(2)}%`,
+        `- Total Mutants: ${summary.total}`,
+        `- Ignored: ${summary.ignored}`,
         "",
-        "### ステータス別内訳",
+        "### Status Breakdown",
         renderStatusTable(summary.statuses),
         "",
-        "### 生存ミューテーション (上位)",
+        "### Top Surviving Mutants",
         renderSurvivorList(summary.survivors),
     ];
 


### PR DESCRIPTION
💡 **What:** Translated Japanese strings in `client/scripts/create-stryker-summary.mjs` to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `node client/scripts/create-stryker-summary.mjs dummy-report.json dummy-summary` with a mock payload and verified the text output in English.

---
*PR created automatically by Jules for task [5324761412460932669](https://jules.google.com/task/5324761412460932669) started by @kitamura-tetsuo*