### PR TITLE
fix: resolve svelte/no-navigation-without-resolve ESLint warnings

### DIFF
--- a/client/src/components/AuthenticatedHome.svelte
+++ b/client/src/components/AuthenticatedHome.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
     import ProjectSelector from "../components/ProjectSelector.svelte";
     import { getLogger } from "../lib/logger";
     import { yjsStore } from "../stores/yjsStore.svelte";
@@ -16,7 +17,7 @@
             yjsStore.yjsClient = client as any;
 
             logger.info(`Navigating to project page: /${projectName}`);
-            goto(`/${projectName}`);
+            goto(resolve(`/${projectName}`));
         } catch (error) {
             logger.error({ error: error as Error }, "Failed to switch project");
         }
@@ -43,7 +44,7 @@
 
     <!-- Create New Project Link -->
     <div class="action-buttons">
-        <a href="/projects/new" class="new-project-button">
+        <a href={resolve("/projects/new")} class="new-project-button">
             <span class="icon">+</span> Create New Outliner
         </a>
     </div>

--- a/client/src/lib/debug.ts
+++ b/client/src/lib/debug.ts
@@ -1,4 +1,5 @@
 import { goto } from "$app/navigation";
+import { resolve } from "$app/paths";
 import { userManager } from "../auth/UserManager";
 import * as yjsHighService from "../lib/yjsService.svelte";
 import { Items } from "../schema/app-schema";
@@ -24,7 +25,7 @@ export function setupGlobalDebugFunctions() {
                 },
             ) => {
                 await Promise.resolve();
-                return goto(url, opts);
+                return goto(resolve(url), opts);
             };
         } else {
             try {

--- a/client/src/routes/[project]/+layout.svelte
+++ b/client/src/routes/[project]/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { onMount } from "svelte";
 import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
 import { userManager } from "../../auth/UserManager";
 import { getYjsClientByProjectTitle } from "../../services";
 import { yjsStore } from "../../stores/yjsStore.svelte";
@@ -45,13 +46,13 @@ async function loadProject(projectNameFromParam?: string) {
             // Only redirect if user is authenticated (to avoid redirecting during initial load)
             // If user is not authenticated, the onMount listener will retry once auth settles.
             if (userManager.getCurrentUser()) {
-                goto("/error/project-unavailable");
+                goto(resolve("/error/project-unavailable"));
             }
         }
     } catch (err) {
         console.error("Failed to load project:", err);
         if (err instanceof Error && err.message.includes("Access Denied")) {
-            goto("/error/project-unavailable");
+            goto(resolve("/error/project-unavailable"));
         }
     }
 }

--- a/client/src/routes/[project]/+page.svelte
+++ b/client/src/routes/[project]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
     import { page } from "$app/stores";
     import { onDestroy, onMount } from "svelte";
     import { userManager } from "../../auth/UserManager";
