### PR TITLE
🌐 Lingo: Translate GlobalTextArea_original.svelte to English

### DIFF
--- a/GlobalTextArea_original.svelte
+++ b/GlobalTextArea_original.svelte
@@ -19,21 +19,21 @@ let measureCtx: CanvasRenderingContext2D | null = null;
 // update-depth loops during E2E when alias picker and focus logic interact.
 // Focus management is handled in onMount and OutlinerItem.startEditing().
 
-// global textarea をストアに登録
+// Register global textarea to store
 onMount(() => {
     // Initialize measurement canvas on client only
-    // Node.jsテスト環境ではCanvas APIがサポートされていない可能性があるため、
-    // 存在チェックをしてから初期化する
+    // Canvas API might not be supported in Node.js test environments,
+    // so initialize after checking for existence
     if (typeof document !== 'undefined' && typeof HTMLCanvasElement !== 'undefined') {
         try {
             measureCanvas = document.createElement("canvas");
-            // テスト環境ではgetContextが実装されていない場合があるため、try-catchで対応
+            // getContext might not be implemented in test environments, handle with try-catch
             measureCtx = measureCanvas.getContext("2d");
             if (!measureCtx) {
                 console.warn('GlobalTextArea: Canvas 2D context not available, text measurement may be affected');
             }
         } catch (error) {
-            // テスト環境や特定のブラウザではCanvas APIが利用できない場合がある
+            // Canvas API might not be available in test environments or specific browsers
             console.warn('GlobalTextArea: Canvas API not available, text measurement may be affected:', error);
             measureCtx = null;
         }
@@ -42,21 +42,21 @@ onMount(() => {
     }
 
     store.setTextareaRef(textareaRef);
-    // generalStore にも参照を保持（コマンドパレットのフォールバックで利用）
+    // Keep reference in generalStore as well (used for command palette fallback)
     try { (generalStore as any).textareaRef = textareaRef; } catch {}
     console.log("GlobalTextArea: Textarea reference set in store");
 
-    // KeyEventHandler をグローバルに公開（テスト用）
+    // Expose KeyEventHandler globally (for tests)
     if (typeof window !== "undefined") {
         (window as any).KeyEventHandler = KeyEventHandler;
     }
 
-    // 初期フォーカスを設定
+    // Set initial focus
     if (textareaRef) {
         textareaRef.focus();
         console.log("GlobalTextArea: Initial focus set on mount, activeElement:", document.activeElement?.tagName);
 
-        // フォーカス確保のための追加試行
+        // Additional attempts to ensure focus
         requestAnimationFrame(() => {
             if (textareaRef) {
                 textareaRef.focus();
@@ -73,14 +73,14 @@ onMount(() => {
         });
     }
 
-    // テスト用にKeyEventHandlerをグローバルに公開
+    // Expose KeyEventHandler globally for tests
     if (typeof window !== "undefined") {
         (window as any).__KEY_EVENT_HANDLER__ = KeyEventHandler;
         (window as any).Items = Items;
         (window as any).generalStore = generalStore;
     }
 
-    // エイリアスピッカー可視時のキーを常にピッカーへフォワード（フォーカスに依存しない）
+    // Always forward keys to alias picker when visible (independent of focus)
     try {
         const forward = (ev: KeyboardEvent) => {
             if (!aliasPickerStore.isVisible) return;
@@ -88,7 +88,7 @@ onMount(() => {
             if (k !== "ArrowDown" && k !== "ArrowUp" && k !== "Enter" && k !== "Escape") return;
             const picker = document.querySelector(".alias-picker") as HTMLElement | null;
             if (!picker) return;
-            // すでにエイリアスピッカー配下で発生したイベントは二重転送しない
+            // Prevent double-forwarding events already originating under alias picker
             const t = ev.target as Node | null;
             if (t && picker.contains(t)) return;
             try { console.log("GlobalTextArea: forward key to alias-picker:", k); } catch {}
@@ -97,15 +97,15 @@ onMount(() => {
             ev.preventDefault();
         };
         window.addEventListener("keydown", forward, { capture: true });
-        // onDestroyで解除
+        // Remove on onDestroy
         (window as any).__ALIAS_FWD__ = forward;
     } catch {}
 
-    // フォールバック: スラッシュ押下で常にパレットを表示（内部リンク直後はKeyEventHandler側で抑止）
+    // Fallback: Always show palette on slash key (suppressed on KeyEventHandler side immediately after internal link)
     try {
         const slashListener = (ev: KeyboardEvent) => {
             if (ev.key !== "/") return;
-            // 既に表示中なら何もしない
+            // Do nothing if already visible
             if ((window as any).commandPaletteStore?.isVisible) return;
             try {
                 const pos = commandPaletteStore.getCursorScreenPosition();
@@ -116,7 +116,7 @@ onMount(() => {
         (window as any).__SLASH_FWD__ = slashListener;
     } catch {}
 
-    // 直近のキー入力を常に記録（/ch のような連続入力を検出するため）
+    // Always record recent key inputs (to detect sequences like /ch)
     try {
         const recordKeys = (ev: KeyboardEvent) => {
             if (ev.ctrlKey || ev.metaKey || ev.altKey) return;
@@ -132,50 +132,50 @@ onMount(() => {
         window.addEventListener("keydown", recordKeys, { capture: true });
         (window as any).__KEYSTREAM_FWD__ = recordKeys;
     } catch {}
-    // フォールバック: テキストエリアにフォーカスがない場合でも入力を反映
+    // Fallback: Reflect input even when textarea lacks focus
     try {
         const typingFallback = (ev: KeyboardEvent) => {
             try { console.log("typingFallback fired:", ev.key, "active=", !!store.getActiveItem()); } catch {}
-            // IME 合成中や修飾キー付きは無視（ただし Alt+Shift+Arrow は矩形選択のため許可）
+            // Ignore IME composition or modifier keys (except Alt+Shift+Arrow which is allowed for box selection)
             const isBoxSelectionKey = ev.altKey && ev.shiftKey &&
                 (ev.key === "ArrowUp" || ev.key === "ArrowDown" || ev.key === "ArrowLeft" || ev.key === "ArrowRight");
             if (ev.isComposing || (!isBoxSelectionKey && (ev.ctrlKey || ev.metaKey || ev.altKey))) return;
-            // エイリアスピッカー/コマンドパレット表示中は既存のフォワーダーに任せる
+            // Delegate to existing forwarder while alias picker/command palette is visible
             if (aliasPickerStore.isVisible || (window as any).commandPaletteStore?.isVisible) return;
 
             const activeId = store.getActiveItem();
             const ta = textareaRef;
-            // 既にtextareaがフォーカスされているなら通常の処理に任せる
+            // Let normal processing handle it if textarea is already focused
             if (document.activeElement === ta) return;
             if (!activeId) return;
 
-            // 単一文字の入力
+            // Single character input
             const k = ev.key;
             if (k.length === 1) {
                 const cursors = store.getCursorInstances();
                 try { console.log("typingFallback chars:", k, "cursors=", cursors.length); } catch {}
                 if (cursors.length > 0 && ta) {
                     ev.preventDefault();
-                    // まず直接モデルを更新（信頼性重視）
+                    // First directly update the model (priority on reliability)
                     try { cursors.forEach(c => c.insertText(k)); } catch {}
 
-                    // 併せてテキストエリアに実入力として反映し、InputEventを発火（通常フロー維持）
+                    // Also reflect as actual input in textarea and dispatch InputEvent (maintain normal flow)
                     const prev = ta.value ?? "";
                     const selStart = typeof ta.selectionStart === "number" ? ta.selectionStart : prev.length;
                     const selEnd = typeof ta.selectionEnd === "number" ? ta.selectionEnd : selStart;
                     ta.value = prev.slice(0, selStart) + k + prev.slice(selEnd);
-                    // キャレットを1文字進める
+                    // Advance caret by 1 character
                     try { ta.selectionStart = ta.selectionEnd = selStart + 1; } catch {}
                     const ie = new InputEvent("input", { data: k, inputType: "insertText", bubbles: true, cancelable: true, composed: true });
                     ta.dispatchEvent(ie);
-                    // フォーカス外でも確実にモデル更新させる
+                    // Ensure model is updated even out of focus
                     try { KeyEventHandler.handleInput(ie as unknown as Event); } catch {}
                     store.startCursorBlink();
                 }
                 return;
             }
 
-            // Enter / Backspace / Delete の簡易フォールバック
+            // Simple fallback for Enter / Backspace / Delete
             const cursors = store.getCursorInstances();
             if (cursors.length === 0) return;
             if (k === "Enter") {
@@ -199,14 +199,14 @@ onMount(() => {
     } catch {}
 
 
-    // フォールバック: パレット表示中はグローバルkeydownから直接文字入力/移動/確定を転送
+    // Fallback: Forward character input/movement/confirmation directly from global keydown while palette is visible
     try {
         const paletteTypeForwarder = (ev: KeyboardEvent) => {
             const cps: any = (window as any).commandPaletteStore ?? commandPaletteStore;
             if (!cps?.isVisible) return;
             const k = ev.key;
             if (!ev.ctrlKey && !ev.metaKey && !ev.altKey && k.length === 1 && k !== "/") {
-                // 軽量入力でUIだけを即時更新（モデルは変更しない）
+                // Immediately update UI with lightweight input (do not change model)
                 cps.inputLight(k);
                 ev.preventDefault();
                 return;
@@ -214,14 +214,14 @@ onMount(() => {
             if (k === "Backspace") { cps.backspaceLight(); ev.preventDefault(); return; }
             if (k === "Enter") {
                 try {
-                    // フィルタ結果が単一で Alias の場合は直接 insert してから閉じる（確実にピッカーを出す）
+                    // If filter result is a single Alias, insert directly then close (ensure picker is shown)
                     const list = cps.filtered ?? [];
                     const sel = list?.[cps.selectedIndex ?? 0];
                     const q = String(cps.query || (cps.deriveQueryFromDoc?.() || "")).toLowerCase();
                     const isAliasOnly = Array.isArray(list) && list.length === 1 && (list[0]?.type === "alias");
                     const looksAlias = q === "alias" || /^(?:al|ali|alia|alias)$/.test(q);
 
-                    // 直接 textarea の値からも厳密に検出
+                    // Also rigorously detect directly from textarea value
                     let textSaysAlias = false;
                     try {
                         const ta: HTMLTextAreaElement | null | undefined = (window as any).generalStore?.textareaRef;
@@ -238,7 +238,7 @@ onMount(() => {
                         ev.preventDefault();
                         return;
                     }
-                    // それ以外は通常の確定
+                    // Otherwise normal confirmation
                     if (sel) {
                         try { console.log("GlobalTextArea: palette Enter confirming sel=", sel?.type); } catch {}
                         cps.confirm();
@@ -246,7 +246,7 @@ onMount(() => {
                         return;
                     }
                 } catch {}
-                // フォールバック
+                // Fallback
                 cps.confirm();
                 ev.preventDefault();
                 return;
@@ -258,16 +258,16 @@ onMount(() => {
         (window as any).__PALETTE_FWD__ = paletteTypeForwarder;
     } catch {}
 
-    // グローバル: フォーカス位置に関わらず KeyEventHandler を呼ぶバックアップ
+    // Global: Backup to call KeyEventHandler regardless of focus position
     try {
         const globalKeyForwarder = (ev: KeyboardEvent) => {
-            // 既に他で処理済みは尊重
+            // Respect if already processed elsewhere
             if (ev.defaultPrevented) return;
-            // IME/修飾キーは無視（ただし Alt+Shift+Arrow は矩形選択のため許可）
+            // Ignore IME/modifier keys (except Alt+Shift+Arrow which is allowed for box selection)
             const isBoxSelectionKey = ev.altKey && ev.shiftKey &&
                 (ev.key === "ArrowUp" || ev.key === "ArrowDown" || ev.key === "ArrowLeft" || ev.key === "ArrowRight");
             if (ev.isComposing || (!isBoxSelectionKey && (ev.ctrlKey || ev.metaKey || ev.altKey))) return;
-            // 常に KeyEventHandler へ委譲（内部で必要時のみ処理される）
+            // Always delegate to KeyEventHandler (processed internally only when necessary)
             KeyEventHandler.handleKeyDown(ev);
         };
         window.addEventListener("keydown", globalKeyForwarder);
@@ -290,9 +290,9 @@ onDestroy(() => {
 
 function updateCompositionWidth(text: string) {
     if (!textareaRef || !measureCtx) {
-        // フォールバック：measureCtxが利用できない場合は固定幅を設定
+        // Fallback: Set fixed width if measureCtx is unavailable
         if (textareaRef) {
-            textareaRef.style.width = `${(text.length * 10) + 4}px`; // テキスト長に応じた適当な幅
+            textareaRef.style.width = `${(text.length * 10) + 4}px`; // Appropriate width based on text length
         }
         return;
     }
@@ -311,7 +311,7 @@ function handleCompositionStart(event: CompositionEvent) {
     KeyEventHandler.handleCompositionStart(event);
 }
 
-// キーダウンイベントを KeyEventHandler へ委譲
+// Delegate keydown event to KeyEventHandler
 function handleKeyDown(event: KeyboardEvent) {
     console.log("GlobalTextArea.handleKeyDown called with key:", event.key);
     console.log("GlobalTextArea.handleKeyDown: event.target:", event.target);
@@ -338,7 +338,7 @@ function handleKeyDown(event: KeyboardEvent) {
     } catch {}
 }
 
-// 入力イベントを KeyEventHandler へ委譲
+// Delegate input event to KeyEventHandler
 function handleInput(event: Event) {
     console.log("GlobalTextArea.handleInput called with event:", event);
     console.log("GlobalTextArea.handleInput: event.target:", event.target);
@@ -349,7 +349,7 @@ function handleInput(event: Event) {
     KeyEventHandler.handleInput(event);
 }
 
-// CompositionEnd イベントを KeyEventHandler へ委譲
+// Delegate CompositionEnd event to KeyEventHandler
 function handleCompositionEnd(event: CompositionEvent) {
     KeyEventHandler.handleCompositionEnd(event);
     isComposing = false;
@@ -359,46 +359,46 @@ function handleCompositionEnd(event: CompositionEvent) {
     textareaRef.style.width = "1px";
 }
 
-// CompositionUpdate イベントを KeyEventHandler へ委譲
+// Delegate CompositionUpdate event to KeyEventHandler
 function handleCompositionUpdate(event: CompositionEvent) {
     updateCompositionWidth(event.data || "");
     KeyEventHandler.handleCompositionUpdate(event);
 }
 
-// コピーイベントを KeyEventHandler へ委譲
+// Delegate copy event to KeyEventHandler
 function handleCopy(event: ClipboardEvent) {
     KeyEventHandler.handleCopy(event);
 }
 
-// カットイベントを KeyEventHandler へ委譲
+// Delegate cut event to KeyEventHandler
 function handleCut(event: ClipboardEvent) {
     KeyEventHandler.handleCut(event);
 }
 
 /**
- * ペーストイベントを KeyEventHandler に委譲する非同期ハンドラ。
- * `KeyEventHandler.handlePaste` は Promise を返すため `await` して
- * 権限拒否や読み取り失敗を捕捉し、`clipboard-permission-denied`
- * または `clipboard-read-error` を dispatch してユーザーにはペーストされない。
+ * Async handler to delegate paste event to KeyEventHandler.
+ * Since `KeyEventHandler.handlePaste` returns a Promise, we `await` it
+ * to catch permission denials or read failures, dispatching `clipboard-permission-denied`
+ * or `clipboard-read-error` without pasting for the user.
  */
 async function handlePaste(event: ClipboardEvent) {
     await KeyEventHandler.handlePaste(event);
 }
 
-// フォーカス喪失時の処理を追加
+// Add processing for focus loss
 function handleBlur(_event: FocusEvent) { // eslint-disable-line @typescript-eslint/no-unused-vars
     const activeItemId = store.getActiveItem();
-    // エイリアスピッカー表示中はフォーカス復元しない
+    // Do not restore focus while alias picker is visible
     if (aliasPickerStore.isVisible) {
         return;
     }
     if (activeItemId) {
-        // フォーカスを確実に設定するための複数の試行
+        // Multiple attempts to ensure focus is set
         setTimeout(() => {
             if (textareaRef && !aliasPickerStore.isVisible) {
                 textareaRef.focus();
 
-                // デバッグ情報
+                // Debug info
                 if (typeof window !== "undefined" && (window as any).DEBUG_MODE) {
                     console.log(
                         `GlobalTextArea: focus restored after blur. Active element is textarea: ${


### PR DESCRIPTION
💡 What: Translated Japanese comments in `GlobalTextArea_original.svelte` to technical English.
🎯 Why: Improving codebase accessibility and consistency.
🛠 Verification: Ran `cd client && pnpm lint` and `cd client && pnpm test` to ensure the build stays green.

---
*PR created automatically by Jules for task [12288373744287153199](https://jules.google.com/task/12288373744287153199) started by @kitamura-tetsuo*