### PR TITLE
Fix "No content" preview on text-only pages in project page list

### DIFF
--- a/client/src/components/OutlinerBase.svelte
+++ b/client/src/components/OutlinerBase.svelte
@@ -5,6 +5,7 @@
     import * as Y from "yjs";
     import { store as generalStore } from "../stores/store.svelte";
     import { onMount } from "svelte";
+    import { extractPagePreview } from "../lib/pagePreview";
     import GlobalTextArea from "./GlobalTextArea.svelte";
     import OutlinerTree from "./OutlinerTree.svelte";
     import PresenceAvatars from "./PresenceAvatars.svelte";
@@ -37,6 +38,37 @@
         const byProp = pageItem as Item | undefined;
         if (byProp) return byProp;
         return (generalStore.currentPage as Item | undefined) ?? undefined;
+    });
+
+    let previewUpdateTimeout: ReturnType<typeof setTimeout>;
+
+    $effect(() => {
+        if (!effectivePageItem) return;
+
+        const currentDoc = effectivePageItem.ydoc;
+        if (!currentDoc) return;
+
+        const updatePreviewDebounced = () => {
+            clearTimeout(previewUpdateTimeout);
+            previewUpdateTimeout = setTimeout(() => {
+                if (!effectivePageItem) return;
+                try {
+                    const newPreview = extractPagePreview(effectivePageItem);
+                    const oldPreview = effectivePageItem.preview;
+                    if (JSON.stringify(newPreview) !== JSON.stringify(oldPreview)) {
+                        effectivePageItem.preview = newPreview;
+                    }
+                } catch (e) {
+                    console.warn("Failed to update page preview:", e);
+                }
+            }, 1000);
+        };
+
+        currentDoc.on("update", updatePreviewDebounced);
+        return () => {
+            clearTimeout(previewUpdateTimeout);
+            currentDoc.off("update", updatePreviewDebounced);
+        };
     });
 
     // Ensure a minimal currentPage on mount (effectivePageItem follows thereafter)

