### PR TITLE
Fix: Correct API URL resolution for seed-demo SvelteKit endpoint

### DIFF
--- a/client/src/routes/api/seed-demo/+server.ts
+++ b/client/src/routes/api/seed-demo/+server.ts
@@ -3,7 +3,18 @@ import type { RequestHandler } from "./$types";
 
 export const POST: RequestHandler = async () => {
     try {
-        const apiBaseUrl = process.env.VITE_API_SERVER_URL || "http://127.0.0.1:7091";
+        let apiBaseUrl = process.env.VITE_YJS_API_URL;
+
+        // Fallback to deriving the API URL from the WebSocket URL if available
+        if (!apiBaseUrl && process.env.VITE_YJS_WS_URL) {
+            apiBaseUrl = process.env.VITE_YJS_WS_URL.replace(/^ws(s)?:\/\//, "http$1://");
+        }
+
+        // Final fallback to the default API server URL
+        if (!apiBaseUrl) {
+            apiBaseUrl = process.env.VITE_API_SERVER_URL || "http://127.0.0.1:7091";
+        }
+
         const response = await fetch(`${apiBaseUrl}/api/seed-demo`, {
             method: "POST",
             headers: {


### PR DESCRIPTION
[Issues]
In the production environment, the `/api/seed-demo` endpoint attempts to connect to the Node.js server (Hocuspocus Express backend) using the `process.env.VITE_API_SERVER_URL`. However, in `.env.production`, this URL points to the Firebase Hosting domain (`https://outliner-d57b0.web.app`), which routes `/api` requests to Firebase Cloud Functions rather than the Node server running alongside the Yjs WebSocket. As a result, requests to seed the demo fail because the endpoint doesn't exist on Firebase Functions.

[Changes]
Modified `client/src/routes/api/seed-demo/+server.ts` to implement a better URL resolution strategy. The endpoint now:
1. Checks for `VITE_YJS_API_URL`.
2. Falls back to replacing `ws://`/`wss://` with `http://`/`https://` from `VITE_YJS_WS_URL`.
3. Falls back to `VITE_API_SERVER_URL` as a final default.
This ensures the Express endpoint correctly resolves the Node.js server URL, especially in environments where the HTTP API and WebSocket use the same domain separated from Firebase Hosting.

[Verification Results]
- `npm run test` in `server/` passes successfully.
- `npm run test:unit` and `npm run test:e2e:basic` in `client/` ran effectively without regressions directly related to this backend logic change.
- Format and linters pass (`npm run lint:diff-lines`).

---
*PR created automatically by Jules for task [9302490628186016279](https://jules.google.com/task/9302490628186016279) started by @kitamura-tetsuo*