### PR TITLE
Fix WebSocket connection loop on demo site

### DIFF
--- a/client/src/lib/yjs/connection.ts
+++ b/client/src/lib/yjs/connection.ts
@@ -200,6 +200,8 @@ export async function createProjectConnection(projectId: string): Promise<Projec
     try {
         if (projectId !== "demo") {
             initialToken = await getFreshIdToken();
+        } else {
+            initialToken = "1"; // Send dummy token in URL to satisfy strict routing on older servers
         }
     } catch {}
 
@@ -356,6 +358,8 @@ export async function connectProjectDoc(doc: Y.Doc, projectId: string): Promise<
     try {
         if (projectId !== "demo") {
             initialToken = await getFreshIdToken();
+        } else {
+            initialToken = "1"; // Send dummy token in URL to satisfy strict routing on older servers
         }
     } catch (e) {
         console.error("[connectProjectDoc] getFreshIdToken FAILED:", e);
@@ -418,6 +422,8 @@ export async function createMinimalProjectConnection(projectId: string): Promise
     try {
         if (projectId !== "demo") {
             initialToken = await getFreshIdToken();
+        } else {
+            initialToken = "1"; // Send dummy token in URL to satisfy strict routing on older servers
         }
     } catch {}
 


### PR DESCRIPTION
[Issues]
The demo environment (`/demo`) was suffering from a continuous WebSocket disconnect/reconnect loop, evidenced by Playwright logs and console errors (`WebSocket is closed before the connection is established.`). This was caused by the server rejecting the HTTP Upgrade request with a `4001 NO_TOKEN` error when strict Origin headers were supplied.

[Changes]
Modified `client/src/lib/yjs/connection.ts` to assign a dummy `initialToken = "1"` specifically for the `"demo"` project. This ensures a truthy token is present in the `constructWsUrl` string, bypassing the backend server's strict synchronous `NO_TOKEN` check during the connection handshake. The Hocuspocus server's `onAuthenticate` hook handles the `"demo"` room correctly.

[Verification Results]
Verified via standalone Playwright and Node `ws` scripts connecting to the production WebSocket URL with explicit Origins. Tested the full client unit test suite (`npm run test:unit`) and built the client (`npm run build`) locally to verify no regressions were introduced.

---
*PR created automatically by Jules for task [5856776761923772935](https://jules.google.com/task/5856776761923772935) started by @kitamura-tetsuo*