### PR TITLE
feat(docs): enable local search in VitePress configuration

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,6 +45,7 @@ export default defineConfig({
         },
     },
     themeConfig: {
+        search: { provider: "local" },
         sidebar: [
             {
                 text: "User Manual",


### PR DESCRIPTION
Added the `search: { provider: 'local' }` configuration to `docs/.vitepress/config.mts` to enable the built-in search function in the documentation as requested in the issue.

---
*PR created automatically by Jules for task [8438027937591468951](https://jules.google.com/task/8438027937591468951) started by @kitamura-tetsuo*

close #2822

Related issue: https://github.com/kitamura-tetsuo/outliner/issues/2822