### PR TITLE
Fix: Make mobile action toolbar always visible

### DIFF
--- a/client/src/components/OutlinerTree.svelte
+++ b/client/src/components/OutlinerTree.svelte
@@ -2175,7 +2175,7 @@
         bottom: 0;
         left: 0;
         right: 0;
-        display: none; /* Hidden by default */
+        display: flex; /* Always visible */
         background: white;
         border-top: 1px solid #ddd;
         padding: 8px;
@@ -2203,12 +2203,6 @@
         background: #e0e0e0;
     }
 
-    /* Show mobile toolbar only on small screens */
-    @media (max-width: 768px) {
-        .mobile-action-toolbar {
-            display: flex;
-        }
-    }
 
     .outliner {
         background: white;


### PR DESCRIPTION
This commit ensures that the toolbar previously restricted to mobile screens is now permanently visible on all screen sizes, per the requirements of issue #2828.

---
*PR created automatically by Jules for task [14228853065951130220](https://jules.google.com/task/14228853065951130220) started by @kitamura-tetsuo*

close #2828

Related issue: https://github.com/kitamura-tetsuo/outliner/issues/2828