### PR TITLE
refactor(lint): incrementally replace explicit 'any' with strict types

### DIFF
--- a/client/src/components/ApiKeyManager.svelte
+++ b/client/src/components/ApiKeyManager.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import { listApiKeys, createApiKey, revokeApiKey } from "../services/apiKeyService";
+    import { listApiKeys, createApiKey, revokeApiKey, type ApiKey } from "../services/apiKeyService";
 
-    let apiKeys: any[] = $state([]);
+    let apiKeys: ApiKey[] = $state([]);
     let loading = $state(true);
     let error = $state<string | null>(null);
 
@@ -19,8 +19,8 @@
         error = null;
         try {
             apiKeys = await listApiKeys();
-        } catch (err: any) {
-            error = err.message || "Failed to load API keys";
+        } catch (err: unknown) {
+            error = err instanceof Error ? err.message : "Failed to load API keys";
         } finally {
             loading = false;
         }
@@ -39,8 +39,8 @@
             newlyGeneratedKey = result.apiKey;
             newKeyDescription = "";
             await loadKeys(); // Refresh list
-        } catch (err: any) {
-            error = err.message || "Failed to create API key";
+        } catch (err: unknown) {
+            error = err instanceof Error ? err.message : "Failed to create API key";
         } finally {
             isGenerating = false;
         }
@@ -52,8 +52,8 @@
         try {
             await revokeApiKey(id);
             apiKeys = apiKeys.filter(key => key.id !== id);
-        } catch (err: any) {
-            error = err.message || "Failed to revoke API key";
+        } catch (err: unknown) {
+            error = err instanceof Error ? err.message : "Failed to revoke API key";
         }
     }
 

