### PR TITLE
feat: Implement Public Demo Page

### DIFF
--- a/client/src/lib/yjs/connection.ts
+++ b/client/src/lib/yjs/connection.ts
@@ -197,7 +197,9 @@ export async function createProjectConnection(projectId: string): Promise<Projec
     // Ensure token is available for initial connection URL (required by server upgrade handler)
     let initialToken = "";
     try {
-        initialToken = await getFreshIdToken();
+        if (projectId !== "demo") {
+            initialToken = await getFreshIdToken();
+        }
     } catch {}
 
     // Send a dummy `token` to satisfy HocuspocusServer's unconditional wait for a `MessageType.Auth` message.

--- a/client/src/lib/yjsService.svelte.ts
+++ b/client/src/lib/yjsService.svelte.ts
@@ -220,6 +220,22 @@ export async function createNewProject(projectName: string, existingProjectId?: 
 export async function getClientByProjectTitle(projectTitle: string): Promise<YjsClient | undefined> {
     console.log(`[getClientByProjectTitle] projectTitle=${projectTitle}, registry.map.size=${registry.map.size}`);
 
+    // Special bypass for demo project
+    if (projectTitle === "demo") {
+        const userId = userManager.getCurrentUser()?.id || "anonymous-demo";
+        const projectId = "demo";
+
+        if (registry.has(keyFor(userId, projectId))) {
+            const [c] = registry.get(keyFor(userId, projectId))!;
+            if (c) return c;
+        }
+
+        const project = Project.createInstance("Demo");
+        const client = await YjsClient.connect(projectId, project);
+        registry.set(keyFor(userId, projectId), [client, project]);
+        return client;
+    }
+
     // First, check the registry for a matching client
     for (const [, [client, project]] of registry.entries()) {
         if (project?.title === projectTitle && client) {

--- a/client/src/routes/api/seed-demo/+server.ts
+++ b/client/src/routes/api/seed-demo/+server.ts
@@ -1,0 +1,26 @@
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+
+export const POST: RequestHandler = async () => {
+    try {
+        const apiBaseUrl = process.env.VITE_API_SERVER_URL || "http://127.0.0.1:7091";
+        const response = await fetch(`${apiBaseUrl}/api/seed-demo`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({}),
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            return json({ error: `API error: ${response.status} ${errorText}` }, { status: response.status });
+        }
+
+        const result = await response.json();
+        return json(result);
+    } catch (error) {
+        console.error("Seed demo API error:", error);
+        return json({ error: "Internal server error" }, { status: 500 });
+    }
+};

--- a/client/src/routes/demo/+page.svelte
+++ b/client/src/routes/demo/+page.svelte
@@ -1,1 +1,173 @@
-<a href="/demo/paraglide">paraglide</a>
+<script lang="ts">
+    import { onMount, onDestroy } from "svelte";
+    import OutlinerBase from "../../components/OutlinerBase.svelte";
+    import { getLogger } from "../../lib/logger";
+    import { getYjsClientByProjectTitle } from "../../services";
+    import { yjsStore } from "../../stores/yjsStore.svelte";
+    import { store } from "../../stores/store.svelte";
+
+    const logger = getLogger("DemoPage");
+
+    let isLoading = $state(true);
+    let error: string | undefined = $state(undefined);
+
+    async function initializeDemo() {
+        try {
+            isLoading = true;
+            error = undefined;
+
+            // Seed demo document via API
+            try {
+                const response = await fetch('/api/seed-demo', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                });
+                if (!response.ok) {
+                    logger.warn(`Failed to seed demo: ${response.statusText}`);
+                }
+            } catch (seedErr) {
+                logger.warn(`Error seeding demo ${seedErr}`);
+            }
+
+            // Connect to demo room
+            let client = await getYjsClientByProjectTitle("demo");
+            if (!client) {
+                throw new Error("Failed to connect to the demo project.");
+            }
+
+            yjsStore.yjsClient = client as any;
+            const project = client.getProject();
+            store.project = project as any;
+
+            // Wait for sync or timeout
+            let retries = 0;
+            let demoPage = undefined;
+
+            while (retries < 20) { // 2 seconds max
+                const pages = store.project?.items?.length || 0;
+
+                for (let i = 0; i < pages; i++) {
+                    const item = store.project?.items?.at?.(i);
+                    if (item && item.text === "Demo") {
+                        demoPage = item;
+                        break;
+                    }
+                }
+
+                if (!demoPage && pages > 0) {
+                     demoPage = store.project?.items?.at?.(0);
+                }
+
+                if (demoPage) {
+                    break;
+                }
+
+                await new Promise(r => setTimeout(r, 100));
+                retries++;
+            }
+
+            if (!demoPage) {
+                logger.warn("Timeout waiting for Demo page to sync");
+            }
+
+            store.currentPage = demoPage as any;
+
+        } catch (err) {
+            console.error("Failed to initialize demo:", err);
+            error = err instanceof Error ? err.message : "An error occurred while loading the demo.";
+        } finally {
+            isLoading = false;
+        }
+    }
+
+    onMount(() => {
+        initializeDemo();
+    });
+
+    onDestroy(() => {
+        try {
+            yjsStore.yjsClient?.dispose();
+            yjsStore.yjsClient = undefined;
+            store.project = undefined as any;
+            store.currentPage = undefined;
+        } catch {}
+    });
+</script>
+
+<svelte:head>
+    <title>Demo | Outliner</title>
+</svelte:head>
+
+<main class="container mx-auto px-4 py-4">
+    <div class="mb-4">
+        <!-- Breadcrumb Navigation -->
+        <nav class="mb-2 flex items-center text-sm text-gray-600">
+            <a href="/" class="text-blue-600 hover:text-blue-800 hover:underline">
+                Home
+            </a>
+            <span class="mx-2">/</span>
+            <span class="text-gray-900">Demo Page</span>
+        </nav>
+
+        <div class="flex items-center justify-between">
+            <h1 class="text-2xl font-bold">Public Demo</h1>
+        </div>
+        <p class="text-sm text-gray-500 mt-1">This is a public, collaborative demo space. Content resets every 24 hours.</p>
+    </div>
+
+    {#if isLoading}
+        <div class="flex justify-center py-8">
+            <div class="loader">Loading Demo...</div>
+        </div>
+    {:else if error}
+        <div class="rounded-md bg-red-50 p-4">
+            <div class="flex">
+                <div class="flex-shrink-0">
+                    <span class="text-red-400">⚠️</span>
+                </div>
+                <div class="ml-3">
+                    <h3 class="text-sm font-medium text-red-800">An error occurred</h3>
+                    <div class="mt-2 text-sm text-red-700">
+                        <p>{error}</p>
+                    </div>
+                    <div class="mt-4">
+                        <button
+                            onclick={initializeDemo}
+                            class="rounded-md bg-red-100 px-2 py-1.5 text-sm font-medium text-red-800 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2"
+                        >
+                            Retry
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {:else}
+        <OutlinerBase
+            pageItem={store.currentPage}
+            projectName="demo"
+            pageName="Demo"
+            isReadOnly={false}
+            isTemporary={false}
+            onEdit={undefined}
+        />
+    {/if}
+</main>
+
+<style>
+    .loader {
+        border: 4px solid #f3f3f3;
+        border-top: 4px solid #3498db;
+        border-radius: 50%;
+        width: 30px;
+        height: 30px;
+        animation: spin 1s linear infinite;
+        margin: 0 auto;
+    }
+
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+</style>

--- a/client/src/routes/demo/+page.ts
+++ b/client/src/routes/demo/+page.ts
@@ -1,0 +1,2 @@
+export const ssr = false;
+export const prerender = false;

--- a/docs/demo-template.txt
+++ b/docs/demo-template.txt
@@ -1,0 +1,19 @@
+Welcome to the Outliner Demo!
+This is a demonstration page that is accessible without logging in.
+The content of this demo page resets every 24 hours.
+
+Basic formatting:
+- You can make text **bold** using [[bold]] syntax.
+- You can make text _italic_ using [/italic] syntax.
+- You can [-strike through] text.
+
+Creating Lists:
+- Press Enter to create a new item.
+- Press Tab to indent the item (make it a child of the above item).
+- Press Shift+Tab to unindent the item.
+
+Checkboxes:
+- [ ] You can type [ ] to create an interactive checklist.
+- [x] Once checked, the parent items will reflect completion status.
+
+Give it a try! You can edit everything on this page.

--- a/server/src/demo-api.ts
+++ b/server/src/demo-api.ts
@@ -1,7 +1,7 @@
 import express from "express";
-import * as Y from "yjs";
 import fs from "fs";
 import path from "path";
+import * as Y from "yjs";
 import { logger } from "./logger.js";
 import { Project } from "./schema/app-schema.js";
 
@@ -55,7 +55,7 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                         logger.warn({ event: "seed_demo_template_not_found", error: String(e) });
                         templateLines = [
                             "Welcome to the Outliner Demo!",
-                            "This demo resets every 24 hours."
+                            "This demo resets every 24 hours.",
                         ];
                     }
 
@@ -92,12 +92,10 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                 }
 
                 res.json({ success: true, reset: shouldReset });
-
             } finally {
                 // Must disconnect to prevent memory leak
                 await directConnection.disconnect();
             }
-
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             logger.error({ event: "seed_demo_error", error: errorMessage });

--- a/server/src/demo-api.ts
+++ b/server/src/demo-api.ts
@@ -1,0 +1,109 @@
+import express from "express";
+import * as Y from "yjs";
+import fs from "fs";
+import path from "path";
+import { logger } from "./logger.js";
+import { Project } from "./schema/app-schema.js";
+
+type HocuspocusInstance = any;
+
+const DEMO_PROJECT_ID = "demo";
+const RESET_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export function createDemoRouter(hocuspocus: HocuspocusInstance) {
+    const router = express.Router();
+
+    router.post("/seed-demo", async (req, res): Promise<void> => {
+        try {
+            logger.info({ event: "seed_demo_request" });
+
+            const projectRoom = `projects/${DEMO_PROJECT_ID}`;
+
+            // Connect to demo document
+            const directConnection = await hocuspocus.openDirectConnection(projectRoom, {
+                isSeeding: true,
+            });
+
+            try {
+                const doc = directConnection.document;
+                if (!doc) {
+                    throw new Error("Failed to get document from direct connection");
+                }
+
+                let shouldReset = false;
+                const now = Date.now();
+
+                const metadata = doc.getMap("metadata") as Y.Map<any>;
+                const lastReset = metadata.get("lastReset") as number | undefined;
+
+                if (!lastReset || (now - lastReset > RESET_INTERVAL_MS)) {
+                    shouldReset = true;
+                }
+
+                if (shouldReset) {
+                    logger.info({ event: "seed_demo_resetting", lastReset, now });
+
+                    // Read template
+                    let templateLines: string[] = [];
+                    try {
+                        // Find docs relative to current file to be more robust
+                        const docsDir = path.resolve(__dirname, "../../docs");
+                        const templatePath = path.resolve(docsDir, "demo-template.txt");
+                        const templateContent = fs.readFileSync(templatePath, "utf-8");
+                        templateLines = templateContent.split("\n");
+                    } catch (e) {
+                        logger.warn({ event: "seed_demo_template_not_found", error: String(e) });
+                        templateLines = [
+                            "Welcome to the Outliner Demo!",
+                            "This demo resets every 24 hours."
+                        ];
+                    }
+
+                    await directConnection.transact((document: any) => {
+                        const ydoc = document as unknown as Y.Doc;
+
+                        // Clear orderedTree completely
+                        const orderedTree = ydoc.getMap("orderedTree");
+                        Array.from(orderedTree.keys()).forEach(key => orderedTree.delete(key));
+
+                        // Clear items map completely
+                        const itemsMap = ydoc.getMap("items");
+                        Array.from(itemsMap.keys()).forEach(key => itemsMap.delete(key));
+
+                        // Re-initialize metadata
+                        const meta = ydoc.getMap("metadata");
+                        meta.set("title", "Demo Project");
+                        meta.set("lastReset", now);
+
+                        // Create project wrapper and root page
+                        const project = Project.fromDoc(ydoc);
+                        const page = project.addPage("Demo", "seed-server");
+
+                        if (templateLines.length > 0) {
+                            const pageItems = page.items;
+                            for (const line of templateLines) {
+                                const item = pageItems.addNode("seed-server");
+                                item.text = line;
+                            }
+                        }
+                    });
+                } else {
+                    logger.info({ event: "seed_demo_no_reset_needed", lastReset, now });
+                }
+
+                res.json({ success: true, reset: shouldReset });
+
+            } finally {
+                // Must disconnect to prevent memory leak
+                await directConnection.disconnect();
+            }
+
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            logger.error({ event: "seed_demo_error", error: errorMessage });
+            res.status(500).json({ error: "Demo seeding failed", message: errorMessage });
+        }
+    });
+
+    return router;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -10,12 +10,12 @@ import * as Y from "yjs";
 import { checkContainerAccess as defaultCheckAccess } from "./access-control.js";
 import { requireAuth } from "./auth-middleware.js";
 import { type Config } from "./config.js";
+import { createDemoRouter } from "./demo-api.js";
 import { logger as defaultLogger } from "./logger.js";
 import { getMetrics, recordMessage } from "./metrics.js";
 import { createPersistence } from "./persistence.js";
 import { parseRoom } from "./room-validator.js";
 import { createSeedRouter } from "./seed-api.js";
-import { createDemoRouter } from "./demo-api.js";
 import { getClientIp } from "./utils/ip.js";
 import {
     refreshClientLogStream,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15,6 +15,7 @@ import { getMetrics, recordMessage } from "./metrics.js";
 import { createPersistence } from "./persistence.js";
 import { parseRoom } from "./room-validator.js";
 import { createSeedRouter } from "./seed-api.js";
+import { createDemoRouter } from "./demo-api.js";
 import { getClientIp } from "./utils/ip.js";
 import {
     refreshClientLogStream,
@@ -217,6 +218,19 @@ export async function startServer(
             const token = extractAuthToken(request);
             console.log(`[Hocuspocus] onAuthenticate: room=${data.documentName}, token=${token ? "FOUND" : "MISSING"}`);
 
+            const room = parseRoom(data.documentName);
+            if (!room?.project) {
+                throw Object.assign(new Error("Authentication failed: Invalid room format"), { code: 4001 });
+            }
+
+            if (room.project === "demo") {
+                console.log(`[Hocuspocus] onAuthenticate: Anonymous demo access for room=${data.documentName}`);
+                return {
+                    user: { uid: "anonymous-demo" },
+                    room,
+                };
+            }
+
             if (!token) {
                 throw Object.assign(new Error("Authentication failed: No token provided"), { code: 4001 });
             }
@@ -227,11 +241,6 @@ export async function startServer(
             } catch (err: any) {
                 // Re-throw so Hocuspocus sends 4001 Unauthorized to client
                 throw err;
-            }
-
-            const room = parseRoom(data.documentName);
-            if (!room?.project) {
-                throw Object.assign(new Error("Authentication failed: Invalid room format"), { code: 4001 });
             }
 
             const hasAccess = await checkContainerAccess(decoded.uid, room.project);
@@ -271,6 +280,9 @@ export async function startServer(
 
     // Seed API - use Hocuspocus's openDirectConnection for proper document lifecycle
     app.use("/api", createSeedRouter(hocuspocus));
+
+    // Demo API - anonymous access for the public demo page
+    app.use("/api", createDemoRouter(hocuspocus));
 
     // Log rotation endpoint
     app.post("/api/rotate-logs", requireAuth, async (req: any, res: any) => {
@@ -356,11 +368,6 @@ export async function startServer(
                 return rejectSync(4008, "MAX_SOCKETS_PER_IP");
             }
 
-            // 4. Validate token presence and room format (synchronous, no network calls)
-            const token = extractAuthToken(request);
-            if (!token) {
-                return rejectSync(4001, "NO_TOKEN");
-            }
             let documentName = "";
             if (request.url) {
                 const urlPath = request.url.split("?")[0];
@@ -369,6 +376,14 @@ export async function startServer(
             const room = parseRoom(documentName);
             if (!room?.project) {
                 return rejectSync(4001, "INVALID_ROOM");
+            }
+
+            const isDemoRoom = room.project === "demo";
+
+            // 4. Validate token presence (synchronous, no network calls)
+            const token = extractAuthToken(request);
+            if (!token && !isDemoRoom) {
+                return rejectSync(4001, "NO_TOKEN");
             }
 
             // 5. Check room connection limit (synchronous)


### PR DESCRIPTION
Implements a public, unauthenticated demo page at `/demo` with a 24-hour auto-reset.

This resolves issue #2868 by enabling anyone to visit `/demo` and test the application securely. The document connects via Hocuspocus using anonymous authentication for the specific room `projects/demo` and uses a server-side seeding route (`/api/seed-demo`) backed by `demo-api.ts` to ensure the document resets every 24 hours back to `docs/demo-template.txt`.

---
*PR created automatically by Jules for task [6802441716101772116](https://jules.google.com/task/6802441716101772116) started by @kitamura-tetsuo*

close #2868

Related issue: https://github.com/kitamura-tetsuo/outliner/issues/2868