### PR TITLE
feat: Add "Add Database" button to toolbar (#2864)

### DIFF
--- a/client/e2e/core/add-database-toolbar-button.spec.ts
+++ b/client/e2e/core/add-database-toolbar-button.spec.ts
@@ -21,11 +21,11 @@ test("Toolbar 'Add Database' button inserts a Database (table) component", async
     await page.waitForTimeout(500);
 
     // Click the Add Database button in the main-toolbar
-    const addDatabaseBtn = page.getByTestId("main-toolbar").locator('.add-database-btn').last();
+    const addDatabaseBtn = page.getByTestId("main-toolbar").locator(".add-database-btn").last();
     await expect(addDatabaseBtn).toBeVisible({ timeout: 10000 });
     await addDatabaseBtn.click();
 
     // Check for the inserted inline-join-table block
-    const inlineTable = page.locator('.inline-join-table').first();
+    const inlineTable = page.locator(".inline-join-table").first();
     await expect(inlineTable).toBeVisible({ timeout: 10000 });
 });

--- a/client/e2e/core/add-database-toolbar-button.spec.ts
+++ b/client/e2e/core/add-database-toolbar-button.spec.ts
@@ -1,0 +1,31 @@
+import "../utils/registerAfterEachSnapshot";
+import { expect, test } from "@playwright/test";
+import { registerCoverageHooks } from "../utils/registerCoverageHooks";
+import { TestHelpers } from "../utils/testHelpers";
+registerCoverageHooks();
+
+test.beforeEach(async ({ page }, testInfo) => {
+    test.setTimeout(90000);
+    await TestHelpers.seedProjectAndNavigate(page, testInfo);
+});
+
+test("Toolbar 'Add Database' button inserts a Database (table) component", async ({ page }) => {
+    // Wait for the outliner items to load
+    await expect(page.locator(".outliner-item").first()).toBeVisible({ timeout: 10000 });
+
+    // Click the first item to focus it
+    await page.locator(".outliner-item").first().click();
+
+    // Type a key to ensure the global textarea catches the focus
+    await page.keyboard.type("setup");
+    await page.waitForTimeout(500);
+
+    // Click the Add Database button in the main-toolbar
+    const addDatabaseBtn = page.getByTestId("main-toolbar").locator('.add-database-btn').last();
+    await expect(addDatabaseBtn).toBeVisible({ timeout: 10000 });
+    await addDatabaseBtn.click();
+
+    // Check for the inserted inline-join-table block
+    const inlineTable = page.locator('.inline-join-table').first();
+    await expect(inlineTable).toBeVisible({ timeout: 10000 });
+});

--- a/client/src/components/Toolbar.svelte
+++ b/client/src/components/Toolbar.svelte
@@ -4,6 +4,7 @@ import SearchBox from "./SearchBox.svelte";
 import { store } from "../stores/store.svelte";
 import { onMount } from "svelte";
 import LoginStatusIndicator from "./LoginStatusIndicator.svelte";
+import { commandPaletteStore } from "../stores/CommandPaletteStore.svelte";
 
 interface Props {
     project?: Project | null;
@@ -198,6 +199,12 @@ if (typeof window !== "undefined") {
 <div class="main-toolbar" data-testid="main-toolbar" bind:this={toolbarEl} aria-hidden="false">
     <div class="main-toolbar-content" aria-hidden="false">
         <div class="toolbar-left">
+            <button
+                class="add-database-btn"
+                onclick={() => commandPaletteStore.insert("table")}
+            >
+                Add Database
+            </button>
             <div role="search">
                 <SearchBox project={effectiveProject ?? undefined} />
             </div>
@@ -266,6 +273,23 @@ if (typeof window !== "undefined") {
 
 .toolbar-left > div {
     flex: 1 1 auto;
+}
+
+.add-database-btn {
+    margin-right: 1rem;
+    padding: 0.25rem 0.75rem;
+    background-color: #f3f4f6;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #374151;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.add-database-btn:hover {
+    background-color: #e5e7eb;
 }
 
 .toolbar-right {


### PR DESCRIPTION
Resolves #2864 by implementing the "Add Database" button to the main toolbar and testing it locally using Playwright E2E testing framework.

---
*PR created automatically by Jules for task [14105955197500847203](https://jules.google.com/task/14105955197500847203) started by @kitamura-tetsuo*

close #2864

Related issue: https://github.com/kitamura-tetsuo/outliner/issues/2864