### PR TITLE
🌐 Lingo: Translate client/scripts/move-register-import-to-top.sh to English

### DIFF
--- a/client/scripts/move-register-import-to-top.sh
+++ b/client/scripts/move-register-import-to-top.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 
-# 全てのe2eテストファイルで registerAfterEachSnapshot のインポートを先頭に移動するスクリプト
+# Script to move the import of registerAfterEachSnapshot to the top in all e2e test files
 
 set -e
 
 cd "$(dirname "$0")/.."
 
-# e2eディレクトリ内の全ての.spec.tsファイルを検索
+# Find all .spec.ts files in the e2e directory
 find e2e -name "*.spec.ts" | while read -r file; do
-    # registerAfterEachSnapshot のインポートが含まれているか確認
+    # Check if the import of registerAfterEachSnapshot is included
     if grep -q "registerAfterEachSnapshot" "$file"; then
         echo "Processing: $file"
         
-        # 一時ファイルを作成
+        # Create a temporary file
         temp_file=$(mktemp)
         
-        # registerAfterEachSnapshot のインポート行を抽出
+        # Extract the import line of registerAfterEachSnapshot
         import_line=$(grep "registerAfterEachSnapshot" "$file" | head -1)
         
-        # registerAfterEachSnapshot のインポート行を削除
+        # Remove the import line of registerAfterEachSnapshot
         grep -v "registerAfterEachSnapshot" "$file" > "$temp_file"
         
-        # 新しいファイルを作成: インポート行を先頭に追加
+        # Create a new file: Add the import line to the top
         {
             echo "$import_line"
             cat "$temp_file"


### PR DESCRIPTION
💡 **What:** Translated the inline comments in `client/scripts/move-register-import-to-top.sh` from Japanese to English.
🎯 **Why:** Improving codebase accessibility, readability, and consistency for global developers.
🛠 **Verification:** 
- `npm run lint` completed successfully with no new errors.
- Verified that no Japanese characters remain in the file via regex check.
- `npm run build` completed successfully.

---
*PR created automatically by Jules for task [6771402250206682961](https://jules.google.com/task/6771402250206682961) started by @kitamura-tetsuo*