### PR TITLE
fix: address TypeScript explicit any and logger issues in new project page

### DIFF
--- a/client/src/routes/projects/new/+page.svelte
+++ b/client/src/routes/projects/new/+page.svelte
@@ -24,7 +24,7 @@ let createdContainerId: string | undefined = $state(undefined);
 
 // Handle successful authentication
 async function handleAuthSuccess(authResult: unknown) {
-    logger.info("Authentication success:", authResult);
+    logger.info({ authResult }, "Authentication success:");
     isAuthenticated = true;
 }
 
@@ -47,7 +47,7 @@ async function createNewContainer() {
 
     try {
         // Dispose and reset the current client
-        const client = yjsStore.yjsClient as any;
+        const client = yjsStore.yjsClient;
         if (client) {
             client.dispose?.();
             yjsStore.yjsClient = undefined;
@@ -63,7 +63,7 @@ async function createNewContainer() {
         const newClient = await yjsHighService.createNewProject(containerName, newProjectId);
 
         // Update the store
-        yjsStore.yjsClient = newClient as any;
+        yjsStore.yjsClient = newClient;
 
         success = `New outliner created! (ID: ${createdContainerId})`;
 


### PR DESCRIPTION
[Issues] 
- TypeScript explicit `any` warnings were raised in `client/src/routes/projects/new/+page.svelte` due to unnecessary type casting of `yjsStore.yjsClient`.
- `logger.info` was using an invalid parameter order, leading to Svelte-check overload mismatch errors.

[Changes] 
- Removed `as any` casts from the `yjsClient` references in the project creation page, as `YjsClient` natively implements the required `dispose` method.
- Refactored `logger.info("Authentication success:", authResult)` to `logger.info({ authResult }, "Authentication success:")` to comply with the project's strict structured logging format.

[Verification Results] 
- Ran `npx svelte-check` in the client directory, confirming zero typing or overload errors in the modified file.
- Executed `npm run test:unit` in the client workspace successfully.

---
*PR created automatically by Jules for task [5172765836766752556](https://jules.google.com/task/5172765836766752556) started by @kitamura-tetsuo*