@@ -80,13 +81,13 @@
         const pageName = event.detail.pageName;
 
         if (pageName) {
-            goto(`/${projectName}/${pageName}`);
+            goto(resolve(`/${projectName}/${pageName}`));
         }
     }
 
     // Return to home
     function goHome() {
-        goto("/");
+        goto(resolve("/"));
     }
 
     $effect(() => {

--- a/client/src/routes/[project]/[page]/+page.svelte
+++ b/client/src/routes/[project]/[page]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
     // Use SvelteKit page store from $app/stores (not $app/state)
     import { page } from "$app/stores";
     import { onDestroy, onMount } from "svelte";
@@ -314,20 +315,20 @@
 
     // Return to Home
     function goHome() {
-        goto("/");
+        goto(resolve("/"));
     }
 
     // Return to Project Page
     function goToProject() {
-        goto(`/${projectName}`);
+        goto(resolve(`/${projectName}`));
     }
 
     function goToSchedule() {
-        goto(`/${projectName}/${pageName}/schedule`);
+        goto(resolve(`/${projectName}/${pageName}/schedule`));
     }
 
     function goToGraphView() {
-        goto(`/${projectName}/graph`);
+        goto(resolve(`/${projectName}/graph`));
     }
 
     // Auxiliary button to add items from top of screen (for E2E stabilization)

--- a/client/src/routes/debug/+page.svelte
+++ b/client/src/routes/debug/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { resolve } from "$app/paths";
 import { browser } from "$app/environment";
 import {
     onDestroy,
@@ -280,7 +281,7 @@ onDestroy(() => {
     </div>
 
     <div class="back-link">
-        <a href="/">Return to Main Page</a>
+        <a href={resolve("/")}>Return to Main Page</a>
     </div>
 </main>
 

--- a/client/src/routes/demo/+page.svelte
+++ b/client/src/routes/demo/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { resolve } from "$app/paths";
     import { onMount, onDestroy } from "svelte";
     import OutlinerBase from "../../components/OutlinerBase.svelte";
     import { getLogger } from "../../lib/logger";
@@ -104,7 +105,7 @@
     <div class="mb-4">
         <!-- Breadcrumb Navigation -->
         <nav class="mb-2 flex items-center text-sm text-gray-600">
-            <a href="/" class="text-blue-600 hover:text-blue-800 hover:underline">
+            <a href={resolve("/")} class="text-blue-600 hover:text-blue-800 hover:underline">
                 Home
             </a>
             <span class="mx-2">/</span>

--- a/client/src/routes/error/project-unavailable/+page.svelte
+++ b/client/src/routes/error/project-unavailable/+page.svelte
@@ -1,5 +1,6 @@
 <script>
     import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
 </script>
 
 <div class="flex flex-col items-center justify-center min-h-screen text-center p-4">
@@ -9,7 +10,7 @@
     </p>
     <button
         class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-        on:click={() => goto("/")}
+        on:click={() => goto(resolve("/"))}
     >
         Go Home
     </button>

--- a/client/src/routes/projects/new/+page.svelte
+++ b/client/src/routes/projects/new/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
 import {
     onDestroy,
     onMount,
@@ -68,7 +69,7 @@ async function createNewContainer() {
 
         // Navigate to the created project page after 1.5 seconds
         setTimeout(() => {
-            goto("/" + containerName);
+            goto(resolve("/" + containerName));
         }, 1500);
     }
     catch (err) {
@@ -184,7 +185,7 @@ onDestroy(() => {
 
     <div class="mt-6 text-center">
         <a
-            href="/"
+            href={resolve("/")}
             class="rounded-md px-2 py-1 text-blue-600 hover:text-blue-800 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
             Back to Home

--- a/client/src/routes/settings/+page.svelte
+++ b/client/src/routes/settings/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { resolve } from "$app/paths";
     import { projectStore } from "../../stores/projectStore.svelte";
     import { userPreferencesStore } from "../../stores/UserPreferencesStore.svelte";
 </script>
@@ -15,7 +16,7 @@
                 {#each projectStore.projects as project (project.id)}
                     <li>
                         <a
-                            href="/settings/{encodeURIComponent(project.name)}"
+                            href={resolve(`/settings/${encodeURIComponent(project.name)}`)}
                             class="text-blue-600 hover:text-blue-800 hover:underline text-lg"
                         >
                             {project.name || project.id}

--- a/client/src/routes/settings/[project]/+page.svelte
+++ b/client/src/routes/settings/[project]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
     import { page } from "$app/stores";
 
     import {
@@ -85,7 +86,7 @@
                    const updated = projectStore.projects.find(p => p.name === newTitle);
                    if (updated) {
                        clearInterval(checkInterval);
-                       goto(`/settings/${encodeURIComponent(newTitle)}`, { replaceState: true });
+                       goto(resolve(`/settings/${encodeURIComponent(newTitle)}`), { replaceState: true });
                    }
                 }, 100);
 
@@ -93,7 +94,7 @@
                 setTimeout(() => {
                     clearInterval(checkInterval);
                     // Fallback redirect
-                    goto(`/settings/${encodeURIComponent(newTitle)}`, { replaceState: true });
+                    goto(resolve(`/settings/${encodeURIComponent(newTitle)}`), { replaceState: true });
                 }, 5000);
 
             } else {
@@ -160,7 +161,7 @@
 
 <div class="container mx-auto px-4 py-8">
     <div class="mb-4">
-        <a href="/settings" class="text-blue-600 hover:underline">&larr; Back to Settings</a>
+        <a href={resolve("/settings")} class="text-blue-600 hover:underline">&larr; Back to Settings</a>
     </div>
 
     {#if isLoading}

--- a/client/src/routes/share/[token]/+page.svelte
+++ b/client/src/routes/share/[token]/+page.svelte
@@ -4,6 +4,7 @@
     import { authStore } from "$stores/authStore.svelte";
     import { userManager } from "../../../auth/UserManager";
     import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
 
     let token = $derived($page.params.token);
     let status = $state<"loading" | "success" | "error" | "unauthenticated">("loading");
@@ -50,7 +51,7 @@
             status = "success";
             message = "Successfully joined! Redirecting to project...";
             setTimeout(() => {
-                goto(`/${data.projectId}`);
+                goto(resolve(`/${data.projectId}`));
             }, 1500);
         } catch (e: any) {
             status = "error";
@@ -68,13 +69,13 @@
         
         {#if status === 'unauthenticated'}
             <div class="actions">
-                <a href="/" class="login-btn">Go to Login</a>
+                <a href={resolve("/")} class="login-btn">Go to Login</a>
             </div>
         {/if}
 
         {#if status === 'error'}
             <div class="actions">
-                <a href="/" class="home-btn">Go Home</a>
+                <a href={resolve("/")} class="home-btn">Go Home</a>
             </div>
         {/if}
         


### PR DESCRIPTION
[Issues] The ESLint rule `svelte/no-navigation-without-resolve` reported 14 warnings across the client application. These warnings occurred because navigation paths in `goto()` calls and `<a>` tag `href` attributes were not using the `resolve()` utility from SvelteKit's `$app/paths`. Failing to use `resolve()` can lead to broken navigation if the application is deployed under a subpath or base path.

[Changes] Added `import { resolve } from "$app/paths";` to the affected components and wrapped the URLs passed to `goto()` and the values assigned to `href` with `resolve()`.

Modified files:
- `client/src/components/AuthenticatedHome.svelte`
- `client/src/lib/debug.ts`
- `client/src/routes/[project]/+layout.svelte`
- `client/src/routes/[project]/+page.svelte`
- `client/src/routes/[project]/[page]/+page.svelte`
- `client/src/routes/debug/+page.svelte`
- `client/src/routes/demo/+page.svelte`
- `client/src/routes/error/project-unavailable/+page.svelte`
- `client/src/routes/projects/new/+page.svelte`
- `client/src/routes/settings/+page.svelte`
- `client/src/routes/settings/[project]/+page.svelte`
- `client/src/routes/share/[token]/+page.svelte`

[Verification Results] Ran `cd client && npm run test:unit` and verified that tests still pass. Also ran `npx eslint .` within the `client` directory and confirmed that no warnings related to `svelte/no-navigation-without-resolve` are reported anymore. Removed all generated temporary/debug files before submission.

---
*PR created automatically by Jules for task [9594645709998590546](https://jules.google.com/task/9594645709998590546) started by @kitamura-tetsuo*