### PR TITLE
test: improve scheduleService test coverage

### DIFF
--- a/client/src/tests/scheduleService.test.ts
+++ b/client/src/tests/scheduleService.test.ts
@@ -138,6 +138,7 @@ it("calls updateSchedule API", async () => {
 });
 
 it("calls exportSchedulesIcal API", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         headers: {

--- a/client/src/tests/scheduleService.test.ts
+++ b/client/src/tests/scheduleService.test.ts
@@ -136,3 +136,33 @@ it("calls updateSchedule API", async () => {
         },
     );
 });
+
+it("calls exportSchedulesIcal API", async () => {
+
+    (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        headers: {
+            get: (key: string) => key === "Content-Disposition" ? 'attachment; filename="test.ics"' : null,
+        },
+        text: () => Promise.resolve("test calendar content"),
+    });
+
+    const { exportSchedulesIcal } = await import("../services/scheduleService");
+    const result = await exportSchedulesIcal("page1");
+
+    expect(result).toBeDefined();
+    expect(result.filename).toBe("test.ics");
+    expect(result.blob).toBeInstanceOf(Blob);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:57070/outliner-d57b0/us-central1/exportSchedulesIcal",
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                idToken: "test-id-token",
+                pageId: "page1",
+            }),
+        },
+    );
+});

--- a/client/src/tests/scheduleService.test.ts
+++ b/client/src/tests/scheduleService.test.ts
@@ -138,7 +138,6 @@ it("calls updateSchedule API", async () => {
 });
 
 it("calls exportSchedulesIcal API", async () => {
-
     (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         headers: {


### PR DESCRIPTION
[Issues]
- The test coverage for `client/src/services/scheduleService.ts` was low (around 40%).
- Needed code health improvements.

[Changes]
- Added unit test for `exportSchedulesIcal` API in `client/src/tests/scheduleService.test.ts`.

[Verification Results]
- Executed `npm run test:unit --prefix client` and `npm run test:integration --prefix client` successfully.
- Code coverage for `scheduleService.ts` improved significantly from 40% to 76.66%.

---
*PR created automatically by Jules for task [7875946995884331919](https://jules.google.com/task/7875946995884331919) started by @kitamura-tetsuo*