### PR TITLE
🌐 Lingo: Translate client/scripts/merge-coverage.js to English

### DIFF
--- a/client/scripts/merge-coverage.js
+++ b/client/scripts/merge-coverage.js
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 
 /**
- * カバレッジレポートを統合するスクリプト
+ * Script to merge coverage reports
  *
- * unit/integration/e2eテストのカバレッジを統合し、
- * 統一されたレポートを生成します。
+ * Merges coverage from unit/integration/e2e tests and
+ * generates a unified report.
  *
- * 使用方法:
+ * Usage:
  *   node scripts/merge-coverage.js
  *
- * 前提条件:
- *   - unit/integration/e2eテストが実行済みであること
- *   - 各テストのカバレッジデータが生成されていること
+ * Prerequisites:
+ *   - unit/integration/e2e tests must have been executed
+ *   - Coverage data for each test must have been generated
  */
 
 import fs from "fs";
@@ -27,7 +27,7 @@ const libCoverage = require("istanbul-lib-coverage");
 const libReport = require("istanbul-lib-report");
 const reports = require("istanbul-reports");
 
-// カバレッジディレクトリのパス
+// Path to coverage directory
 const workspaceDir = path.resolve(__dirname, "../..");
 const coverageDir = path.join(workspaceDir, "coverage");
 const unitAndIntegrationCoverageFile = path.join(coverageDir, "unit_and_integration", "coverage-final.json");
@@ -35,19 +35,19 @@ const e2eCoverageFile = path.join(coverageDir, "e2e", "coverage-final.json");
 const mergedCoverageFile = path.join(coverageDir, "merged", "coverage-final.json");
 const mergedReportDir = path.join(coverageDir, "merged");
 
-console.log("カバレッジレポートの統合を開始します...");
+console.log("Starting integration of coverage reports...");
 
-// カバレッジマップを作成
+// Create coverage map
 const coverageMap = libCoverage.createCoverageMap();
 
-// 各カバレッジファイルを読み込んで統合
+// Read and integrate each coverage file
 let filesFound = 0;
 const coverageSources = [];
 
-// Unit/Integrationテストのカバレッジを追加
-// Vitestは全プロジェクトのカバレッジを1つのファイルに統合します
+// Add coverage for Unit/Integration tests
+// Vitest integrates coverage for all projects into one file
 if (fs.existsSync(unitAndIntegrationCoverageFile)) {
-    console.log("Unit/Integrationテストのカバレッジを読み込んでいます...");
+    console.log("Loading coverage for Unit/Integration tests...");
     const unitAndIntegrationCoverage = JSON.parse(fs.readFileSync(unitAndIntegrationCoverageFile, "utf8"));
     const files = Object.keys(unitAndIntegrationCoverage);
     const jsFiles = files.filter((f) => !f.includes(".css"));
@@ -61,17 +61,17 @@ if (fs.existsSync(unitAndIntegrationCoverageFile)) {
         jsFiles: jsFiles.length,
         cssFiles: cssFiles.length,
     });
-    console.log(`  ✓ ${files.length} ファイルのカバレッジを追加しました`);
-    console.log(`    - JavaScript: ${jsFiles.length} 個`);
-    console.log(`    - CSS: ${cssFiles.length} 個`);
+    console.log(`  ✓ Added coverage for ${files.length} files`);
+    console.log(`    - JavaScript: ${jsFiles.length} files`);
+    console.log(`    - CSS: ${cssFiles.length} files`);
 } else {
-    console.log("  ⚠ Unit/Integrationテストのカバレッジが見つかりません");
-    console.log(`     探したパス: ${unitAndIntegrationCoverageFile}`);
+    console.log("  ⚠ Coverage for Unit/Integration tests not found");
+    console.log(`     Searched path: ${unitAndIntegrationCoverageFile}`);
 }
 
-// E2Eテストのカバレッジを追加
+// Add coverage for E2E tests
 if (fs.existsSync(e2eCoverageFile)) {
-    console.log("E2Eテストのカバレッジを読み込んでいます...");
+    console.log("Loading coverage for E2E tests...");
     const e2eCoverage = JSON.parse(fs.readFileSync(e2eCoverageFile, "utf8"));
     const files = Object.keys(e2eCoverage);
     const jsFiles = files.filter((f) => !f.includes(".css"));
@@ -85,85 +85,85 @@ if (fs.existsSync(e2eCoverageFile)) {
         jsFiles: jsFiles.length,
         cssFiles: cssFiles.length,
     });
-    console.log(`  ✓ ${files.length} ファイルのカバレッジを追加しました`);
-    console.log(`    - JavaScript: ${jsFiles.length} 個`);
-    console.log(`    - CSS: ${cssFiles.length} 個`);
+    console.log(`  ✓ Added coverage for ${files.length} files`);
+    console.log(`    - JavaScript: ${jsFiles.length} files`);
+    console.log(`    - CSS: ${cssFiles.length} files`);
 
