### PR TITLE
feat: implement clearAll method in test-data-seeder.ts

### DIFF
--- a/scripts/test-data-seeder.ts
+++ b/scripts/test-data-seeder.ts
@@ -55,9 +55,21 @@ class TestDataSeeder {
         });
     }
 
-    async clearAll() {
-        console.log("Clearing all test data");
-        // TODO: Implement data clearing logic
+    async clearAll(projectId: string) {
+        console.log(`Clearing all test data for project: ${projectId}`);
+        await this._withProject(projectId, (project) => {
+            const ydoc = project.ydoc;
+
+            // Clear orderedTree completely
+            const orderedTree = ydoc.getMap("orderedTree");
+            Array.from(orderedTree.keys()).forEach(key => orderedTree.delete(key));
+
+            // Clear items map completely
+            const itemsMap = ydoc.getMap("items");
+            Array.from(itemsMap.keys()).forEach(key => itemsMap.delete(key));
+
+            console.log(`Project "${projectId}" data cleared successfully.`);
+        });
     }
 
     private async _withProject(projectId: string, action: (project: Project) => Promise<void> | void) {
@@ -146,13 +158,19 @@ async function main() {
             await seeder.addTextNode(projectId, pageId, text);
             break;
         }
-        case "clear-all":
-            await seeder.clearAll();
+        case "clear-all": {
+            const clearProjectId = args[1];
+            if (!clearProjectId) {
+                console.error("Usage: clear-all <projectId>");
+                process.exit(1);
+            }
+            await seeder.clearAll(clearProjectId);
             break;
+        }
         default:
             console.error(`Unknown command: ${command}`);
             console.log(
-                "Available commands: create-project <name> <pages...>, add-page <projectId> <title>, add-text-node <projectId> <pageId> <text>, clear-all",
+                "Available commands: create-project <name> <pages...>, add-page <projectId> <title>, add-text-node <projectId> <pageId> <text>, clear-all <projectId>",
             );
             process.exit(1);
     }


### PR DESCRIPTION
[Issues]
- The `clearAll` method in `scripts/test-data-seeder.ts` was unimplemented and contained a TODO comment to add data clearing logic.

[Changes]
- Updated `clearAll` method to take a `projectId` as an argument.
- Implemented clearing logic by connecting to the Yjs document via `_withProject` and clearing the keys of both `orderedTree` and `items` maps.
- Updated the `main()` function's `clear-all` command parsing to require and pass the `projectId` argument.

[Verification Results]
- Executed `scripts/test-data-seeder.ts clear-all 1234` manually.
- Ran tests inside `scripts/` using `vitest run`.
- Confirmed that code successfully establishes WebSocket connections and applies mutations gracefully per existing `Yjs` conventions.

---
*PR created automatically by Jules for task [16123475496558250469](https://jules.google.com/task/16123475496558250469) started by @kitamura-tetsuo*