### PR TITLE
🌐 Lingo: Translate scripts/package.json to English

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -2,7 +2,7 @@
     "name": "scripts",
     "version": "1.0.0",
     "type": "module",
-    "description": "VSCodeのlaunch.jsonで定義されているLocalhost設定をbashで実行するためのスクリプト集です。",
+    "description": "A collection of scripts for executing the Localhost configuration defined in VSCode's launch.json via bash.",
     "main": "backup-production-data.cjs",
     "directories": {
         "test": "tests"


### PR DESCRIPTION
💡 **What:** Translated the `description` field in `scripts/package.json` from Japanese to English.
🎯 **Why:** Improving codebase accessibility and consistency.
🛠 **Verification:** Ran `npm run test --prefix scripts` and `npx dprint fmt scripts/package.json` to verify no syntax errors were introduced.

---
*PR created automatically by Jules for task [2127568599957878288](https://jules.google.com/task/2127568599957878288) started by @kitamura-tetsuo*