### PR TITLE
test(e2e): fix flaky sidebar project links test

### DIFF
--- a/client/e2e/new/sidebar.spec.ts
+++ b/client/e2e/new/sidebar.spec.ts
@@ -414,7 +414,7 @@ test.describe("Sidebar Navigation", () => {
         // away and back might not reliably trigger firestore listeners in the mocked environment
         await TestHelpers.setAccessibleProjects(page, [firstProjectName, secondProjectName]);
 
-        await page.waitForFunction(() => document.querySelectorAll('.project-item').length >= 2, { timeout: 15000 });
+        await page.waitForFunction(() => document.querySelectorAll(".project-item").length >= 2, { timeout: 15000 });
 
         // Explicitly wait for the project link to appear in the project list
         const projectLink = projectList.locator(".project-item", { hasText: firstProjectName });

--- a/client/e2e/new/sidebar.spec.ts
+++ b/client/e2e/new/sidebar.spec.ts
@@ -369,10 +369,6 @@ test.describe("Sidebar Navigation", () => {
         expect(currentUrl).toMatch(/settings/i);
     });
 
-    // TODO: This test is skipped because it's flaky. The project list in the sidebar
-    // doesn't reliably update when a new project is created in the test environment.
-    // This needs to be investigated and fixed.
-
     test("should use project name in project links", async ({ page }, testInfo) => {
         test.setTimeout(120000);
 
@@ -418,8 +414,10 @@ test.describe("Sidebar Navigation", () => {
         // away and back might not reliably trigger firestore listeners in the mocked environment
         await TestHelpers.setAccessibleProjects(page, [firstProjectName, secondProjectName]);
 
+        await page.waitForFunction(() => document.querySelectorAll('.project-item').length >= 2, { timeout: 15000 });
+
         // Explicitly wait for the project link to appear in the project list
-        const projectLink = projectList.locator(`a:has-text("${firstProjectName}")`);
+        const projectLink = projectList.locator(".project-item", { hasText: firstProjectName });
         await projectLink.waitFor({ state: "visible", timeout: 15000 });
         await expect(projectLink).toBeVisible();
 


### PR DESCRIPTION
[Issues]
The `should use project name in project links` test in `client/e2e/new/sidebar.spec.ts` was marked as flaky due to the project list in the sidebar not reliably updating when a new project is created in the test environment. 

[Changes]
- Removed the TODO comment about the flaky test.
- Modified the locator for the project link in the sidebar to correctly target `.project-item` and use `hasText`.
- Added an explicit `page.waitForFunction` to wait for at least two `.project-item` elements to be rendered in the DOM after manually setting accessible projects, ensuring that the Reactivity finishes updating before Playwright tries to locate the specific project link.

[Verification Results]
- The test `npm run test:e2e --prefix client -- --project=new-4 e2e/new/sidebar.spec.ts` successfully passes reliably.
- `npm run test:unit --prefix client` and `npm run test:integration --prefix client` passed successfully.

---
*PR created automatically by Jules for task [14654319546543837626](https://jules.google.com/task/14654319546543837626) started by @kitamura-tetsuo*