### PR TITLE
test(client): fix failing DOM unit tests by configuring jsdom environment

### DIFF
--- a/client/src/utils/ScrapboxFormatter.test.ts
+++ b/client/src/utils/ScrapboxFormatter.test.ts
@@ -1,4 +1,7 @@
 import { beforeAll, describe, expect, it } from "vitest";
+/**
+ * @vitest-environment jsdom
+ */
 import { ScrapboxFormatter } from "./ScrapboxFormatter";
 
 describe("ScrapboxFormatter", () => {

--- a/client/src/utils/domCursorUtils.test.ts
+++ b/client/src/utils/domCursorUtils.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+/**
+ * @vitest-environment jsdom
+ */
 import { calculateGlobalOffset } from "./domCursorUtils";
 
 describe("calculateGlobalOffset", () => {


### PR DESCRIPTION
[Issues]
Several unit tests in `client/src/utils/domCursorUtils.test.ts` and `client/src/utils/ScrapboxFormatter.test.ts` were failing with `ReferenceError: document is not defined` because they were executing in the default Node.js environment without DOM APIs.

[Changes]
Added the `/** @vitest-environment jsdom */` pragma at the top of the affected test files to explicitly configure Vitest to use the jsdom environment for these specific test suites.

[Verification Results]
Verified that `npm run test:unit` now successfully passes for these files and the rest of the unit test suite without throwing `ReferenceError`s.

---
*PR created automatically by Jules for task [14327751602645007637](https://jules.google.com/task/14327751602645007637) started by @kitamura-tetsuo*