### PR TITLE
refactor: remove debug console logs from sqlService.ts

### DIFF
--- a/client/src/services/sqlService.ts
+++ b/client/src/services/sqlService.ts
@@ -37,6 +37,7 @@ if (typeof window !== "undefined") {
 export async function initDb() {
     if (db) return;
 
+
     // Load WASM from appropriate path in test or production environment
     if (typeof process !== "undefined" && (process.env.NODE_ENV === "test" || process.env.NODE_ENV === "production")) {
         const fs = await import("fs");
@@ -64,6 +65,7 @@ export async function initDb() {
         if (!wasmBinary) {
             throw new Error("Could not find sql-wasm.wasm file in any expected location");
         }
+
 
         SQL = await initSqlJs({
             wasmBinary: wasmBinary,
@@ -96,6 +98,7 @@ export async function initDb() {
 }
 
 function extendQuery(sql: string): { sql: string; aliases: string[]; tableMap: Record<string, string>; } {
+
     // Process only the last SELECT statement
     const lastSelectIndex = sql.toUpperCase().lastIndexOf("SELECT");
     if (lastSelectIndex === -1) {
@@ -228,6 +231,5 @@ export function applyEdit(info: EditInfo, value: unknown) {
     if (currentSelect) {
         rawExec(currentSelect);
         runQuery(currentSelect);
-    } else {
     }
 }

--- a/client/src/services/sqlService.ts
+++ b/client/src/services/sqlService.ts
@@ -37,7 +37,6 @@ if (typeof window !== "undefined") {
 export async function initDb() {
     if (db) return;
 
-
     // Load WASM from appropriate path in test or production environment
     if (typeof process !== "undefined" && (process.env.NODE_ENV === "test" || process.env.NODE_ENV === "production")) {
         const fs = await import("fs");
@@ -65,7 +64,6 @@ export async function initDb() {
         if (!wasmBinary) {
             throw new Error("Could not find sql-wasm.wasm file in any expected location");
         }
-
 
         SQL = await initSqlJs({
             wasmBinary: wasmBinary,
@@ -98,7 +96,6 @@ export async function initDb() {
 }
 
 function extendQuery(sql: string): { sql: string; aliases: string[]; tableMap: Record<string, string>; } {
-
     // Process only the last SELECT statement
     const lastSelectIndex = sql.toUpperCase().lastIndexOf("SELECT");
     if (lastSelectIndex === -1) {

--- a/client/src/services/sqlService.ts
+++ b/client/src/services/sqlService.ts
@@ -37,7 +37,6 @@ if (typeof window !== "undefined") {
 export async function initDb() {
     if (db) return;
 
-    console.log("Initializing SQL.js database...");
 
     // Load WASM from appropriate path in test or production environment
     if (typeof process !== "undefined" && (process.env.NODE_ENV === "test" || process.env.NODE_ENV === "production")) {
@@ -67,7 +66,6 @@ export async function initDb() {
             throw new Error("Could not find sql-wasm.wasm file in any expected location");
         }
 
-        console.log(`Loading WASM from: ${wasmPath}`);
 
         SQL = await initSqlJs({
             wasmBinary: wasmBinary,
@@ -97,23 +95,18 @@ export async function initDb() {
 
     db = new SQL.Database();
     worker = new SyncWorker(db as unknown as SqlJsDatabase);
-    console.log("SQL.js database initialized successfully");
 }
 
 function extendQuery(sql: string): { sql: string; aliases: string[]; tableMap: Record<string, string>; } {
-    console.log("extendQuery called with:", sql);
 
     // Process only the last SELECT statement
     const lastSelectIndex = sql.toUpperCase().lastIndexOf("SELECT");
-    console.log("lastSelectIndex:", lastSelectIndex);
     if (lastSelectIndex === -1) {
-        console.log("No SELECT found, returning original");
         return { sql, aliases: [], tableMap: {} };
     }
 
     const selectPart = sql.slice(lastSelectIndex);
     const beforeSelect = sql.slice(0, lastSelectIndex);
-    console.log("selectPart:", selectPart);
 
     // Process FROM and JOIN separately
     const fromRegex =
@@ -122,46 +115,35 @@ function extendQuery(sql: string): { sql: string; aliases: string[]; tableMap: R
         /\bjoin\s+([a-zA-Z0-9_]+)(?:\s+(?:as\s+)?([a-zA-Z0-9_]+))?(?=\s+(?:on|join|where|group|order|limit|;|$)|\s*;|\s*$)/gi;
     const tableMap: Record<string, string> = {};
     let match;
-    console.log("Testing regex against:", selectPart);
     // Process FROM clause
     while ((match = fromRegex.exec(selectPart)) !== null) {
-        console.log("FROM match:", match);
         const table = match[1];
         const alias = match[2] || table;
-        console.log("FROM Table:", table, "Alias:", alias);
         tableMap[alias] = table;
     }
 
     // Process JOIN clause
     while ((match = joinRegex.exec(selectPart)) !== null) {
-        console.log("JOIN match:", match);
         const table = match[1];
         const alias = match[2] || table;
-        console.log("JOIN Table:", table, "Alias:", alias);
         tableMap[alias] = table;
     }
     if (Object.keys(tableMap).length === 0) {
-        console.log("No aliases found, returning original");
         return { sql, aliases: [], tableMap };
     }
 
     const selectMatch = selectPart.match(/select\s+([\s\S]+?)\s+from/i);
-    console.log("selectMatch:", selectMatch);
     if (!selectMatch) {
-        console.log("No select match found, returning original");
         const aliases = Object.keys(tableMap);
         return { sql, aliases, tableMap };
     }
 
     const selectClause = selectMatch[1];
-    console.log("selectClause:", selectClause);
     const aliasesInSelect = Object.keys(tableMap);
     const additions = aliasesInSelect
         .filter(a => !new RegExp(`${a}.id`, "i").test(selectClause))
         .map(a => `${a}.id AS ${a}_pk`);
-    console.log("additions:", additions);
     if (additions.length === 0) {
-        console.log("No additions needed, returning original");
         return { sql, aliases: aliasesInSelect, tableMap };
     }
 
@@ -172,15 +154,12 @@ function extendQuery(sql: string): { sql: string; aliases: string[]; tableMap: R
     const modifiedSelectPart = selectPart.replace(selectMatch[0], `SELECT ${newSelect} FROM`);
     const modified = beforeSelect + modifiedSelectPart;
 
-    console.log("Extended query result:", { original: sql, modified, aliases, tableMap });
     return { sql: modified, aliases, tableMap };
 }
 
 export function runQuery(sql: string) {
-    console.log("Running query:", sql);
     if (!db) throw new Error("DB not initialized");
     const { sql: extended, tableMap } = extendQuery(sql);
-    console.log("Extended query:", extended);
     const idx = extended.toUpperCase().lastIndexOf("SELECT");
     currentSelect = idx >= 0 ? extended.slice(idx) : extended;
     const results = db.exec(extended);
@@ -244,19 +223,14 @@ export function rawExec(sql: string) {
 }
 
 export function applyEdit(info: EditInfo, value: unknown) {
-    console.log("Applying edit:", info, "value:", value);
     if (!worker) {
-        console.log("No worker available");
         return;
     }
     const op: Op = { table: info.table, pk: info.pk, column: info.column, value };
     worker.applyOp(op);
-    console.log("Applied operation:", op);
     if (currentSelect) {
-        console.log("Re-running query:", currentSelect);
         rawExec(currentSelect);
         runQuery(currentSelect);
     } else {
-        console.log("No currentSelect to re-run");
     }
 }


### PR DESCRIPTION
[Issues]
Numerous debug `console.log` statements were left in `client/src/services/sqlService.ts`, contributing to console noise in the application and potentially cluttering logs in production.

[Changes]
Removed all `console.log` statements from `client/src/services/sqlService.ts`.

[Verification Results]
Verified changes by running the complete suite of unit tests in `client` via `npm run test:unit`, which passed successfully with no regressions.

---
*PR created automatically by Jules for task [6468555593583872297](https://jules.google.com/task/6468555593583872297) started by @kitamura-tetsuo*