### PR TITLE
refactor: fix typescript-eslint no-explicit-any warnings in client files

### DIFF
--- a/client/src/routes/[project]/+layout.svelte
+++ b/client/src/routes/[project]/+layout.svelte
@@ -11,7 +11,10 @@ import { store } from "../../stores/store.svelte";
 // This layout applies to both /[project] and /[project]/[page]
 let { data, children } = $props();
 
-let project: any = $state(null);
+import type { Project } from "../../schema/app-schema";
+import type { YjsClient } from "../../yjs/YjsClient";
+
+let project: Project | null = $state(null);
 
 // Retrieve project from the store
 $effect(() => {
@@ -22,7 +25,7 @@ $effect(() => {
 
 // Retrieve project name from URL parameters
 $effect(() => {
-    const projectParam = (data as any)?.project;
+    const projectParam = (data as { project?: string })?.project;
     if (!projectParam) return;
 
     if (!yjsStore.yjsClient) {
@@ -32,13 +35,13 @@ $effect(() => {
 
 async function loadProject(projectNameFromParam?: string) {
     try {
-        const projectName = projectNameFromParam ?? (data as any).project;
+        const projectName = projectNameFromParam ?? (data as { project: string }).project;
 
         // Retrieve Yjs client from project name
         let client = await getYjsClientByProjectTitle(projectName);
 
         if (client) {
-            yjsStore.yjsClient = client as any;
+            yjsStore.yjsClient = client as YjsClient;
             project = client.getProject();
             // expose project to the global store so pages become available immediately
             store.project = project;
@@ -62,7 +65,7 @@ onMount(() => {
     try {
         userManager.addEventListener(() => {
             // If project not yet loaded but param exists, try again when auth flips
-            const projectParam = (data as any)?.project;
+            const projectParam = (data as { project?: string })?.project;
             if (projectParam && !yjsStore.yjsClient) {
                 loadProject(projectParam);
             }

--- a/client/src/routes/demo/+page.svelte
+++ b/client/src/routes/demo/+page.svelte
@@ -38,9 +38,9 @@
                 throw new Error("Failed to connect to the demo project.");
             }
 
-            yjsStore.yjsClient = client as any;
+            yjsStore.yjsClient = client as import("../../yjs/YjsClient").YjsClient;
             const project = client.getProject();
-            store.project = project as any;
+            store.project = project;
 
             // Wait for sync or timeout
             let retries = 0;
@@ -73,7 +73,7 @@
                 logger.warn("Timeout waiting for Demo page to sync");
             }
 
-            store.currentPage = demoPage as any;
+            store.currentPage = demoPage as import("../../schema/app-schema").Item;
 
         } catch (err) {
             console.error("Failed to initialize demo:", err);
@@ -91,7 +91,7 @@
         try {
             yjsStore.yjsClient?.dispose();
             yjsStore.yjsClient = undefined;
-            store.project = undefined as any;
+            store.project = undefined;
             store.currentPage = undefined;
         } catch {}
     });

--- a/client/src/routes/yjs-outliner/+page.svelte
+++ b/client/src/routes/yjs-outliner/+page.svelte
@@ -4,8 +4,9 @@ import { Project } from "../../schema/app-schema";
 import { store as generalStore } from "../../stores/store.svelte";
 import * as Y from "yjs";
 import { onMount } from "svelte";
+import type { Item } from "../../schema/app-schema";
 
-let pageItem = $state<any>(undefined);
+let pageItem = $state<Item | undefined>(undefined);
 
 const PROJECT_ID = "yjs-outliner-test";
 
@@ -13,12 +14,12 @@ onMount(async () => {
   // 1) Create local doc immediately for UI rendering (server optional)
   const doc = new Y.Doc({ guid: PROJECT_ID });
   const p = Project.fromDoc(doc);
-  if ((p.items as any).length === 0) {
+  if (p.items && p.items.length === 0) {
     const pg = p.addPage("Untitled", "tester");
-    while ((pg.items as any)?.length < 3) pg.items.addNode("tester");
+    while (pg.items && pg.items.length < 3) pg.items.addNode("tester");
   }
-  pageItem = (p.items as any).at(0);
-  generalStore.project = p as any;
+  pageItem = p.items?.at(0);
+  generalStore.project = p;
   generalStore.currentPage = pageItem;
   console.log("/yjs-outliner: pageItem set", { hasPageItem: !!pageItem });
 

--- a/client/src/tests/integration/cnt-shared-container-store-12ee98aa.integration.spec.ts
+++ b/client/src/tests/integration/cnt-shared-container-store-12ee98aa.integration.spec.ts
@@ -9,14 +9,14 @@ import UserContainerDisplay from "../fixtures/UserContainerDisplay.svelte";
 describe("CNT shared container store", () => {
     it("reflects user project updates", async () => {
         render(UserContainerDisplay);
-        const storeGlobal: any = (globalThis as any).window?.__FIRESTORE_STORE__ ?? firestoreStore;
+        const storeGlobal = (globalThis as unknown as { window?: { __FIRESTORE_STORE__?: typeof firestoreStore } }).window?.__FIRESTORE_STORE__ ?? firestoreStore;
         storeGlobal.setUserProject({
             userId: "u",
             accessibleProjectIds: ["a"],
             defaultProjectId: "a",
             createdAt: new Date(),
             updatedAt: new Date(),
-        } as any);
+        } as import("../../stores/firestoreStore.svelte").UserProject);
         await tick();
         await tick();
         // Is the store itself updated? (Assertion for debugging)
@@ -32,7 +32,7 @@ describe("CNT shared container store", () => {
             defaultProjectId: "b",
             createdAt: new Date(),
             updatedAt: new Date(),
-        } as any);
+        } as import("../../stores/firestoreStore.svelte").UserProject);
         await tick();
         expect(screen.getByTestId("default").textContent).toBe("b");
         expect(screen.getAllByRole("listitem").map(li => li.textContent)).toEqual(["a", "b"]);

--- a/client/src/tests/integration/cnt-shared-container-store-12ee98aa.integration.spec.ts
+++ b/client/src/tests/integration/cnt-shared-container-store-12ee98aa.integration.spec.ts
@@ -9,14 +9,18 @@ import UserContainerDisplay from "../fixtures/UserContainerDisplay.svelte";
 describe("CNT shared container store", () => {
     it("reflects user project updates", async () => {
         render(UserContainerDisplay);
-        const storeGlobal = (globalThis as unknown as { window?: { __FIRESTORE_STORE__?: typeof firestoreStore } }).window?.__FIRESTORE_STORE__ ?? firestoreStore;
-        storeGlobal.setUserProject({
-            userId: "u",
-            accessibleProjectIds: ["a"],
-            defaultProjectId: "a",
-            createdAt: new Date(),
-            updatedAt: new Date(),
-        } as import("../../stores/firestoreStore.svelte").UserProject);
+        const storeGlobal =
+            (globalThis as unknown as { window?: { __FIRESTORE_STORE__?: typeof firestoreStore; }; }).window
+                ?.__FIRESTORE_STORE__ ?? firestoreStore;
+        storeGlobal.setUserProject(
+            {
+                userId: "u",
+                accessibleProjectIds: ["a"],
+                defaultProjectId: "a",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            } as import("../../stores/firestoreStore.svelte").UserProject,
+        );
         await tick();
         await tick();
         // Is the store itself updated? (Assertion for debugging)
@@ -26,13 +30,15 @@ describe("CNT shared container store", () => {
         // Then, verify visualization of defaultProjectId
         expect(screen.getByTestId("default").textContent).toBe("a");
 
-        storeGlobal.setUserProject({
-            userId: "u",
-            accessibleProjectIds: ["a", "b"],
-            defaultProjectId: "b",
-            createdAt: new Date(),
-            updatedAt: new Date(),
-        } as import("../../stores/firestoreStore.svelte").UserProject);
+        storeGlobal.setUserProject(
+            {
+                userId: "u",
+                accessibleProjectIds: ["a", "b"],
+                defaultProjectId: "b",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            } as import("../../stores/firestoreStore.svelte").UserProject,
+        );
         await tick();
         expect(screen.getByTestId("default").textContent).toBe("b");
         expect(screen.getAllByRole("listitem").map(li => li.textContent)).toEqual(["a", "b"]);

--- a/client/src/tests/integration/cursor/cursor-navigation.integration.spec.ts
+++ b/client/src/tests/integration/cursor/cursor-navigation.integration.spec.ts
@@ -76,7 +76,7 @@ describe("Cursor Integration", () => {
         (mockItem as unknown as { parent: Item | null; }).parent = mockParentItem;
 
         // Mock the general store
-        (generalStore as unknown as { currentPage: Item }).currentPage = mockParentItem;
+        (generalStore as unknown as { currentPage: Item; }).currentPage = mockParentItem;
 
         // Setup editor overlay store mocks
         (editorOverlayStore.setCursor as unknown as ReturnType<typeof vi.fn>).mockReturnValue("new-cursor-id");
@@ -158,7 +158,7 @@ describe("Cursor Integration", () => {
             mockItem.updateText = vi.fn();
 
             // Mock a selection
-            (editorOverlayStore as unknown as { selections: Record<string, unknown> }).selections = {
+            (editorOverlayStore as unknown as { selections: Record<string, unknown>; }).selections = {
                 "selection-1": {
                     userId: "user-1",
                     startItemId: "test-item-1",
@@ -188,16 +188,17 @@ describe("Cursor Integration", () => {
 
             // Ensure parent has indexOf and addNode methods
             if (mockItem.parent) {
-                (mockItem.parent as unknown as { indexOf: (item: Item) => number }).indexOf = (item: Item) => {
+                (mockItem.parent as unknown as { indexOf: (item: Item) => number; }).indexOf = (item: Item) => {
                     if (item === mockItem) return 0;
                     return -1;
                 };
-                (mockItem.parent as unknown as { addNode: ReturnType<typeof vi.fn> }).addNode = vi.fn().mockReturnValue({
-                    id: "new-item-1",
-                    text: "World",
-                    updateText: vi.fn(),
-                    delete: vi.fn(),
-                });
+                (mockItem.parent as unknown as { addNode: ReturnType<typeof vi.fn>; }).addNode = vi.fn()
+                    .mockReturnValue({
+                        id: "new-item-1",
+                        text: "World",
+                        updateText: vi.fn(),
+                        delete: vi.fn(),
+                    });
             }
 
             mockParentItem.items.addNode = vi.fn().mockReturnValue({
@@ -220,7 +221,8 @@ describe("Cursor Integration", () => {
             expect(mockItem.updateText).toHaveBeenCalledWith("Hello");
             // Check if either parent.addNode or mockParentItem.items.addNode was called
             expect(
-                (mockItem.parent as unknown as { addNode: ReturnType<typeof vi.fn> })?.addNode || mockParentItem.items.addNode,
+                (mockItem.parent as unknown as { addNode: ReturnType<typeof vi.fn>; })?.addNode
+                    || mockParentItem.items.addNode,
             ).toHaveBeenCalled();
         });
     });

--- a/client/src/tests/integration/cursor/cursor-navigation.integration.spec.ts
+++ b/client/src/tests/integration/cursor/cursor-navigation.integration.spec.ts
@@ -76,7 +76,7 @@ describe("Cursor Integration", () => {
         (mockItem as unknown as { parent: Item | null; }).parent = mockParentItem;
 
         // Mock the general store
-        (generalStore as any).currentPage = mockParentItem;
+        (generalStore as unknown as { currentPage: Item }).currentPage = mockParentItem;
 
         // Setup editor overlay store mocks
         (editorOverlayStore.setCursor as unknown as ReturnType<typeof vi.fn>).mockReturnValue("new-cursor-id");
@@ -158,7 +158,7 @@ describe("Cursor Integration", () => {
             mockItem.updateText = vi.fn();
 
             // Mock a selection
-            (editorOverlayStore as any).selections = {
+            (editorOverlayStore as unknown as { selections: Record<string, unknown> }).selections = {
                 "selection-1": {
                     userId: "user-1",
                     startItemId: "test-item-1",
@@ -188,11 +188,11 @@ describe("Cursor Integration", () => {
 
             // Ensure parent has indexOf and addNode methods
             if (mockItem.parent) {
-                (mockItem.parent as any).indexOf = (item: Item) => {
+                (mockItem.parent as unknown as { indexOf: (item: Item) => number }).indexOf = (item: Item) => {
                     if (item === mockItem) return 0;
                     return -1;
                 };
-                (mockItem.parent as any).addNode = vi.fn().mockReturnValue({
+                (mockItem.parent as unknown as { addNode: ReturnType<typeof vi.fn> }).addNode = vi.fn().mockReturnValue({
                     id: "new-item-1",
                     text: "World",
                     updateText: vi.fn(),
@@ -220,7 +220,7 @@ describe("Cursor Integration", () => {
             expect(mockItem.updateText).toHaveBeenCalledWith("Hello");
             // Check if either parent.addNode or mockParentItem.items.addNode was called
             expect(
-                (mockItem.parent as any).addNode || mockParentItem.items.addNode,
+                (mockItem.parent as unknown as { addNode: ReturnType<typeof vi.fn> })?.addNode || mockParentItem.items.addNode,
             ).toHaveBeenCalled();
         });
     });

--- a/client/src/tests/utils/testDataHelper.ts
+++ b/client/src/tests/utils/testDataHelper.ts
@@ -27,7 +27,7 @@ export function createTestUserData(): TestUserProject {
     };
 
     // Set test data in firestoreStore using public API to ensure reactivity wrapping
-    (firestoreStore as any).setUserProject(testUserProject as any);
+    (firestoreStore as unknown as { setUserProject: (project: import("../../stores/firestoreStore.svelte").UserProject) => void }).setUserProject(testUserProject as import("../../stores/firestoreStore.svelte").UserProject);
 
     return testUserProject;
 }
@@ -58,7 +58,7 @@ export function setupTestEnvironment(): TestUserProject {
  */
 export async function performTestLogin(): Promise<void> {
     try {
-        const userManager = (window as any).__USER_MANAGER__;
+        const userManager = (window as unknown as { __USER_MANAGER__: { loginWithEmailPassword: (e: string, p: string) => Promise<void> } }).__USER_MANAGER__;
         if (userManager && userManager.loginWithEmailPassword) {
             await userManager.loginWithEmailPassword("test@example.com", "password");
             console.log("Manual test login successful");
@@ -77,8 +77,8 @@ export async function performTestLogin(): Promise<void> {
  */
 export function logDebugInfo(): void {
     console.log("=== Test Debug Info ===");
-    console.log("Current user:", (window as any).__USER_MANAGER__?.getCurrentUser());
-    console.log("Auth state:", (window as any).__USER_MANAGER__?.auth?.currentUser);
+    console.log("Current user:", (window as unknown as { __USER_MANAGER__?: { getCurrentUser: () => unknown } }).__USER_MANAGER__?.getCurrentUser());
+    console.log("Auth state:", (window as unknown as { __USER_MANAGER__?: { auth?: { currentUser: unknown } } }).__USER_MANAGER__?.auth?.currentUser);
     console.log("Firestore userProject:", firestoreStore.userProject);
     console.log("======================");
 }

--- a/client/src/tests/utils/testDataHelper.ts
+++ b/client/src/tests/utils/testDataHelper.ts
@@ -27,7 +27,9 @@ export function createTestUserData(): TestUserProject {
     };
 
     // Set test data in firestoreStore using public API to ensure reactivity wrapping
-    (firestoreStore as unknown as { setUserProject: (project: import("../../stores/firestoreStore.svelte").UserProject) => void }).setUserProject(testUserProject as import("../../stores/firestoreStore.svelte").UserProject);
+    (firestoreStore as unknown as {
+        setUserProject: (project: import("../../stores/firestoreStore.svelte").UserProject) => void;
+    }).setUserProject(testUserProject as import("../../stores/firestoreStore.svelte").UserProject);
 
     return testUserProject;
 }
@@ -58,7 +60,9 @@ export function setupTestEnvironment(): TestUserProject {
  */
 export async function performTestLogin(): Promise<void> {
     try {
-        const userManager = (window as unknown as { __USER_MANAGER__: { loginWithEmailPassword: (e: string, p: string) => Promise<void> } }).__USER_MANAGER__;
+        const userManager = (window as unknown as {
+            __USER_MANAGER__: { loginWithEmailPassword: (e: string, p: string) => Promise<void>; };
+        }).__USER_MANAGER__;
         if (userManager && userManager.loginWithEmailPassword) {
             await userManager.loginWithEmailPassword("test@example.com", "password");
             console.log("Manual test login successful");
@@ -77,8 +81,16 @@ export async function performTestLogin(): Promise<void> {
  */
 export function logDebugInfo(): void {
     console.log("=== Test Debug Info ===");
-    console.log("Current user:", (window as unknown as { __USER_MANAGER__?: { getCurrentUser: () => unknown } }).__USER_MANAGER__?.getCurrentUser());
-    console.log("Auth state:", (window as unknown as { __USER_MANAGER__?: { auth?: { currentUser: unknown } } }).__USER_MANAGER__?.auth?.currentUser);
+    console.log(
+        "Current user:",
+        (window as unknown as { __USER_MANAGER__?: { getCurrentUser: () => unknown; }; }).__USER_MANAGER__
+            ?.getCurrentUser(),
+    );
+    console.log(
+        "Auth state:",
+        (window as unknown as { __USER_MANAGER__?: { auth?: { currentUser: unknown; }; }; }).__USER_MANAGER__?.auth
+            ?.currentUser,
+    );
     console.log("Firestore userProject:", firestoreStore.userProject);
     console.log("======================");
 }


### PR DESCRIPTION
[Issues]
Addresses the `TODO: Fix these issues incrementally and convert back to errors` in `client/eslint.config.js` for `@typescript-eslint/no-explicit-any`.

[Changes]
Replaced `any` type casts with `unknown` or more specific structural types (e.g. `import("../../schema/app-schema").Item`) to fix strict typing `@typescript-eslint/no-explicit-any` ESLint warnings across several client files:
- `client/src/routes/[project]/+layout.svelte`
- `client/src/routes/demo/+page.svelte`
- `client/src/routes/yjs-outliner/+page.svelte`
- `client/src/tests/integration/cnt-shared-container-store-12ee98aa.integration.spec.ts`
- `client/src/tests/integration/cursor/cursor-navigation.integration.spec.ts`
- `client/src/tests/utils/testDataHelper.ts`

[Verification Results]
- `npm run test:unit` inside `client` completed successfully.
- `npm run build` inside `client` completed successfully.
- Warnings for `@typescript-eslint/no-explicit-any` were confirmed removed for these specific files via `npx eslint <files> --format unix`.

---
*PR created automatically by Jules for task [8833452530321459128](https://jules.google.com/task/8833452530321459128) started by @kitamura-tetsuo*