### PR TITLE
fix: resolve service worker sync registration warning and flaky test comment

### DIFF
--- a/client/e2e/new/sidebar.spec.ts
+++ b/client/e2e/new/sidebar.spec.ts
@@ -372,7 +372,7 @@ test.describe("Sidebar Navigation", () => {
     // TODO: This test is skipped because it's flaky. The project list in the sidebar
     // doesn't reliably update when a new project is created in the test environment.
     // This needs to be investigated and fixed.
-    // eslint-disable-next-line no-restricted-syntax
+
     test("should use project name in project links", async ({ page }, testInfo) => {
         test.setTimeout(120000);
 

--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -184,14 +184,17 @@ onMount(async () => {
             navigator.serviceWorker.register("/service-worker.js", { scope: "/" })
                 .then(reg => {
                     if (import.meta.env.DEV) logger.info("Service worker registered successfully");
+                    reg.addEventListener("updatefound", () => {
+                        if (import.meta.env.DEV) logger.info("Service worker update found");
+                    });
+                    return navigator.serviceWorker.ready;
+                })
+                .then(reg => {
                     if ("sync" in reg) {
                         (reg as any).sync.register("sync-ops").catch((err: any) => {
                             logger.warn("Failed to register background sync:", err);
                         });
                     }
-                    reg.addEventListener("updatefound", () => {
-                        if (import.meta.env.DEV) logger.info("Service worker update found");
-                    });
                 })
                 .catch(err => { logger.error({ error: err as Error }, "Service worker registration failed:"); });
         }


### PR DESCRIPTION
[Issues] 
- A console error/warning (`Failed to register background sync: InvalidStateError`) appeared in the demo environment because the code attempted to register `sync-ops` before the Service Worker was fully active. 
- A test in `client/e2e/new/sidebar.spec.ts` had an unused `eslint-disable-next-line no-restricted-syntax` directive.

[Changes]
- Modified `client/src/routes/+layout.svelte` to await `navigator.serviceWorker.ready` before checking for `"sync" in reg` and registering the background sync.
- Removed the unused `eslint-disable-next-line` comment from `client/e2e/new/sidebar.spec.ts`.

[Verification Results]
- Executed `npm run test:unit`, `npm run test:integration`, and `npm run test:e2e` for the client which all passed successfully.
- Executed server and functions test suites which also passed.
- Ran a local script (`check_console_e2e.cjs`) mimicking the client initialization to verify that the `InvalidStateError` warning is no longer logged to the browser console.

---
*PR created automatically by Jules for task [15702383411237115713](https://jules.google.com/task/15702383411237115713) started by @kitamura-tetsuo*