### PR TITLE
🌐 Lingo: Translate AGENTS.md to English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Mocks are generally forbidden. Limited exceptions:
 - The cloud environment is prone to timeouts. Keep each Playwright spec short and split larger flows across multiple files. Document any timeouts; tests will be rerun elsewhere.
 - Use `TestHelpers.prepareTestEnvironment(page)` in `test.beforeEach` and Playwright's `expect(locator).toBeVisible()` assertions.
 - **Test Data Creation**: For display/rendering tests, create test data using `TestHelpers.prepareTestEnvironment(page, test.info(), lines)` where `lines` is an array of strings representing item text. This ensures proper Yjs synchronization and avoids keyboard input issues with special characters like `[/` that may trigger command palettes or shortcuts.
-  - Example: `await TestHelpers.prepareTestEnvironment(page, test.info(), ["これは[[太字と[/斜体]の組み合わせ]]です"]);`
+  - Example: `await TestHelpers.prepareTestEnvironment(page, test.info(), ["This is a combination of [[bold and [/italic]]]"]);`
   - Do NOT manually type text with `page.keyboard.type()` for display tests, as it may conflict with keyboard shortcuts.
 - Create projects and pages programmatically via `fluidClient` rather than via the UI.
 - Simulate user input with `page.keyboard.type()` and manage cursors with `editorStore.setCursor()` and `cursor.insertText()` followed by a 500 ms wait and `waitForCursorVisible()`.


### PR DESCRIPTION
💡 What: Translated the Japanese example string in the "Test Data Creation" section of AGENTS.md to English.
🎯 Why: Improving codebase accessibility and consistency.
🛠 Verification: Ran `cd client && pnpm lint` and `cd client && pnpm test`.

---
*PR created automatically by Jules for task [12862799076245997721](https://jules.google.com/task/12862799076245997721) started by @kitamura-tetsuo*