### PR TITLE
🌐 Lingo: Translate client/.env.test to English

### DIFF
--- a/client/.env.test
+++ b/client/.env.test
@@ -1,17 +1,17 @@
 
 # .env.test
-# テスト環境設定
+# Test environment configuration
 
-# 環境設定
+# Environment configuration
 VITE_IS_TEST=true
 VITE_IS_TEST_MODE_FORCE_E2E=true
 
-# サーバー設定
+# Server configuration
 VITE_HOST=127.0.0.1
 VITE_PORT=7090
 TEST_PORT=7090
 
-# Firebase設定（テスト用）
+# Firebase configuration (for testing)
 # Note: API key format must be valid even for emulator mode in newer Firebase SDK versions
 VITE_FIREBASE_API_KEY=AIzaSyCMPfoobar1234567890abcdefghij
 VITE_FIREBASE_AUTH_DOMAIN=outliner-d57b0.firebaseapp.com
@@ -21,28 +21,28 @@ VITE_FIREBASE_MESSAGING_SENDER_ID=000000000000
 VITE_FIREBASE_APP_ID=1:000000000000:web:0000000000000000000000
 VITE_FIREBASE_MEASUREMENT_ID=G-TEST123456
 
-# Azure Fluid Relay設定
-# テスト環境では主にTinyliciousを使用
+# Azure Fluid Relay configuration
+# Uses Tinylicious mainly in the test environment
 
-# 接続サービスの選択
+# Connection service selection
 VITE_USE_TINYLICIOUS=true
 VITE_FORCE_AZURE=false
 
-# 認証設定
+# Authentication configuration
 VITE_USE_FIREBASE_AUTH=true
 VITE_USE_API_AUTH=true
 
-# API設定
+# API configuration
 VITE_API_SERVER_URL=http://127.0.0.1:7091
 VITE_FIREBASE_FUNCTIONS_URL=http://127.0.0.1:57070
 VITE_TOKEN_VERIFY_URL=http://127.0.0.1:7091/verify
 
-# Tinylicious設定
+# Tinylicious configuration
 VITE_TINYLICIOUS_HOST=127.0.0.1
 VITE_TINYLICIOUS_PORT=7092
 VITE_TINYLICIOUS_ENDPOINT=http://127.0.0.1:7092
 
-# Firebase Emulator設定
+# Firebase Emulator configuration
 VITE_USE_FIREBASE_EMULATOR=true
 VITE_FIREBASE_EMULATOR_HOST=127.0.0.1
 VITE_FIRESTORE_EMULATOR_PORT=58080
@@ -50,12 +50,12 @@ VITE_AUTH_EMULATOR_PORT=59099
 VITE_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:59099
 VITE_FIREBASE_EMULATOR_UI_PORT=54000
 
-# テスト用ユーザー設定
+# Test user configuration
 VITE_DEBUG_USER_ID=test-user-id
 VITE_DEBUG_USER_NAME="Test User"
 VITE_DEBUG_USER_EMAIL=test@example.com
 
-# Fluid Framework Telemetry設定
+# Fluid Framework Telemetry configuration
 VITE_DISABLE_FLUID_TELEMETRY=true
 
 # Yjs WebSocket server


### PR DESCRIPTION
💡 **What:** Translated Japanese comments in `client/.env.test` to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `npm run lint --prefix client`, `npm run build --prefix client`, and `npm run test:unit --prefix client` to verify no logic was impacted and the code remains valid. Checked that the changes are correctly reflected using `git diff`.

---
*PR created automatically by Jules for task [4561902800785445959](https://jules.google.com/task/4561902800785445959) started by @kitamura-tetsuo*