### PR TITLE
fix: skip auth token fetch for demo project to fix page loading

### DIFF
--- a/client/src/lib/yjs/connection.ts
+++ b/client/src/lib/yjs/connection.ts
@@ -347,7 +347,9 @@ export async function connectProjectDoc(doc: Y.Doc, projectId: string): Promise<
     // Ensure token is available for initial connection URL (required by server upgrade handler)
     let initialToken = "";
     try {
-        initialToken = await getFreshIdToken();
+        if (projectId !== "demo") {
+            initialToken = await getFreshIdToken();
+        }
     } catch (e) {
         console.error("[connectProjectDoc] getFreshIdToken FAILED:", e);
     }
@@ -405,7 +407,9 @@ export async function createMinimalProjectConnection(projectId: string): Promise
     // Ensure token is available for initial connection URL (required by server upgrade handler)
     let initialToken = "";
     try {
-        initialToken = await getFreshIdToken();
+        if (projectId !== "demo") {
+            initialToken = await getFreshIdToken();
+        }
     } catch {}
 
     // Send a dummy `token` for the same reason as in createProjectConnection


### PR DESCRIPTION
Fixes the issue where the public demo page at `https://outliner-d57b0.web.app/demo` fails to load.

**Problem:**
The Yjs connection handlers `connectProjectDoc` and `createMinimalProjectConnection` in `client/src/lib/yjs/connection.ts` were attempting to fetch a fresh ID token regardless of the project ID. For the `demo` project, which is accessed anonymously without authentication, this triggered an error resulting in a failed WebSocket connection (4001 or 1005 close code).

**Solution:**
Updated both functions to skip `getFreshIdToken()` when `projectId === "demo"`, identical to the check that already exists in `createProjectConnection`. This ensures the dummy/empty token is properly passed without failing on auth, allowing the Hocuspocus server to grant anonymous demo access.

**Verification:**
- Ran client unit tests: Passed
- Ran client integration tests: Passed
- Simulated a connection locally and verified no auth token is required for `/projects/demo`.

---
*PR created automatically by Jules for task [6430236323121491338](https://jules.google.com/task/6430236323121491338) started by @kitamura-tetsuo*