### PR TITLE
refactor: fix eslint warnings in search test with explicit types

### DIFF
--- a/client/src/tests/search.test.ts
+++ b/client/src/tests/search.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { replaceAll, replaceFirst, searchItems } from "../lib/search";
-import { Project } from "../schema/app-schema";
+import { Item, Items, Project } from "../schema/app-schema";
 
 function setupTree() {
     const project = Project.createInstance("Test");
     const page = project.addPage("root", "user");
-    const child1 = (page.items as any).addNode("user");
+    const child1 = (page.items as Items).addNode("user");
     child1.updateText("hello world");
-    const child2 = (page.items as any).addNode("user");
+    const child2 = (page.items as Items).addNode("user");
     child2.updateText("Hello World");
     return { page, child1, child2 };
 }
@@ -15,24 +15,24 @@ function setupTree() {
 describe("search utilities", () => {
     it("finds matches case insensitive", () => {
         const { page } = setupTree();
-        const results = searchItems(page as any, "hello", {});
+        const results = searchItems(page as Item, "hello", {});
         const total = results.reduce((c, r) => c + r.matches.length, 0);
         expect(total).toBe(2);
     });
 
     it("respects case sensitivity", () => {
         const { page } = setupTree();
-        const results = searchItems(page as any, "hello", { caseSensitive: true });
+        const results = searchItems(page as Item, "hello", { caseSensitive: true });
         const total = results.reduce((c, r) => c + r.matches.length, 0);
         expect(total).toBe(1);
     });
 
     it("replace functions modify text", () => {
         const { page, child1 } = setupTree();
-        const replaced = replaceFirst(page as any, "hello", "hi");
+        const replaced = replaceFirst(page as Item, "hello", "hi");
         expect(replaced).toBe(true);
         expect(child1.text.includes("hi")).toBe(true);
-        replaceAll(page as any, "world", "earth");
+        replaceAll(page as Item, "world", "earth");
         expect(child1.text.includes("earth")).toBe(true);
     });
 });


### PR DESCRIPTION
[Issues]
Loose typing in `client/src/tests/search.test.ts` triggered `@typescript-eslint/no-explicit-any` warnings during linting.

[Changes]
* Imported `Item` and `Items` explicitly from `../schema/app-schema`.
* Replaced `(page.items as any)` with `(page.items as Items)`.
* Replaced `(page as any)` with `(page as Item)`.
* Formatted the file using `dprint`.

[Verification Results]
* Running `npm run lint:diff-lines --prefix client` now yields no errors/warnings for this file.
* Running `npm run test:unit src/tests/search.test.ts --prefix client` completes successfully.
* Full client build (`npm run build`) runs successfully.

---
*PR created automatically by Jules for task [14945752226248357726](https://jules.google.com/task/14945752226248357726) started by @kitamura-tetsuo*