### PR TITLE
refactor: remove explicit 'any' from textUtils and test

### DIFF
--- a/client/src/utils/textUtils.test.ts
+++ b/client/src/utils/textUtils.test.ts
@@ -3,17 +3,24 @@ import { JSDOM } from "jsdom";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getClickPosition, pixelPositionToTextPosition } from "./textUtils";
 
-let originalGetBoundingClientRect: any;
-let originalGetComputedStyle: any;
+let originalGetBoundingClientRect: typeof Element.prototype.getBoundingClientRect;
+let originalGetComputedStyle: typeof window.getComputedStyle;
 
 beforeAll(() => {
     // Set DOM globally
     const dom = new JSDOM("<!DOCTYPE html><body></body>");
-    (global as any).window = dom.window;
-    (global as any).document = dom.window.document;
-    (global as any).Element = dom.window.Element;
-    (global as any).HTMLElement = dom.window.HTMLElement;
-    (global as any).Node = dom.window.Node;
+    const globalAny = global as typeof globalThis & {
+        window?: Window;
+        document?: Document;
+        Element?: typeof Element;
+        HTMLElement?: typeof HTMLElement;
+        Node?: typeof Node;
+    };
+    globalAny.window = dom.window as unknown as Window;
+    globalAny.document = dom.window.document;
+    globalAny.Element = dom.window.Element;
+    globalAny.HTMLElement = dom.window.HTMLElement;
+    globalAny.Node = dom.window.Node;
     // Mock getBoundingClientRect: textContent length * 10px
     originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
     Element.prototype.getBoundingClientRect = function() {
@@ -27,7 +34,7 @@ beforeAll(() => {
         fontSize: "",
         fontWeight: "",
         letterSpacing: "",
-    } as any);
+    } as unknown as CSSStyleDeclaration);
 });
 
 afterAll(() => {

--- a/client/src/utils/textUtils.ts
+++ b/client/src/utils/textUtils.ts
@@ -1,18 +1,28 @@
 // Utility functions for text measuring and cursor positioning
 
+interface CaretPosition {
+    offsetNode: Node;
+    offset: number;
+}
+
+interface DocumentWithCaret extends Document {
+    caretPositionFromPoint?: (x: number, y: number) => CaretPosition | null;
+}
+
 // getClickPosition: Receives Text Element, MouseEvent, and content, returning the offset.
 export function getClickPosition(textEl: HTMLElement, event: MouseEvent, content: string): number {
     const x = event.clientX;
     const y = event.clientY;
     // Try using Caret API
-    if (textEl && (document.caretRangeFromPoint || (document as any).caretPositionFromPoint)) {
+    const doc = document as DocumentWithCaret;
+    if (textEl && (doc.caretRangeFromPoint || doc.caretPositionFromPoint)) {
         let range: Range | null = null;
-        if (document.caretRangeFromPoint) {
-            range = document.caretRangeFromPoint(x, y);
-        } else {
-            const posInfo = (document as any).caretPositionFromPoint(x, y);
+        if (doc.caretRangeFromPoint) {
+            range = doc.caretRangeFromPoint(x, y);
+        } else if (doc.caretPositionFromPoint) {
+            const posInfo = doc.caretPositionFromPoint(x, y);
             if (posInfo) {
-                range = document.createRange();
+                range = doc.createRange();
                 range.setStart(posInfo.offsetNode, posInfo.offset);
                 range.collapse(true);
             }


### PR DESCRIPTION
[Issues] 
- Codebase-wide effort to incrementally remove `@typescript-eslint/no-explicit-any` usages (Issue #733).
- `client/src/utils/textUtils.ts` and `client/src/utils/textUtils.test.ts` contained a few instances of explicit `any` casting, bypassing TypeScript's static type checks.

[Changes]
- `client/src/utils/textUtils.ts`: Replaced `(document as any)` with a custom `DocumentWithCaret` interface that extends `Document` to safely type the non-standard `caretPositionFromPoint` method.
- `client/src/utils/textUtils.test.ts`: 
  - Typed `originalGetBoundingClientRect` and `originalGetComputedStyle` variables using `typeof`.
  - Replaced `(global as any)` with an intersection type extending `typeof globalThis` to type `window`, `document`, `Element`, `HTMLElement`, and `Node`.
  - Replaced `as any` when mocking `window.getComputedStyle` with `as unknown as CSSStyleDeclaration`.

[Verification Results]
- `npm run lint:diff-lines` passes cleanly with no warnings for the modified files.
- `npx eslint` on the modified files passes with zero warnings.
- Unit tests run successfully (`npm run test:unit -- src/utils/textUtils.test.ts`).
- Full client unit test suite (`npm run test:unit`) run successfully without regressions.

---
*PR created automatically by Jules for task [13580530967201534175](https://jules.google.com/task/13580530967201534175) started by @kitamura-tetsuo*