-    // E2Eカバレッジの検証: JavaScriptファイルが含まれているか確認
+    // Validate E2E coverage: check if JavaScript files are included
     if (jsFiles.length === 0 && cssFiles.length > 0) {
-        console.error("\n❌ エラー: E2EカバレッジにJavaScriptファイルが含まれていません");
-        console.error("   CSSファイルのみが含まれています。");
-        console.error("   これは E2E カバレッジ生成時に問題が発生した可能性があります。");
-        console.error("\n   以下を確認してください:");
-        console.error("   1. scripts/generate-e2e-coverage.js の entryFilter 設定");
-        console.error("   2. scripts/generate-e2e-coverage.js の sourceFilter 設定");
-        console.error("   3. monocart-coverage-reports のバージョン");
+        console.error("\n❌ Error: E2E coverage does not include JavaScript files");
+        console.error("   It only includes CSS files.");
+        console.error("   This might indicate an issue occurred during E2E coverage generation.");
+        console.error("\n   Please check the following:");
+        console.error("   1. entryFilter setting in scripts/generate-e2e-coverage.js");
+        console.error("   2. sourceFilter setting in scripts/generate-e2e-coverage.js");
+        console.error("   3. monocart-coverage-reports version");
         process.exit(1);
     }
 } else {
-    console.log("  ⚠ E2Eテストのカバレッジが見つかりません");
-    console.log(`     探したパス: ${e2eCoverageFile}`);
+    console.log("  ⚠ Coverage for E2E tests not found");
+    console.log(`     Searched path: ${e2eCoverageFile}`);
 }
 
 if (filesFound === 0) {
-    console.error("\nエラー: カバレッジファイルが見つかりませんでした");
-    console.error("まず、以下のコマンドでテストを実行してください:");
+    console.error("\nError: No coverage files found");
+    console.error("Please run tests first using the following commands:");
     console.error("  npm run test:unit");
     console.error("  npm run test:integration");
     console.error("  COVERAGE=true npm run test:e2e");
     process.exit(1);
 }
 
-// 統合されたカバレッジを保存
-console.log("\n統合されたカバレッジを保存しています...");
+// Save merged coverage
+console.log("\nSaving merged coverage...");
 fs.mkdirSync(mergedReportDir, { recursive: true });
 fs.writeFileSync(mergedCoverageFile, JSON.stringify(coverageMap.toJSON(), null, 2));
-console.log(`  ✓ ${mergedCoverageFile} に保存しました`);
+console.log(`  ✓ Saved to ${mergedCoverageFile}`);
 
-// レポートを生成
-console.log("\nレポートを生成しています...");
+// Generate reports
+console.log("\nGenerating reports...");
 const context = libReport.createContext({
     dir: mergedReportDir,
     coverageMap: coverageMap,
 });
 
-// HTML レポート
-console.log("  - HTML レポート");
+// HTML report
+console.log("  - HTML report");
 const htmlReport = reports.create("html", {});
 htmlReport.execute(context);
 
-// テキスト レポート (コンソール出力)
-console.log("  - テキスト レポート");
+// Text report (console output)
+console.log("  - Text report");
 const textReport = reports.create("text", {});
 textReport.execute(context);
 
-// LCOV レポート (CI/CD用)
-console.log("  - LCOV レポート");
+// LCOV report (for CI/CD)
+console.log("  - LCOV report");
 const lcovReport = reports.create("lcov", {});
 lcovReport.execute(context);
 
-// JSON レポート
-console.log("  - JSON レポート");
+// JSON report
+console.log("  - JSON report");
 const jsonReport = reports.create("json", {});
 jsonReport.execute(context);
 
-console.log("\n✓ カバレッジレポートの統合が完了しました");
-console.log(`\nレポートの場所: ${mergedReportDir}/index.html`);
+console.log("\n✓ Integration of coverage reports is complete");
+console.log(`\nReport location: ${mergedReportDir}/index.html`);
 
-// カバレッジソースのサマリーを表示
+// Display summary of coverage sources
 if (coverageSources.length > 0) {
-    console.log("\nカバレッジソース:");
+    console.log("\nCoverage sources:");
     for (const source of coverageSources) {
         console.log(`  ${source.name}:`);
-        console.log(`    - 総ファイル数: ${source.totalFiles}`);
-        console.log(`    - JavaScript: ${source.jsFiles} 個`);
-        console.log(`    - CSS: ${source.cssFiles} 個`);
+        console.log(`    - Total files: ${source.totalFiles}`);
+        console.log(`    - JavaScript: ${source.jsFiles} files`);
+        console.log(`    - CSS: ${source.cssFiles} files`);
     }
 }
 
-console.log("\nカバレッジサマリー:");
+console.log("\nCoverage summary:");
 
-// サマリーを表示
+// Display summary
 const summary = coverageMap.getCoverageSummary();
 console.log(
     `  Statements   : ${


### PR DESCRIPTION
💡 **What:** Translated `client/scripts/merge-coverage.js` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `pnpm lint` and `pnpm test:unit` in the `client` directory to verify the build and syntax.

---
*PR created automatically by Jules for task [18034096354546363063](https://jules.google.com/task/18034096354546363063) started by @kitamura-tetsuo*