### PR TITLE
fix: resolve svelte-check typescript errors and logger signatures

### DIFF
--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -114,9 +114,7 @@ async function rotateLogFiles() {
         }
     }
     catch (error) {
-        logger.error("An error occurred during log rotation", {
-            error,
-        });
+        logger.error({ error }, "An error occurred during log rotation");
     }
 }
 
@@ -170,7 +168,7 @@ onMount(async () => {
             await import("../lib/metaDoc.svelte");
             await import("../services");
         } catch (e) {
-            logger.error("Failed to load client-only modules", e);
+            logger.error({ err: e }, "Failed to load client-only modules");
         }
         // Application initialization log
         if (import.meta.env.DEV) {
@@ -197,7 +195,7 @@ onMount(async () => {
                         if (import.meta.env.DEV) logger.info("Service worker update found");
                     });
                 })
-                .catch(err => { logger.error("Service worker registration failed:", err); });
+                .catch(err => { logger.error({ err }, "Service worker registration failed:"); });
         }
 
         // Check authentication status
@@ -205,14 +203,14 @@ onMount(async () => {
 
         if (isAuthenticated) {
             // Initialize debug functions
-            setupGlobalDebugFunctions(yjsService?.yjsHighService);
+            setupGlobalDebugFunctions();
         }
         else {
             // Monitor authentication state changes
             userManager?.addEventListener((authResult: any) => {
                 isAuthenticated = authResult !== null;
                 if (isAuthenticated && browser) {
-                    setupGlobalDebugFunctions(yjsService?.yjsHighService);
+                    setupGlobalDebugFunctions();
                 }
             });
         }

--- a/client/src/routes/[project]/+layout.svelte
+++ b/client/src/routes/[project]/+layout.svelte
@@ -23,7 +23,7 @@ $effect(() => {
 // Retrieve project name from URL parameters
 $effect(() => {
     // Prefer explicit param over optional data prop
-    const projectParam = (pageStore?.params?.project as string) || (data as any)?.project;
+    const projectParam = ($$$pageStore?.params?.project as string) || (data as any)?.project;
     if (!projectParam) return;
 
     if (!yjsStore.yjsClient) {
@@ -63,7 +63,7 @@ onMount(() => {
     try {
         userManager.addEventListener(() => {
             // If project not yet loaded but param exists, try again when auth flips
-            const projectParam = (pageStore?.params?.project as string) || (data as any)?.project;
+        const projectParam = ($$$pageStore?.params?.project as string) || (data as any)?.project;
             if (projectParam && !yjsStore.yjsClient) {
                 loadProject(projectParam);
             }

--- a/client/src/routes/[project]/[page]/schedule/+page.svelte
+++ b/client/src/routes/[project]/[page]/schedule/+page.svelte
@@ -69,7 +69,7 @@ onMount(async () => {
     // IMPORTANT: Also check if the loaded project has the correct title (handles store reset during navigation)
     const currentProjectTitle = store.project?.title ?? "";
     const isCorrectProject = currentProjectTitle === project;
-    const hasProjectData = store.project?.items?.length > 0 && isCorrectProject;
+    const hasProjectData = (store.project?.items?.length ?? 0) > 0 && isCorrectProject;
 
     // Check if we have a saved pageId in session storage
     const sessionKey = `schedule:lastPageChildId:${encodeURIComponent(project)}:${encodeURIComponent(pageTitle)}`;
@@ -98,12 +98,12 @@ onMount(async () => {
         // Navigate to main page to trigger loadProjectAndPage
         const mainPageUrl = `/${encodeURIComponent(project)}/${encodeURIComponent(pageTitle)}`;
         console.log("Schedule page: Navigating to main page:", mainPageUrl);
-        await goto(mainPageUrl, { waitUntil: "networkidle" });
+        await goto(mainPageUrl);
         console.log("Schedule page: Back from main page, waiting for store.project to be populated...");
 
         // Wait for store.project to be populated after navigation
         for (let i = 0; i < 50; i++) {
-            if (store.project?.items?.length > 0) {
+            if ((store.project?.items?.length ?? 0) > 0) {
                 console.log("Schedule page: store.project populated after", i * 100, "ms");
                 break;
             }
@@ -114,7 +114,7 @@ onMount(async () => {
         // Navigate back to schedule page
         const scheduleUrl = `/${encodeURIComponent(project)}/${encodeURIComponent(pageTitle)}/schedule`;
         console.log("Schedule page: Navigating back to schedule:", scheduleUrl);
-        await goto(scheduleUrl, { waitUntil: "networkidle" });
+        await goto(scheduleUrl);
         console.log("Schedule page: Back on schedule page, store.project?.items?.length =", store.project?.items?.length ?? 0);
     } else {
         console.log("Schedule page: Using saved pageId, no navigation needed");
@@ -545,7 +545,7 @@ async function saveEdit() {
 }
 
 async function back() {
-    await goto(resolve(`/${project}/${pageTitle}`));
+    await goto(resolve(`/${project}/${pageTitle}`) || "/");
 }
 
 async function downloadIcs() {

--- a/client/src/routes/[project]/graph/+page.svelte
+++ b/client/src/routes/[project]/graph/+page.svelte
@@ -7,7 +7,7 @@ let { data } = $props<{ data: { project: string; }; }>();
 const projectName = $derived(data.project);
 
 async function goBack() {
-    await goto(resolve(`/${projectName}`));
+    await goto(resolve(`/${projectName}`) || "/");
 }
 </script>
 

--- a/client/src/routes/demo/paraglide/+page.svelte
+++ b/client/src/routes/demo/paraglide/+page.svelte
@@ -8,8 +8,8 @@ import {
     localizeHref,
 } from "$lib/paraglide/runtime";
 
-function switchToLanguage(newLanguage: string) {
-    const localisedPath = localizeHref(page.url.pathname, { locale: newLanguage });
+function switchToLanguage(newLanguage: "en" | "ja") {
+    const localisedPath = localizeHref($$$page.url.pathname, { locale: newLanguage });
     goto(localisedPath);
 }
 </script>

--- a/client/src/routes/min/+page.svelte
+++ b/client/src/routes/min/+page.svelte
@@ -54,7 +54,7 @@ async function signIn() {
         idToken = await result.user.getIdToken(true);
         console.log("Retrieved ID Token:", idToken);
 
-        const verifyUrl = import.meta.env.VITE_TOKEN_VERIFY_URL;
+        const verifyUrl = import.meta.env.VITE_TOKEN_VERIFY_URL || "";
         const response = await fetch(verifyUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/client/src/routes/projects/new/+page.svelte
+++ b/client/src/routes/projects/new/+page.svelte
@@ -22,7 +22,7 @@ let isAuthenticated = $state(false);
 let createdContainerId: string | undefined = $state(undefined);
 
 // Handle successful authentication
-async function handleAuthSuccess(authResult) {
+async function handleAuthSuccess(authResult: any) {
     logger.info("Authentication success:", authResult);
     isAuthenticated = true;
 }
@@ -72,7 +72,7 @@ async function createNewContainer() {
         }, 1500);
     }
     catch (err) {
-        logger.error("Error creating new outliner:", err);
+        logger.error({ err }, "Error creating new outliner:");
         error = err instanceof Error
             ? err.message
             : "An error occurred while creating the new outliner.";


### PR DESCRIPTION
This PR addresses multiple TypeScript compilation and strict typing errors found via `svelte-check` as a code health improvement.

Specifically:
- Updated the `logger.error` calls to correctly pass the error as an object property (`{ error }` or `{ err }`) since Pino's first argument needs to be the object when providing a custom message string.
- Fixed reactivity prefixes for `$page` and `$pageStore`.
- Ensured strictly typed signatures for `switchToLanguage` where `"en" | "ja"` is required instead of `string`.
- Set explicit types for implicitly typed `any` variables (`authResult`).

This reduces the warnings and errors generated during static analysis checks.

---
*PR created automatically by Jules for task [7043135047210536583](https://jules.google.com/task/7043135047210536583) started by @kitamura-tetsuo*