### PR TITLE
🌐 Lingo: Translate generate-e2e-coverage.js to English

### DIFF
--- a/client/scripts/generate-e2e-coverage.js
+++ b/client/scripts/generate-e2e-coverage.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
 /**
- * E2Eテストのカバレッジレポートを生成するスクリプト
+ * Script to generate E2E test coverage report
  *
- * 使用方法:
+ * Usage:
  *   node scripts/generate-e2e-coverage.js
  *
- * 前提条件:
- *   - E2Eテストが COVERAGE=true で実行済みであること
- *   - coverage/e2e/raw/ にカバレッジデータが存在すること
+ * Prerequisites:
+ *   - E2E tests have been executed with COVERAGE=true
+ *   - Coverage data exists in coverage/e2e/raw/
  */
 
 import fs from "fs";
@@ -23,13 +23,13 @@ const workspaceDir = path.resolve(__dirname, "../..");
 const rawCoverageDir = path.join(workspaceDir, "coverage", "e2e", "raw");
 const e2eCoverageDir = path.join(workspaceDir, "coverage", "e2e");
 
-console.log("E2Eカバレッジレポートを生成しています...");
+console.log("Generating E2E coverage report...");
 
-// カバレッジデータが存在するか確認
+// Check if coverage data exists
 if (!fs.existsSync(rawCoverageDir)) {
-    console.error("エラー: カバレッジデータが見つかりません");
-    console.error(`探したパス: ${rawCoverageDir}`);
-    console.error("\nまず、以下のコマンドでE2Eテストを実行してください:");
+    console.error("Error: Coverage data not found");
+    console.error(`Looked in path: ${rawCoverageDir}`);
+    console.error("\nFirst, execute E2E tests with the following command:");
     console.error("  COVERAGE=true npm run test:e2e");
     process.exit(1);
 }