--- a/client/src/components/OutlinerItemAttachments.test.ts
+++ b/client/src/components/OutlinerItemAttachments.test.ts
@@ -22,7 +22,7 @@ describe("OutlinerItemAttachments", () => {
 
         render(OutlinerItemAttachments, {
             modelId: "test-id",
-            item: item as unknown as import('../schema/app-schema').Item,
+            item: item as unknown as import("../schema/app-schema").Item,
         });
 
         // Check if link exists with accessible name
@@ -51,7 +51,7 @@ describe("OutlinerItemAttachments", () => {
 
         render(OutlinerItemAttachments, {
             modelId: "test-id",
-            item: item as unknown as import('../schema/app-schema').Item,
+            item: item as unknown as import("../schema/app-schema").Item,
         });
 
         const link = screen.getByRole("link", { name: /^View attachment$/i });

--- a/client/src/components/OutlinerItemAttachments.test.ts
+++ b/client/src/components/OutlinerItemAttachments.test.ts
@@ -22,7 +22,7 @@ describe("OutlinerItemAttachments", () => {
 
         render(OutlinerItemAttachments, {
             modelId: "test-id",
-            item: item as any,
+            item: item as unknown as import('../schema/app-schema').Item,
         });
 
         // Check if link exists with accessible name
@@ -51,7 +51,7 @@ describe("OutlinerItemAttachments", () => {
 
         render(OutlinerItemAttachments, {
             modelId: "test-id",
-            item: item as any,
+            item: item as unknown as import('../schema/app-schema').Item,
         });
 
         const link = screen.getByRole("link", { name: /^View attachment$/i });

--- a/client/src/components/PresenceAvatars.svelte
+++ b/client/src/components/PresenceAvatars.svelte
@@ -9,7 +9,7 @@ let users = $state<PresenceUser[]>([]);
 
 function readUsers(): PresenceUser[] {
   try {
-    const store = (globalThis as any).presenceStore;
+    const store = (window as Window).presenceStore;
     return store ? Object.values(store.users || {}) : [];
   } catch { return []; }
 }

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -50,4 +50,6 @@ interface Window {
     __PALETTE_FWD__?: (ev: KeyboardEvent) => void;
     __GLOBAL_KEY_FWD__?: (ev: KeyboardEvent) => void;
     DEBUG_MODE?: string | boolean;
+    presenceStore?: typeof import('./stores/PresenceStore.svelte').presenceStore;
+    userPreferencesStore?: typeof import('./stores/UserPreferencesStore.svelte').userPreferencesStore;
 }

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -50,6 +50,6 @@ interface Window {
     __PALETTE_FWD__?: (ev: KeyboardEvent) => void;
     __GLOBAL_KEY_FWD__?: (ev: KeyboardEvent) => void;
     DEBUG_MODE?: string | boolean;
-    presenceStore?: typeof import('./stores/PresenceStore.svelte').presenceStore;
-    userPreferencesStore?: typeof import('./stores/UserPreferencesStore.svelte').userPreferencesStore;
+    presenceStore?: typeof import("./stores/PresenceStore.svelte").presenceStore;
+    userPreferencesStore?: typeof import("./stores/UserPreferencesStore.svelte").userPreferencesStore;
 }

--- a/client/src/lib/pagePreview.ts
+++ b/client/src/lib/pagePreview.ts
@@ -18,10 +18,10 @@ export function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDept
                     if (typeof val === "string") {
                         image = val;
                     } else if (val && typeof val === "object") {
-                        if ("url" in val) {
-                            image = (val as any).url;
-                        } else if (Array.isArray(val) && (val as any[]).length > 0) {
-                            image = val[0];
+                        if ("url" in val && typeof (val as Record<string, unknown>).url === "string") {
+                            image = (val as Record<string, unknown>).url as string;
+                        } else if (Array.isArray(val) && (val as unknown[]).length > 0 && typeof (val as unknown[])[0] === "string") {
+                            image = (val as unknown[])[0] as string;
                         }
                     }
                 }

--- a/client/src/lib/pagePreview.ts
+++ b/client/src/lib/pagePreview.ts
@@ -20,7 +20,10 @@ export function extractPagePreview(pageItem: Item, maxLines: number = 3, maxDept
                     } else if (val && typeof val === "object") {
                         if ("url" in val && typeof (val as Record<string, unknown>).url === "string") {
                             image = (val as Record<string, unknown>).url as string;
-                        } else if (Array.isArray(val) && (val as unknown[]).length > 0 && typeof (val as unknown[])[0] === "string") {
+                        } else if (
+                            Array.isArray(val) && (val as unknown[]).length > 0
+                            && typeof (val as unknown[])[0] === "string"
+                        ) {
                             image = (val as unknown[])[0] as string;
                         }
                     }

--- a/client/src/lib/yjsService.test.ts
+++ b/client/src/lib/yjsService.test.ts
@@ -69,7 +69,9 @@ describe("yjsService", () => {
             expect(reloadedClient).toBeDefined();
             // We use structural assertions to match the mock instance.
             type MockClient = { doc: { guid: string; }; };
-            expect((reloadedClient as unknown as MockClient).doc.guid).toBe((originalClient as unknown as MockClient).doc.guid);
+            expect((reloadedClient as unknown as MockClient).doc.guid).toBe(
+                (originalClient as unknown as MockClient).doc.guid,
+            );
 
             // Verify the stable ID matches what's expected
             const expectedId = stableIdFromTitle("TestProject");

--- a/client/src/lib/yjsService.test.ts
+++ b/client/src/lib/yjsService.test.ts
@@ -28,13 +28,7 @@ vi.mock("../yjs/YjsClient", () => ({
 
         static async connect(projectId: string, project: Project) {
             // Return a mock client instance that satisfies the test's assertions.
-            return Promise.resolve({
-                doc: {
-                    guid: projectId,
-                },
-                project,
-                getProject: () => project,
-            } as any);
+            return Promise.resolve(new this(projectId, project));
         }
     },
 }));
@@ -73,11 +67,13 @@ describe("yjsService", () => {
 
             // 4. Assert client is returned and has correct ID.
             expect(reloadedClient).toBeDefined();
-            expect((reloadedClient as any).doc.guid).toBe((originalClient as any).doc.guid);
+            // We use structural assertions to match the mock instance.
+            type MockClient = { doc: { guid: string; }; };
+            expect((reloadedClient as unknown as MockClient).doc.guid).toBe((originalClient as unknown as MockClient).doc.guid);
 
             // Verify the stable ID matches what's expected
             const expectedId = stableIdFromTitle("TestProject");
-            expect((reloadedClient as any).doc.guid.startsWith(expectedId)).toBe(true);
+            expect((reloadedClient as unknown as MockClient).doc.guid.startsWith(expectedId)).toBe(true);
         });
     });
 

--- a/client/src/services/apiKeyService.ts
+++ b/client/src/services/apiKeyService.ts
@@ -1,6 +1,6 @@
 import { userManager } from "../auth/UserManager";
 
-interface ApiKey {
+export interface ApiKey {
     id: string;
     description: string;
     createdAt: number;

--- a/client/src/stores/UserPreferencesStore.svelte.ts
+++ b/client/src/stores/UserPreferencesStore.svelte.ts
@@ -64,7 +64,7 @@ export class UserPreferencesStore {
 export const userPreferencesStore = $state(new UserPreferencesStore());
 
 if (typeof window !== "undefined") {
-    (window as any).userPreferencesStore = userPreferencesStore;
+    window.userPreferencesStore = userPreferencesStore;
     // Ensure initial theme is applied on startup
     userPreferencesStore.applyDocumentTheme();
 }


### PR DESCRIPTION
[Issues]
Several `TODO` items explicitly requested the incremental conversion from `any` usage to more stricter typing models as outlined in `#733` issue. Certain files such as `ApiKeyManager.svelte`, `PresenceAvatars.svelte`, and `app-schema.ts` threw validation warnings due to the reliance on `any`.

[Changes]
- Augmented the `client/src/global.d.ts` file to extend the `Window` interface, correctly importing `PresenceStore` and `UserPreferencesStore`.
- Modified `PresenceAvatars.svelte` and `UserPreferencesStore.svelte.ts` to typecast `globalThis` using `Window` rather than `any`.
- Refactored the `ApiKey` data type natively exporting it within `apiKeyService.ts` and casting internal variables securely within `ApiKeyManager.svelte`, in addition to converting unknown error handling structurally against standard `Error` types.
- Rewrote the test instantiation behavior of `yjsService.test.ts` to instantiate a class object avoiding object structural failure on properties. 
- Restructured `pagePreview.ts` to test parameter presence within arrays safely relying on `Record<string, unknown>` and native arrays.

[Verification Results]
Verified functionality with:
- `npm run lint:diff-lines` to ensure all line modifications no longer generated warnings.
- Executed specific modified unit tests including `npm run test:unit --prefix client -- src/lib/yjsService.test.ts` passing successfully. 
- General execution of total test suite successfully bypassed without runtime regressions.

---
*PR created automatically by Jules for task [14463766335068112339](https://jules.google.com/task/14463766335068112339) started by @kitamura-tetsuo*