### PR TITLE
🌐 Lingo: Translate .devcontainer/Dockerfile.override to English

### DIFF
--- a/.devcontainer/Dockerfile.override
+++ b/.devcontainer/Dockerfile.override
@@ -43,7 +43,7 @@ RUN git config --global pull.ff only
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
-RUN pipx ensurepath   # 必要に応じてシェルを再起動/再ログイン
+RUN pipx ensurepath   # Restart shell/re-login if necessary
 # RUN pipx install git+https://github.com/kitamura-tetsuo/auto-coder.git
 
 RUN pipx install git+https://github.com/kitamura-tetsuo/github-sub-issue.git


### PR DESCRIPTION
💡 What:
Translated a Japanese comment in `.devcontainer/Dockerfile.override` to English.

🎯 Why:
Improving codebase global accessibility and consistency by converting non-critical Japanese comments into clear, technical English without modifying logic.

🛠 Verification:
- Checked `git status` to ensure only the target file was staged.
- Verified the string replacement using `sed`.
- Ignored testing for Dockerfile.

---
*PR created automatically by Jules for task [1532901746868103113](https://jules.google.com/task/1532901746868103113) started by @kitamura-tetsuo*