--- a/client/src/components/PageListItem.svelte
+++ b/client/src/components/PageListItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Item } from "../schema/app-schema";
+import { extractPagePreview } from "../lib/pagePreview";
 
 interface Props {
     page: Item;
@@ -13,82 +14,8 @@ let preview = $state<{ lines: string[]; image: string | null }>({ lines: [], ima
 let pageTitle = $state("");
 let lastChanged = $state<number | undefined>();
 
-function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDepth: number = 3) {
-    const lines: string[] = [];
-    let image: string | null = null;
-    let nodeCount = 0;
-    const maxNodes = 50;
-
-    function traverse(item: Item, currentDepth: number) {
-        if (nodeCount >= maxNodes) return;
-        nodeCount++;
-
-        if (!image && item.attachments) {
-            try {
-                const arr = item.attachments.toArray();
-                if (arr && arr.length > 0) {
-                    const val = arr[0];
-                    if (typeof val === "string") {
-                        image = val;
-                    } else if (val && typeof val === "object") {
-                        if ("url" in val) {
-                            image = (val as any).url;
-                        } else if (Array.isArray(val) && (val as any[]).length > 0) {
-                            image = val[0];
-                        }
-                    }
-                }
-            } catch (e) {
-                console.warn("Failed to extract attachment", e);
-            }
-        }
-
-        let text = "";
-        try {
-            text = item.text ? item.text.trim() : "";
-        } catch (e) {
-             console.warn("Failed to extract text", e);
-        }
-
-        if (text && lines.length < maxLines && item.id !== pageItem.id) {
-            lines.push(text);
-        }
-
-        if (currentDepth >= maxDepth) return;
-
-        try {
-            if (item.items) {
-                let i = 0;
-                for (const child of item.items) {
-                    if (i++ > 10) break;
-                    if (child) traverse(child, currentDepth + 1);
-                    if (lines.length >= maxLines && image) return;
-                    if (nodeCount >= maxNodes) return;
-                }
-            }
-        } catch (e) {
-            console.warn("Failed to iterate children", e);
-        }
-    }
-
-    try {
-        if (pageItem.items) {
-            let i = 0;
-            for (const child of pageItem.items) {
-                if (i++ > 20) break;
-                if (child) traverse(child, 1);
-                if (lines.length >= maxLines && image) break;
-            }
-        }
-    } catch (e) {
-        console.warn("Failed to iterate root children", e);
-    }
-
-    return { lines, image };
-}
-
 function updatePreview() {
-    preview = extractPagePreview(page);
+    preview = page.preview || extractPagePreview(page);
     pageTitle = page.text || "Untitled Page";
     lastChanged = page.lastChanged;
 }
@@ -129,7 +56,9 @@ $effect(() => {
                     <p class="m-0 mb-1 line-clamp-1">{line}</p>
                 {/each}
                 {#if preview.lines.length === 0 && !preview.image}
-                    <p class="m-0 text-gray-400 italic">No content</p>
+                    <div class="flex items-center justify-center h-full min-h-[3rem] rounded border border-dashed border-gray-200 bg-gray-50/50">
+                        <span class="text-xs text-gray-400 font-medium">Empty page - Click to start writing</span>
+                    </div>
                 {/if}
             </div>
 
@@ -161,7 +90,7 @@ $effect(() => {
                         {#if preview.lines.length > 0}
                             {preview.lines[0]}
                         {:else}
-                            <span class="italic">No text content</span>
+                            <span class="italic text-gray-400">Empty page - Click to start writing</span>
                         {/if}
                     </span>
                 </div>

--- a/client/src/lib/pagePreview.ts
+++ b/client/src/lib/pagePreview.ts
@@ -34,7 +34,7 @@ export function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDept
         try {
             text = item.text ? item.text.trim() : "";
         } catch (e) {
-             console.warn("Failed to extract text", e);
+            console.warn("Failed to extract text", e);
         }
 
         if (text && lines.length < maxLines && item.id !== pageItem.id) {

--- a/client/src/lib/pagePreview.ts
+++ b/client/src/lib/pagePreview.ts
@@ -1,0 +1,75 @@
+import type { Item } from "../schema/app-schema";
+
+export function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDepth: number = 3) {
+    const lines: string[] = [];
+    let image: string | null = null;
+    let nodeCount = 0;
+    const maxNodes = 50;
+
+    function traverse(item: Item, currentDepth: number) {
+        if (nodeCount >= maxNodes) return;
+        nodeCount++;
+
+        if (!image && item.attachments) {
+            try {
+                const arr = item.attachments.toArray();
+                if (arr && arr.length > 0) {
+                    const val = arr[0];
+                    if (typeof val === "string") {
+                        image = val;
+                    } else if (val && typeof val === "object") {
+                        if ("url" in val) {
+                            image = (val as any).url;
+                        } else if (Array.isArray(val) && (val as any[]).length > 0) {
+                            image = val[0];
+                        }
+                    }
+                }
+            } catch (e) {
+                console.warn("Failed to extract attachment", e);
+            }
+        }
+
+        let text = "";
+        try {
+            text = item.text ? item.text.trim() : "";
+        } catch (e) {
+             console.warn("Failed to extract text", e);
+        }
+
+        if (text && lines.length < maxLines && item.id !== pageItem.id) {
+            lines.push(text);
+        }
+
+        if (currentDepth >= maxDepth) return;
+
+        try {
+            if (item.items) {
+                let i = 0;
+                for (const child of item.items) {
+                    if (i++ > 10) break;
+                    if (child) traverse(child, currentDepth + 1);
+                    if (lines.length >= maxLines && image) return;
+                    if (nodeCount >= maxNodes) return;
+                }
+            }
+        } catch (e) {
+            console.warn("Failed to iterate children", e);
+        }
+    }
+
+    try {
+        if (pageItem.items) {
+            let i = 0;
+            for (const child of pageItem.items) {
+                if (i++ > 20) break;
+                if (child) traverse(child, 1);
+                if (lines.length >= maxLines && image) break;
+            }
+        }
+    } catch (e) {
+        console.warn("Failed to iterate root children", e);
+    }
+
+    return { lines, image };
+}

--- a/client/src/schema/app-schema.ts
+++ b/client/src/schema/app-schema.ts
@@ -194,6 +194,15 @@ export class Item {
         this.value.set("lastChanged", Date.now());
     }
 
+    // cached page preview stored in Y.Map
+    get preview(): { lines: string[]; image: string | null; } | undefined {
+        return this.value.get("preview") as { lines: string[]; image: string | null; } | undefined;
+    }
+    set preview(v: { lines: string[]; image: string | null; } | undefined) {
+        this.value.set("preview", v as any);
+        this.value.set("lastChanged", Date.now());
+    }
+
     updateText(text: string) {
         const t = this.value.get("text") as Y.Text;
         t.delete(0, t.length);

--- a/client/src/schema/yjs-schema.ts
+++ b/client/src/schema/yjs-schema.ts
@@ -104,6 +104,18 @@ export class Item {
         }
     }
 
+    get preview(): { lines: string[]; image: string | null; } | undefined {
+        return this.value.get("preview") as { lines: string[]; image: string | null; } | undefined;
+    }
+
+    set preview(value: { lines: string[]; image: string | null; } | undefined) {
+        if (value === undefined) {
+            this.value.delete("preview");
+        } else {
+            this.value.set("preview", value);
+        }
+    }
+
     updateText(text: string) {
         const t = this.text;
         if (t) {


### PR DESCRIPTION
Fixes a bug where pages containing only text displayed a "No content" message in the project page list. This occurred because page subdocuments were lazily loaded and not connected to their WebSocket rooms when displaying the page list.

This fix implements Option A from the issue (Metadata Caching):
- When a page is edited, its preview (first 3 lines of text and first image) is computed and saved to a new `preview` field in the page's metadata within the main project document.
- The `PageListItem.svelte` component now reads from this cached preview directly.
- Added a styled empty state placeholder ("Empty page - Click to start writing") for genuinely empty pages.

---
*PR created automatically by Jules for task [9357423806697372667](https://jules.google.com/task/9357423806697372667) started by @kitamura-tetsuo*

close #2857

Related issue: https://github.com/kitamura-tetsuo/outliner/issues/2857