@@ -37,36 +37,36 @@ if (!fs.existsSync(rawCoverageDir)) {
 const coverageFiles = fs.readdirSync(rawCoverageDir).filter((f) => f.endsWith(".json"));
 
 if (coverageFiles.length === 0) {
-    console.error("エラー: カバレッジデータが見つかりません");
-    console.error(`探したパス: ${rawCoverageDir}`);
+    console.error("Error: Coverage data not found");
+    console.error(`Looked in path: ${rawCoverageDir}`);
     process.exit(1);
 }
 
-console.log(`  ✓ ${coverageFiles.length} 個のカバレッジファイルを見つけました`);
+console.log(`  ✓ Found ${coverageFiles.length} coverage files`);
 
-// カバレッジレポート（出力先など）の準備
+// Prepare coverage report (output destination, etc.)
 const coverageReport = new CoverageReport({
     name: "E2E Coverage Report",
     outputDir: e2eCoverageDir,
-    // メモリを抑えるため JSON(Istanbul map) と console-summary のみを出力
+    // Output only JSON(Istanbul map) and console-summary to save memory
     reports: ["json", "console-summary"],
-    // sourceFilter: ソースマップから抽出されたソースファイルをフィルタリング
-    // NOTE: entryFilterは使用しない。V8カバレッジエントリのフィルタリングは
-    //       add()前に手動で行う。これにより、monocart-coverage-reportsの
-    //       内部処理でJavaScriptファイルが除外される問題を回避する。
+    // sourceFilter: Filter source files extracted from source maps
+    // NOTE: entryFilter is not used. V8 coverage entry filtering is
+    //       done manually before add(). This avoids the problem of
+    //       JavaScript files being excluded by monocart-coverage-reports internal processing.
     sourceFilter: (sourcePath) => {
-        // node_modules/を除外
-        // NOTE: sourcePathはファイル名のみの場合とフルパスの場合がある
-        //       ファイル名のみの場合は、全て含める（entryFilterで既にフィルタリング済み）
+        // Exclude node_modules/
+        // NOTE: sourcePath can be just a filename or a full path
+        //       If it's just a filename, include it all (already filtered by entryFilter)
         if (sourcePath.includes("/node_modules/") || sourcePath.includes("node_modules/")) {
             return false;
         }
-        // 全て含める（entryFilterで既にsrc/配下のみに絞り込み済み）
+        // Include everything (already filtered to only src/ by entryFilter)
         return true;
     },
 });
 
-// 大量メモリ消費を避けるため、ファイルごとに逐次 add して解放する
+// To avoid excessive memory consumption, add sequentially for each file and release
 let totalEntries = 0;
 let jsEntries = 0;
 let cssEntries = 0;
@@ -77,29 +77,29 @@ for (const file of coverageFiles) {
     try {
         data = JSON.parse(text);
     } catch (e) {
-        console.warn(`[MCR] JSON のパースに失敗したためスキップします: ${filePath}`);
+        console.warn(`[MCR] Skipping due to JSON parsing failure: ${filePath}`);
         console.warn(`${e}`);
         continue;
     }
 
-    // 期待フォーマット: V8(Array) または Istanbul(Object)。それ以外はスキップ
+    // Expected format: V8(Array) or Istanbul(Object). Skip otherwise
     if (Array.isArray(data)) {
-        // V8カバレッジデータを手動でフィルタリング
-        // NOTE: monocart-coverage-reportsのentryFilterを使用すると、
-        //       JavaScriptファイルが除外される問題があるため、
-        //       add()前に手動でフィルタリングを行う
+        // Manually filter V8 coverage data
+        // NOTE: Using monocart-coverage-reports entryFilter causes
+        //       an issue where JavaScript files are excluded,
+        //       so filtering is done manually before add()
         const filtered = data.filter((entry) => {
             const url = entry?.url || "";
-            // src/配下のファイルのみを対象とする（node_modules/を除外）
-            // 空のURLは除外（匿名スクリプト）
+            // Target only files under src/ (exclude node_modules/)
+            // Exclude empty URLs (anonymous scripts)
             if (!url) return false;
             if (url.includes("/node_modules/")) return false;
-            // src/配下のファイルまたはCSSファイルを含める
+            // Include files under src/ or CSS files
             return url.includes("/src/");
         });
 
         totalEntries += data.length;
-        // JavaScriptとCSSのエントリ数をカウント
+        // Count JavaScript and CSS entries
         for (const entry of filtered) {
             const url = entry?.url || "";
             if (url.includes(".css")) {
@@ -113,22 +113,22 @@ for (const file of coverageFiles) {
             await coverageReport.add(filtered);
         }
     } else if (data && typeof data === "object") {
-        // Istanbul 形式（オブジェクト）の場合はそのまま追加
+        // For Istanbul format (object), add as is
         await coverageReport.add(data);
-        // 件数は不明なので合算しない
+        // The count is unknown, so don't sum it up
     } else {
         console.warn(`[MCR] Skip unsupported coverage format: ${filePath}`);
     }
 }
 
-console.log(`  ✓ ${totalEntries} 個のカバレッジエントリを読み込みました`);
-console.log(`    - JavaScript: ${jsEntries} 個`);
-console.log(`    - CSS: ${cssEntries} 個`);
+console.log(`  ✓ Loaded ${totalEntries} coverage entries`);
+console.log(`    - JavaScript: ${jsEntries}`);
+console.log(`    - CSS: ${cssEntries}`);
 
-// V8カバレッジデータを保持するため、generate()の前に関数実行回数の修正準備を行う
-// 注意: generate()後にrawディレクトリが削除される可能性があるため、
-//       V8カバレッジデータから関数実行回数を抽出しておく
-console.log("\nV8カバレッジから関数実行回数を抽出しています...");
+// To retain V8 coverage data, prepare to fix function execution counts before generate()
+// Note: Since the raw directory may be deleted after generate(),
+//       extract function execution counts from V8 coverage data beforehand
+console.log("\nExtracting function execution counts from V8 coverage...");
 const functionCounts = new Map(); // Map<fileName, Map<functionName, count>>
 
 function normalizeUrl(url) {
@@ -179,68 +179,68 @@ for (const file of coverageFiles) {
     }
 }
 
-console.log(`  ✓ ${functionCounts.size} 個のファイルから関数実行回数を抽出しました`);
+console.log(`  ✓ Extracted function execution counts from ${functionCounts.size} files`);
 
 const istanbulJson = path.join(e2eCoverageDir, "coverage-final.json");
 
 try {
     await coverageReport.generate();
-    console.log("\n✓ E2Eカバレッジレポートの生成が完了しました");
+    console.log("\n✓ E2E coverage report generation completed");
     if (fs.existsSync(istanbulJson)) {
         console.log(`\nIstanbul JSON: ${istanbulJson}`);
 
-        // カバレッジ変換の検証: JavaScriptファイルが含まれているか確認
-        console.log("\nカバレッジ変換の検証を実行しています...");
+        // Coverage conversion verification: check if JavaScript files are included
+        console.log("\nExecuting coverage conversion verification...");
         const coverageData = JSON.parse(fs.readFileSync(istanbulJson, "utf8"));
         const files = Object.keys(coverageData);
         const jsFiles = files.filter((f) => !f.includes(".css"));
         const cssFiles = files.filter((f) => f.includes(".css"));
 
-        console.log(`  - 総ファイル数: ${files.length}`);
-        console.log(`  - JavaScriptファイル: ${jsFiles.length}`);
-        console.log(`  - CSSファイル: ${cssFiles.length}`);
+        console.log(`  - Total files: ${files.length}`);
+        console.log(`  - JavaScript files: ${jsFiles.length}`);
+        console.log(`  - CSS files: ${cssFiles.length}`);
 
-        // JavaScriptエントリが存在したのにJavaScriptファイルが0の場合はエラー
+        // Error if JavaScript entries exist but there are 0 JavaScript files
         if (jsEntries > 0 && jsFiles.length === 0) {
-            console.error("\n❌ エラー: JavaScriptファイルのカバレッジが変換時に失われました");
-            console.error(`   rawカバレッジには ${jsEntries} 個のJavaScriptエントリが存在しましたが、`);
-            console.error("   変換後のカバレッジにはJavaScriptファイルが含まれていません。");
-            console.error("\n   これは monocart-coverage-reports の設定に問題がある可能性があります。");
-            console.error("   entryFilter と sourceFilter の設定を確認してください。");
+            console.error("\n❌ Error: JavaScript file coverage was lost during conversion");
+            console.error(`   Raw coverage had ${jsEntries} JavaScript entries,`);
+            console.error("   but the converted coverage does not contain any JavaScript files.");
+            console.error("\n   There may be an issue with the monocart-coverage-reports configuration.");
+            console.error("   Please check the entryFilter and sourceFilter settings.");
             process.exit(1);
         }
 
-        // 警告: JavaScriptファイルが少ない場合
+        // Warning: If there are too few JavaScript files
         if (jsEntries > 0 && jsFiles.length < jsEntries * 0.1) {
-            console.warn("\n⚠️  警告: JavaScriptファイルの数が予想より少ないです");
-            console.warn(`   rawカバレッジ: ${jsEntries} 個のJavaScriptエントリ`);
-            console.warn(`   変換後: ${jsFiles.length} 個のJavaScriptファイル`);
-            console.warn("   一部のファイルが除外されている可能性があります。");
+            console.warn("\n⚠️  Warning: The number of JavaScript files is less than expected");
+            console.warn(`   Raw coverage: ${jsEntries} JavaScript entries`);
+            console.warn(`   Converted: ${jsFiles.length} JavaScript files`);
+            console.warn("   Some files may have been excluded.");
         }
 
-        console.log("\n✓ カバレッジ変換の検証が完了しました");
+        console.log("\n✓ Coverage conversion verification completed");
     } else {
-        // MCR の json 出力ファイル名が異なる場合に備えて、トップレベルの .json を探索して coverage-final.json として保存
+        // In case MCR's json output filename is different, search for a top-level .json and save it as coverage-final.json
         const candidates = fs
             .readdirSync(e2eCoverageDir)
             .filter((f) => f.endsWith(".json") && f !== "coverage-final.json");
         if (candidates.length > 0) {
             const src = path.join(e2eCoverageDir, candidates[0]);
             fs.copyFileSync(src, istanbulJson);
-            console.warn(`[MCR] 注意: ${candidates[0]} を coverage-final.json にコピーしました`);
+            console.warn(`[MCR] Note: Copied ${candidates[0]} to coverage-final.json`);
             console.log(`\nIstanbul JSON: ${istanbulJson}`);
         } else {
-            console.log(`\n出力先: ${e2eCoverageDir}`);
-            console.warn("[MCR] 注意: coverage-final.json が見つかりません。json 出力名の確認が必要です。");
+            console.log(`\nOutput destination: ${e2eCoverageDir}`);
+            console.warn("[MCR] Note: coverage-final.json not found. Need to check the json output name.");
         }
     }
 } catch (error) {
-    console.error("エラー: カバレッジレポートの生成に失敗しました:", error);
+    console.error("Error: Failed to generate coverage report:", error);
     process.exit(1);
 }
 
-// V8カバレッジからIstanbul形式への変換時に失われた関数実行回数を修正
-console.log("\nV8カバレッジから関数実行回数を修正しています...");
+// Fix function execution counts lost during conversion from V8 coverage to Istanbul format
+console.log("\nFixing function execution counts from V8 coverage...");
 try {
     const istanbulCoverage = JSON.parse(fs.readFileSync(istanbulJson, "utf8"));
     let totalFixed = 0;
@@ -266,20 +266,20 @@ try {
 
                 if (oldCount === 0 && v8Count > 0) {
                     console.log(
-                        `  修正: ${fileName} - ${functionName}: ${oldCount} -> ${v8Count}`,
+                        `  Fixed: ${fileName} - ${functionName}: ${oldCount} -> ${v8Count}`,
                     );
                 }
             }
         }
     }
 
-    console.log(`  ✓ ${totalFunctions} 個の関数のうち ${totalFixed} 個の実行回数を修正しました`);
+    console.log(`  ✓ Fixed execution counts for ${totalFixed} out of ${totalFunctions} functions`);
 
-    // 修正したカバレッジデータを保存
+    // Save the modified coverage data
     fs.writeFileSync(istanbulJson, JSON.stringify(istanbulCoverage, null, 2));
-    console.log(`  ✓ ${istanbulJson} に保存しました`);
-    console.log("\n✓ 関数実行回数の修正が完了しました");
+    console.log(`  ✓ Saved to ${istanbulJson}`);
+    console.log("\n✓ Function execution count fix completed");
 } catch (error) {
-    console.error("⚠ 関数実行回数の修正に失敗しました:", error.message);
-    console.error("  カバレッジデータは生成されていますが、一部の関数実行回数が不正確な可能性があります");
+    console.error("⚠ Failed to fix function execution counts:", error.message);
+    console.error("  Coverage data was generated, but some function execution counts may be inaccurate");
 }


### PR DESCRIPTION
💡 **What:** Translated the Japanese comments and console logs in `client/scripts/generate-e2e-coverage.js` to clear and natural technical English.
🎯 **Why:** Improving codebase global accessibility and consistency.
🛠 **Verification:** 
- Verified that no Japanese text remains via regex check.
- Ran `npm run lint --prefix client` to ensure syntax is correct.
- Executed the script via `node client/scripts/generate-e2e-coverage.js` to ensure successful completion.

---
*PR created automatically by Jules for task [15651758677840992782](https://jules.google.com/task/15651758677840992782) started by @kitamura-tetsuo*