### PR TITLE
fix(functions): prevent crash on project title update when title map is missing

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -388,7 +388,8 @@ exports.saveProject = onRequest(
             }
 
             // Ensure projectTitles is treated as an object and merged properly
-            const projectTitles = userData.projectTitles && typeof userData.projectTitles === "object"
+            const projectTitles = userData.projectTitles &&
+                typeof userData.projectTitles === "object"
               ? { ...userData.projectTitles }
               : {};
             projectTitles[projectId] = title || projectId;
@@ -1076,9 +1077,10 @@ exports.acceptProjectShareLink = onRequest(
           const userData = userSnap.data();
 
           // Construct updated projectTitles
-          const projectTitles = userData.projectTitles && typeof userData.projectTitles === "object"
-            ? { ...userData.projectTitles }
-            : {};
+          const projectTitles =
+            userData.projectTitles && typeof userData.projectTitles === "object"
+              ? { ...userData.projectTitles }
+              : {};
           projectTitles[projectId] = projectData.title || projectId;
 
           // Always update projectTitles when joining a project, even if already in accessibleProjectIds

--- a/functions/index.js
+++ b/functions/index.js
@@ -387,9 +387,15 @@ exports.saveProject = onRequest(
               accessibleProjectIds.push(projectId);
             }
 
+            // Ensure projectTitles is treated as an object and merged properly
+            const projectTitles = userData.projectTitles && typeof userData.projectTitles === "object"
+              ? { ...userData.projectTitles }
+              : {};
+            projectTitles[projectId] = title || projectId;
+
             transaction.update(userDocRef, {
               accessibleProjectIds,
-              [`projectTitles.${projectId}`]: title || projectId, // Save title or ID as fallback
+              projectTitles,
               updatedAt: FieldValue.serverTimestamp(),
             });
           } else {
@@ -1068,10 +1074,23 @@ exports.acceptProjectShareLink = onRequest(
 
         if (userSnap.exists) {
           const userData = userSnap.data();
+
+          // Construct updated projectTitles
+          const projectTitles = userData.projectTitles && typeof userData.projectTitles === "object"
+            ? { ...userData.projectTitles }
+            : {};
+          projectTitles[projectId] = projectData.title || projectId;
+
+          // Always update projectTitles when joining a project, even if already in accessibleProjectIds
           if (!userData.accessibleProjectIds?.includes(projectId)) {
             transaction.update(userRef, {
               accessibleProjectIds: FieldValue.arrayUnion(projectId),
-              [`projectTitles.${projectId}`]: projectData.title || projectId,
+              projectTitles,
+              updatedAt: FieldValue.serverTimestamp(),
+            });
+          } else {
+            transaction.update(userRef, {
+              projectTitles,
               updatedAt: FieldValue.serverTimestamp(),
             });
           }


### PR DESCRIPTION
Fixes issue #2693 where changing the project title results in "Failed to save project title to server."

The `saveProject` function in `functions/index.js` was using Firestore's nested field update syntax `` [`projectTitles.${projectId}`]: title ``. However, if the `projectTitles` map is absent or somehow invalid, this update fails within the transaction. This was corrected by safely merging the `projectTitles` map natively before applying the update.

This was replicated successfully via Jest testing using real Firestore transaction executions in emulator. The problem extended to `acceptProjectShareLink` as well, so both endpoints were correctly updated.

---
*PR created automatically by Jules for task [16504117581787025422](https://jules.google.com/task/16504117581787025422) started by @kitamura-tetsuo*

close #2693

Related issue: https://github.com/kitamura-tetsuo/outliner/issues/2693