### PR TITLE
feat: add docs link to sidebar

### DIFF
--- a/client/src/components/Sidebar.svelte
+++ b/client/src/components/Sidebar.svelte
@@ -187,6 +187,31 @@
             </a>
             <a
                 class="settings-link"
+                href="https://kitamura-tetsuo.github.io/outliner/"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                <span class="item-content-wrapper">
+                    <svg
+                        aria-hidden="true"
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="item-icon"
+                    >
+                        <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+                        <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+                    </svg>
+                    <span class="settings-text">Docs</span>
+                </span>
+            </a>
+            <a
+                class="settings-link"
                 href="https://github.com/kitamura-tetsuo/outliner"
                 target="_blank"
                 rel="noopener noreferrer"


### PR DESCRIPTION
Added a "Docs" link to the settings section of the application sidebar, which opens `https://kitamura-tetsuo.github.io/outliner/` in a new tab.

Verified visually with Playwright:
* The link appears correctly formatted above the GitHub link.
* The link contains the correct `href`, `target`, and `rel` attributes.

---
*PR created automatically by Jules for task [3763649270873113533](https://jules.google.com/task/3763649270873113533) started by @kitamura-tetsuo*