### PR TITLE
Fix page list "No content" display bug

### DIFF
--- a/client/src/components/PageListItem.svelte
+++ b/client/src/components/PageListItem.svelte
@@ -51,7 +51,7 @@ function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDepth: numb
              console.warn("Failed to extract text", e);
         }
 
-        if (text && lines.length < maxLines && item !== pageItem) {
+        if (text && lines.length < maxLines && item.id !== pageItem.id) {
             lines.push(text);
         }
 
@@ -60,10 +60,12 @@ function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDepth: numb
         try {
             if (item.items) {
                 let i = 0;
-                const children = Array.from(item.items);
-                for (const child of children) {
+                const children = item.items;
+                const len = children.length;
+                for (let k = 0; k < len; k++) {
                     if (i++ > 10) break;
-                    traverse(child, currentDepth + 1);
+                    const child = children.at(k);
+                    if (child) traverse(child, currentDepth + 1);
                     if (lines.length >= maxLines && image) return;
                     if (nodeCount >= maxNodes) return;
                 }
@@ -76,10 +78,12 @@ function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDepth: numb
     try {
         if (pageItem.items) {
             let i = 0;
-            const rootChildren = Array.from(pageItem.items);
-            for (const child of rootChildren) {
+            const rootChildren = pageItem.items;
+            const len = rootChildren.length;
+            for (let k = 0; k < len; k++) {
                 if (i++ > 20) break;
-                traverse(child, 1);
+                const child = rootChildren.at(k);
+                if (child) traverse(child, 1);
                 if (lines.length >= maxLines && image) break;
             }
         }


### PR DESCRIPTION
This PR fixes an issue where the project dashboard page list would incorrectly show "No content" beneath pages that actually had text content.

### Issue
Svelte 5 reactivity logic `$state` implicitly proxies state trees and props. Specifically, the nested `page.items` getter dynamically generates custom proxy iterables (`Items` class mapped via `wrapArrayLike`). Svelte 5 intercepts these proxies and fails gracefully when `Array.from()` invokes standard Javascript Object iterating behaviors like `ownKeys`, leading to an empty array resolution during child traversal in `extractPagePreview`.

Additionally, comparing `item !== pageItem` directly was an incorrect equality comparison given `YTree` instances wrap IDs on the fly instead of retaining stable references. 

### Fix
- Safely extract children during preview compilation using a `for` loop with `item.items.length` and `item.items.at()`, entirely avoiding iterator shadowing behaviors by Playwright/Svelte.
- Fixed equality checks to explicitly map IDs (`item.id !== pageItem.id`), properly excluding the page's own title from bleeding into the page's preview subset.

---
*PR created automatically by Jules for task [45229279599796322](https://jules.google.com/task/45229279599796322) started by @kitamura-tetsuo*