### PR TITLE
🌐 Lingo: Translate .vscode/mcp.json to English

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -3,7 +3,7 @@
         {
             "type": "promptString",
             "id": "example-key",
-            "description": "必要に応じて入力する値（ここでは例として）",
+            "description": "Value to input as needed (as an example here)",
             "password": false
         }
     ],


### PR DESCRIPTION
💡 What: Translated the description field from Japanese to English in `.vscode/mcp.json`.
🎯 Why: Improving codebase accessibility and consistency for non-Japanese speakers.
🛠 Verification: Verified the JSON structure remains valid.

---
*PR created automatically by Jules for task [16186573498275390389](https://jules.google.com/task/16186573498275390389) started by @kitamura-tetsuo*