### PR TITLE
fix: use $effect for reactive page thumbnail updates in PageListItem.svelte

### DIFF
--- a/client/src/components/PageListItem.svelte
+++ b/client/src/components/PageListItem.svelte
@@ -94,14 +94,17 @@ function updatePreview() {
     lastChanged = page.lastChanged;
 }
 
-onMount(() => {
+$effect(() => {
+    // Initial update
     updatePreview();
 
     // Listen for Yjs updates to reactively update the preview
-    if (page.ydoc) {
-        page.ydoc.on("update", updatePreview);
+    // This effect will re-run and clean up the old listener if 'page' or 'page.ydoc' changes
+    const currentDoc = page.ydoc;
+    if (currentDoc) {
+        currentDoc.on("update", updatePreview);
         return () => {
-            page.ydoc.off("update", updatePreview);
+            currentDoc.off("update", updatePreview);
         };
     }
 });

--- a/client/src/components/PageListItem.svelte
+++ b/client/src/components/PageListItem.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { onMount } from "svelte";
 import type { Item } from "../schema/app-schema";
 
 interface Props {
@@ -11,8 +10,8 @@ interface Props {
 let { page, isGridView, onSelect }: Props = $props();
 
 let preview = $state<{ lines: string[]; image: string | null }>({ lines: [], image: null });
-let pageTitle = $state(page.text || "Untitled Page");
-let lastChanged = $state(page.lastChanged);
+let pageTitle = $state("");
+let lastChanged = $state<number | undefined>();
 
 function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDepth: number = 3) {
     const lines: string[] = [];
@@ -34,7 +33,7 @@ function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDepth: numb
                     } else if (val && typeof val === "object") {
                         if ("url" in val) {
                             image = (val as any).url;
-                        } else if (Array.isArray(val) && val.length > 0) {
+                        } else if (Array.isArray(val) && (val as any[]).length > 0) {
                             image = val[0];
                         }
                     }


### PR DESCRIPTION
This PR fixes an issue where page thumbnails in the page list incorrectly displayed "No content" for text-based pages.

### Problem
The component was using `onMount` to set up Yjs listeners. When a component instance was reused (e.g., when switching projects or syncing), the listener remained attached to the old `ydoc`, missing updates from the new one.

### Solution
Replaced `onMount` with Svelte 5's `$effect` to ensure listeners are reactively updated whenever the `page` prop or its `ydoc` property changes. This guarantees that the thumbnail always reflects the current document content.

### Verification
- Verified reactive listener attachment/detachment.
- Confirmed compilation with `npm run build`.
- Ran `dprint fmt` to ensure code style compliance.

Session ID: 8282250721864481556
https://jules.google.com/session/8282250721864481556