### PR TITLE
fix: resolve public demo page WebSocket connection stall by supplying a truthy dummy token

### DIFF
--- a/client/src/lib/yjs/connection.ts
+++ b/client/src/lib/yjs/connection.ts
@@ -209,7 +209,7 @@ export async function createProjectConnection(projectId: string): Promise<Projec
         url: constructWsUrl(wsBase, room, initialToken),
         name: room,
         document: doc,
-        token: projectId === "demo" ? undefined : "1",
+        token: "1", // HocuspocusProvider requires a truthy token to send the Auth message, even for unauthenticated rooms like demo.
     });
     console.log(
         `[createProjectConnection] Provider created for ${room}, wsBase=${wsBase}`,
@@ -361,7 +361,7 @@ export async function connectProjectDoc(doc: Y.Doc, projectId: string): Promise<
         url: constructWsUrl(wsBase, room, initialToken),
         name: room,
         document: doc,
-        token: projectId === "demo" ? undefined : "1",
+        token: "1", // HocuspocusProvider requires a truthy token to send the Auth message, even for unauthenticated rooms like demo.
     });
     const awareness = provider.awareness;
 
@@ -422,7 +422,7 @@ export async function createMinimalProjectConnection(projectId: string): Promise
         url: constructWsUrl(wsBase, room, initialToken),
         name: room,
         document: doc,
-        token: projectId === "demo" ? undefined : "1",
+        token: "1", // HocuspocusProvider requires a truthy token to send the Auth message, even for unauthenticated rooms like demo.
     });
     // HocuspocusProvider connects automatically, no need to call connect()
 


### PR DESCRIPTION
[Issues]
- The public `demo` environment was failing to load correctly due to an abrupt WebSocket connection closure. Developer console warned that "WebSocket is closed before the connection is established" and yjs connection-close fired with no code or reason.
- This occurred because `token` was conditionally set to `undefined` for `projectId === "demo"` in `HocuspocusProvider`. The Hocuspocus client relies on a truthy token to trigger the `MessageType.Auth` message, but the server's `onAuthenticate` hook unconditionally waits for this Auth message before establishing the connection.

[Changes]
- Modified `client/src/lib/yjs/connection.ts` across three initialization functions (`createProjectConnection`, `connectProjectDoc`, and `createMinimalProjectConnection`).
- Replaced `token: projectId === "demo" ? undefined : "1"` with a simple `token: "1"` fallback.
- Added explicit inline comments explaining why a truthy dummy token is strictly necessary, even for unauthenticated rooms like `demo`.

[Verification Results]
- Simulated interactions manually with a Playwright script against the live `demo` room endpoints to reproduce the missing global-textarea issue.
- Locally verified that running `test_local_demo.cjs` successfully reaches `Outliner loaded successfully!` and logs no `yjs-conn` disconnections after the fix.
- Ran all client-side unit tests via `npm run test:unit`, passing with no regressions.
- Ran core basic end-to-end tests via `scripts/test.sh client/e2e/basic` which ran smoothly and passed 24/24 tests in headless browser environment.

---
*PR created automatically by Jules for task [3835391952977029239](https://jules.google.com/task/3835391952977029239) started by @kitamura-tetsuo*