### PR TITLE
refactor(lint): incrementally replace explicit 'any' with strict types

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -96,7 +96,7 @@ export default defineConfig({
         ...(process.env.PLAYWRIGHT_JSON_OUTPUT_NAME
             ? [["json", { outputFile: process.env.PLAYWRIGHT_JSON_OUTPUT_NAME }]]
             : []),
-    ] as any,
+    ] as import("@playwright/test").ReporterDescription[],
     // Extend test execution timeout (to accommodate environment initialization fluctuations)
     // Extended to 120 seconds because connection to Hocuspocus and Yjs synchronization may take time
     timeout: 120 * 1000,

--- a/client/src/lib/cursor/CursorNavigationUtils.ts
+++ b/client/src/lib/cursor/CursorNavigationUtils.ts
@@ -3,7 +3,7 @@ import { store as generalStore } from "../../stores/store.svelte";
 
 function collectChildren(node: Item): Item[] {
     const items = node.items as Iterable<Item> | undefined;
-    if (!items || typeof (items as any)[Symbol.iterator] !== "function") {
+    if (!items || typeof (items as Record<symbol, unknown>)[Symbol.iterator] !== "function") {
         return [];
     }
 

--- a/client/src/lib/env.ts
+++ b/client/src/lib/env.ts
@@ -12,7 +12,8 @@ export function getEnv(key: string, defaultValue: string = ""): string {
     const isTestEnv = (typeof import.meta !== "undefined" && import.meta.env?.MODE === "test")
         || (typeof process !== "undefined" && process.env?.NODE_ENV === "test")
         || (typeof window !== "undefined" && window.localStorage?.getItem?.("VITE_IS_TEST") === "true")
-        || (typeof window !== "undefined" && (window as Window & typeof globalThis & { __E2E__?: boolean }).__E2E__ === true);
+        || (typeof window !== "undefined"
+            && (window as Window & typeof globalThis & { __E2E__?: boolean; }).__E2E__ === true);
 
     // Processing specific to the test environment
     if (isTestEnv) {

--- a/client/src/lib/env.ts
+++ b/client/src/lib/env.ts
@@ -12,7 +12,7 @@ export function getEnv(key: string, defaultValue: string = ""): string {
     const isTestEnv = (typeof import.meta !== "undefined" && import.meta.env?.MODE === "test")
         || (typeof process !== "undefined" && process.env?.NODE_ENV === "test")
         || (typeof window !== "undefined" && window.localStorage?.getItem?.("VITE_IS_TEST") === "true")
-        || (typeof window !== "undefined" && (window as any).__E2E__ === true);
+        || (typeof window !== "undefined" && (window as Window & typeof globalThis & { __E2E__?: boolean }).__E2E__ === true);
 
     // Processing specific to the test environment
     if (isTestEnv) {

--- a/client/src/lib/firebase-app.ts
+++ b/client/src/lib/firebase-app.ts
@@ -14,7 +14,10 @@ function validateFirebaseConfig() {
         "VITE_FIREBASE_APP_ID",
     ];
 
-    const metaEnv = ((typeof import.meta !== "undefined" && import.meta.env) || {}) as Record<string, string | undefined>;
+    const metaEnv = ((typeof import.meta !== "undefined" && import.meta.env) || {}) as Record<
+        string,
+        string | undefined
+    >;
     const missingVars = requiredEnvVars.filter(varName => !metaEnv[varName]);
 
     if (missingVars.length > 0) {
@@ -28,7 +31,10 @@ function validateFirebaseConfig() {
 function getFirebaseConfig() {
     validateFirebaseConfig();
 
-    const metaEnv = ((typeof import.meta !== "undefined" && import.meta.env) || {}) as Record<string, string | undefined>;
+    const metaEnv = ((typeof import.meta !== "undefined" && import.meta.env) || {}) as Record<
+        string,
+        string | undefined
+    >;
 
     const getProjectId = () => {
         if (typeof window !== "undefined") {

--- a/client/src/lib/firebase-app.ts
+++ b/client/src/lib/firebase-app.ts
@@ -14,7 +14,7 @@ function validateFirebaseConfig() {
         "VITE_FIREBASE_APP_ID",
     ];
 
-    const metaEnv = ((typeof import.meta !== "undefined" && import.meta.env) || {}) as any;
+    const metaEnv = ((typeof import.meta !== "undefined" && import.meta.env) || {}) as Record<string, string | undefined>;
     const missingVars = requiredEnvVars.filter(varName => !metaEnv[varName]);
 
     if (missingVars.length > 0) {
@@ -28,7 +28,7 @@ function validateFirebaseConfig() {
 function getFirebaseConfig() {
     validateFirebaseConfig();
 
-    const metaEnv = ((typeof import.meta !== "undefined" && import.meta.env) || {}) as any;
+    const metaEnv = ((typeof import.meta !== "undefined" && import.meta.env) || {}) as Record<string, string | undefined>;
 
     const getProjectId = () => {
         if (typeof window !== "undefined") {

--- a/client/src/lib/linkPreviewHandler.ts
+++ b/client/src/lib/linkPreviewHandler.ts
@@ -88,7 +88,7 @@ function createPreviewContent(pageName: string, projectName?: string): HTMLEleme
 
     // Apply styles
     Object.entries(PREVIEW_STYLES).forEach(([key, value]) => {
-        previewElement.style[key as any] = value;
+        previewElement.style[key as keyof CSSStyleDeclaration] = value;
     });
 
     // Handle internal project links


### PR DESCRIPTION
[Issues]
- The codebase currently has strict TypeScript linting rules (like `@typescript-eslint/no-explicit-any`) downgraded to warnings due to thousands of violations, with a TODO in `client/eslint.config.js` indicating the need to fix these incrementally.
- Leaving `any` types unresolved weakens the static analysis provided by TypeScript, making the application more prone to runtime errors.

[Changes]
- Fixed 6 occurrences of `any` types across the following files with minimal modifications:
  - `client/src/lib/cursor/CursorNavigationUtils.ts`: Type casted iteration to `Record<symbol, unknown>` instead of `any`.
  - `client/src/lib/env.ts`: Correctly typed `window` via global type augmentation for `__E2E__` checks.
  - `client/src/lib/firebase-app.ts`: Updated `import.meta.env` parsing to `Record<string, string | undefined>`.
  - `client/src/lib/linkPreviewHandler.ts`: Leveraged `keyof CSSStyleDeclaration` for style application.
  - `client/playwright.config.ts`: Updated generic `any` casting to the proper `import("@playwright/test").ReporterDescription[]`.

[Verification Results]
- `npm run lint:diff-lines` passes for modified lines.
- `npm run test:unit` inside `client` workspace passes all existing test cases.

---
*PR created automatically by Jules for task [14001618222893589973](https://jules.google.com/task/14001618222893589973) started by @kitamura-tetsuo*