### PR TITLE
fix(client): correct logger.error parameter order

### DIFF
--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -114,9 +114,7 @@ async function rotateLogFiles() {
         }
     }
     catch (error) {
-        logger.error("An error occurred during log rotation", {
-            error,
-        });
+        logger.error({ error }, "An error occurred during log rotation");
     }
 }
 
@@ -168,7 +166,7 @@ onMount(async () => {
             await import("../lib/metaDoc.svelte");
             await import("../services");
         } catch (e) {
-            logger.error("Failed to load client-only modules", e);
+            logger.error({ error: e }, "Failed to load client-only modules");
         }
         // Application initialization log
         if (import.meta.env.DEV) {
@@ -195,7 +193,7 @@ onMount(async () => {
                         if (import.meta.env.DEV) logger.info("Service worker update found");
                     });
                 })
-                .catch(err => { logger.error("Service worker registration failed:", err); });
+                .catch(err => { logger.error({ error: err }, "Service worker registration failed:"); });
         }
 
         // Check authentication status

--- a/client/src/routes/projects/new/+page.svelte
+++ b/client/src/routes/projects/new/+page.svelte
@@ -72,7 +72,7 @@ async function createNewContainer() {
         }, 1500);
     }
     catch (err) {
-        logger.error("Error creating new outliner:", err);
+        logger.error({ error: err }, "Error creating new outliner:");
         error = err instanceof Error
             ? err.message
             : "An error occurred while creating the new outliner.";


### PR DESCRIPTION
Fixes the parameter order in calls to `logger.error` within the client application. Specifically, in `client/src/routes/+layout.svelte` and `client/src/routes/projects/new/+page.svelte`, the arguments were passed as `logger.error("Message", error)`. This commit correctly structures them as `logger.error({ error }, "Message")`, ensuring correct error object serialization and resolving type-checking failures in the application build.

---
*PR created automatically by Jules for task [8223522918577802215](https://jules.google.com/task/8223522918577802215) started by @kitamura-tetsuo*