### PR TITLE
🌐 Lingo: Translate .gitignore to English

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ vite.config.ts.timestamp-*
 # Paraglide
 src/lib/paraglide
 
-# Tinylicious のデータファイル
+# Tinylicious data files
 tinylicious
 
 playwright-report


### PR DESCRIPTION
💡 What:
Translated a Japanese comment in the `.gitignore` file `# Tinylicious のデータファイル` to English `# Tinylicious data files`.

🎯 Why:
Improving codebase global accessibility and consistency by converting Japanese comments into standard technical English.

🛠 Verification:
Ran `cd client && pnpm lint` and `cd client && pnpm test` to ensure no syntax errors or regressions were introduced by this change.

---
*PR created automatically by Jules for task [5767866246294481510](https://jules.google.com/task/5767866246294481510) started by @kitamura-tetsuo*