### PR TITLE
🌐 Lingo: Translate GlobalTextArea_fixed.svelte to English

### DIFF
--- a/GlobalTextArea_fixed.svelte
+++ b/GlobalTextArea_fixed.svelte
@@ -19,11 +19,11 @@ let measureCtx: CanvasRenderingContext2D | null = null;
 // update-depth loops during E2E when alias picker and focus logic interact.
 // Focus management is handled in onMount and OutlinerItem.startEditing().
 
-// global textarea をストアに登録
+// Register global textarea to the store
 onMount(() => {
     // Initialize measurement canvas on client only
-    // Node.jsテスト環境ではCanvas APIがサポートされていない可能性があるため、
-    // 存在チェックをしてから初期化する
+    // Since Canvas API might not be supported in Node.js test environment,
+    // check for existence before initializing
     if (typeof document !== 'undefined' && typeof HTMLCanvasElement !== 'undefined') {
         try {
             measureCanvas = document.createElement("canvas");


### PR DESCRIPTION
💡 **What:** Translated selected Japanese comments in `GlobalTextArea_fixed.svelte` from Japanese to English.

🎯 **Why:** Improving codebase accessibility and consistency.

🛠 **Verification:**
- Ran `pnpm lint` and `pnpm test` in the `client` directory to ensure no logic regressions were introduced.
- Reverted unintentional lockfile modifications.

---
*PR created automatically by Jules for task [17534737103811897358](https://jules.google.com/task/17534737103811897358) started by @kitamura-tetsuo*