### PR TITLE
refactor: replace for...of loops over Items proxies with indexed loops

### DIFF
--- a/client/src/components/LinkPreview.svelte
+++ b/client/src/components/LinkPreview.svelte
@@ -96,14 +96,17 @@ async function loadPreviewContent() {
             hasMoreItems = false;
             if (foundPage.items) {
                 let count = 0;
-                for (const item of foundPage.items) {
-                    if (count < 5) {
-                        previewItems.push({ id: item.id, text: item.text });
-                    } else {
-                        hasMoreItems = true;
-                        break;
+                for (let i = 0; i < foundPage.items.length; i++) {
+                    const item = foundPage.items.at(i);
+                    if (item) {
+                        if (count < 5) {
+                            previewItems.push({ id: item.id, text: item.text });
+                        } else {
+                            hasMoreItems = true;
+                            break;
+                        }
+                        count++;
                     }
-                    count++;
                 }
             }
         } else {

--- a/client/src/components/OutlinerItem.svelte
+++ b/client/src/components/OutlinerItem.svelte
@@ -567,7 +567,8 @@ const aliasTargetIdEffective = $derived.by(() => {
                 const mappedId = map ? map[String(targetId)] : undefined;
                 const curPage: any = w?.generalStore?.currentPage;
                 if (mappedId && curPage?.items) {
-                    for (const cand of curPage.items) {
+                    for (let i = 0; i < curPage.items.length; i++) {
+                        const cand = curPage.items.at(i);
                         if (String(cand?.id) === String(mappedId)) {
                             try { cand.addAttachment(url); } catch { try { (cand as any).attachments.push([url]); } catch {} }
                             try { if (IS_TEST) window.dispatchEvent(new CustomEvent('item-attachments-changed', { detail: { id: mappedId } })); } catch {}
@@ -1705,7 +1706,8 @@ async function handleDrop(event: DragEvent | CustomEvent) {
                                 const mappedId = map ? map[String(model.id)] : undefined;
                                 const curPage:any = w?.generalStore?.currentPage;
                                 if (mappedId && curPage?.items) {
-                                    for (const cand of curPage.items) {
+                                    for (let i = 0; i < curPage.items.length; i++) {
+                                        const cand = curPage.items.at(i);
                                         if (String(cand?.id) === String(mappedId)) { try { cand?.addAttachment?.(localUrl); } catch { try { (cand as any)?.attachments?.push?.([localUrl]); } catch {} } try { if (IS_TEST) window.dispatchEvent(new CustomEvent('item-attachments-changed', { detail: { id: mappedId } })); } catch {} break; }
                                     }
                                 }

--- a/client/src/lib/linkPreviewHandler.ts
+++ b/client/src/lib/linkPreviewHandler.ts
@@ -133,7 +133,8 @@ function createPreviewContent(pageName: string, projectName?: string): HTMLEleme
         ul.style.padding = "0 0 0 20px";
 
         if (foundPage.items) {
-            for (const item of foundPage.items) {
+            for (let i = 0; i < foundPage.items.length; i++) {
+                const item = foundPage.items.at(i);
                 hasItems = true;
                 if (count < 5) {
                     if (item) {

--- a/client/src/lib/pagePreview.ts
+++ b/client/src/lib/pagePreview.ts
@@ -46,7 +46,8 @@ export function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDept
         try {
             if (item.items) {
                 let i = 0;
-                for (const child of item.items) {
+                for (let idx = 0; idx < item.items.length; idx++) {
+                    const child = item.items.at(idx);
                     if (i++ > 10) break;
                     if (child) traverse(child, currentDepth + 1);
                     if (lines.length >= maxLines && image) return;
@@ -61,7 +62,8 @@ export function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDept
     try {
         if (pageItem.items) {
             let i = 0;
-            for (const child of pageItem.items) {
+            for (let idx = 0; idx < pageItem.items.length; idx++) {
+                const child = pageItem.items.at(idx);
                 if (i++ > 20) break;
                 if (child) traverse(child, 1);
                 if (lines.length >= maxLines && image) break;

--- a/client/src/stores/GeneralStore_pageExists.test.ts
+++ b/client/src/stores/GeneralStore_pageExists.test.ts
@@ -31,8 +31,9 @@ describe("GeneralStore Page Existence", () => {
         // We can manually update the item text.
         // Find the item
         let itemA;
-        for (const item of project.items) {
-            if (item.text === "Page A") {
+        for (let i = 0; i < project.items.length; i++) {
+            const item = project.items.at(i);
+            if (item?.text === "Page A") {
                 itemA = item;
                 break;
             }


### PR DESCRIPTION
[Issues] 
The `Items` wrapper class in `app-schema.ts` uses a Proxy to intercept index access, but iterating with `for...of` bypasses this trap because it invokes `[Symbol.iterator]`. This can cause context loss and result in improperly wrapped Item instances.

[Changes] 
Replaced `for...of` iteration over `.items` properties with indexed loops (e.g., `for (let i = 0; i < curPage.items.length; i++)` with `curPage.items.at(i)`) across the codebase.
Specifically modified:
- `client/src/components/OutlinerItem.svelte`
- `client/src/components/LinkPreview.svelte`
- `client/src/lib/linkPreviewHandler.ts`
- `client/src/lib/pagePreview.ts`
- `client/src/stores/GeneralStore_pageExists.test.ts`

[Verification Results] 
Run `npm run test:unit` and `npm run test:integration` inside `client/`. All tests passed successfully. Code review confirmed the changes are correct and safe.

---
*PR created automatically by Jules for task [3354504282620623421](https://jules.google.com/task/3354504282620623421) started by @kitamura-tetsuo*