### PR TITLE
🌐 Lingo: Translate .vscode/launch.json to English

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,8 +25,8 @@
             ],
             "port": 9222,
             "justMyCode": false,
-            "console": "internalConsole", // ← Debug Console に出す
-            "trace": true // どこで拾えない時の調査用
+            "console": "internalConsole", // ← Output to Debug Console
+            "trace": true // For investigation when breakpoints are not hit
         },
         {
             "type": "chrome",
@@ -53,8 +53,8 @@
             ],
             "port": 9876,
             "justMyCode": false,
-            "console": "internalConsole", // ← Debug Console に出す
-            "trace": true // どこで拾えない時の調査用
+            "console": "internalConsole", // ← Output to Debug Console
+            "trace": true // For investigation when breakpoints are not hit
         },
         {
             "type": "chrome",
@@ -81,8 +81,8 @@
             ],
             "port": 9876,
             "justMyCode": false,
-            "console": "internalConsole", // ← Debug Console に出す
-            "trace": true // どこで拾えない時の調査用
+            "console": "internalConsole", // ← Output to Debug Console
+            "trace": true // For investigation when breakpoints are not hit
         },
         {
             "type": "chrome",


### PR DESCRIPTION
💡 **What:** Translated debug comments from Japanese to English in `.vscode/launch.json`.
🎯 **Why:** Improving codebase accessibility and consistency for non-Japanese speaking developers.
🛠 **Verification:** Ran `cd client && pnpm lint` and `cd client && pnpm test`. Checked test results and ensure syntax consistency. Reverted auto-generated lockfiles.

---
*PR created automatically by Jules for task [8701390445066871182](https://jules.google.com/task/8701390445066871182) started by @kitamura-tetsuo*