### PR TITLE
refactor(client): replace any with explicit types in tests

### DIFF
--- a/client/src/lib/yjs/testHelpers.ts
+++ b/client/src/lib/yjs/testHelpers.ts
@@ -173,7 +173,8 @@ export async function initializeBrowserPage(
 
         // Wait for authentication to complete
         await page.waitForFunction(
-            () => !!(window as Window & typeof globalThis & Record<string, unknown>).__USER_MANAGER__?.getCurrentUser?.(),
+            () =>
+                !!(window as Window & typeof globalThis & Record<string, unknown>).__USER_MANAGER__?.getCurrentUser?.(),
             null,
             { timeout: 60000 },
         );
@@ -255,7 +256,7 @@ export async function createMinimalYjsConnection(
             (window as Window & typeof globalThis & Record<string, unknown>)[providerVar] = provider;
 
             if (enableLogging) {
-                provider.on("status", (e: { status: string }) => console.log(`[${providerVar}] status`, e.status));
+                provider.on("status", (e: { status: string; }) => console.log(`[${providerVar}] status`, e.status));
                 provider.on(
                     "synced",
                     (data: { state: boolean; }) => console.log(`[${providerVar}] synced`, data.state),
@@ -264,7 +265,7 @@ export async function createMinimalYjsConnection(
                     `[${providerVar}] init isSynced=`,
                     provider.isSynced,
                     "url=",
-                    (provider as unknown as { configuration?: { url: string } }).configuration?.url,
+                    (provider as unknown as { configuration?: { url: string; }; }).configuration?.url,
                 );
             }
             try {
@@ -459,9 +460,9 @@ export interface TwoFullBrowserPagesResult {
  */
 export async function prepareTwoFullBrowserPages(
     browser: Browser,
-    testInfo: { title: string },
+    testInfo: { title: string; },
     initialItems: string[],
-    TestHelpers: { expectEmptyOutliner: (page: Page) => Promise<void> },
+    TestHelpers: { expectEmptyOutliner: (page: Page) => Promise<void>; },
 ): Promise<TwoFullBrowserPagesResult> {
     // Create first browser context
     const context1 = await browser.newContext();
@@ -504,7 +505,7 @@ export async function prepareTwoFullBrowserPages(
                 console.log("page1: project not found");
                 return false;
             }
-            const items = project.items as unknown as { length: number };
+            const items = project.items as unknown as { length: number; };
             const pageCount = items?.length ?? 0;
             console.log(`page1: Yjs client initialized, pageCount=${pageCount}`);
             return !!(project && items);

--- a/client/src/lib/yjs/testHelpers.ts
+++ b/client/src/lib/yjs/testHelpers.ts
@@ -156,7 +156,7 @@ export async function initializeBrowserPage(
     });
 
     await page.waitForFunction(
-        () => !!(window as any).__USER_MANAGER__,
+        () => !!(window as Window & typeof globalThis & Record<string, unknown>).__USER_MANAGER__,
         null,
         { timeout: 60000 },
     );
@@ -164,7 +164,7 @@ export async function initializeBrowserPage(
     // Authenticate if required
     if (requireAuth) {
         await page.evaluate(async () => {
-            const mgr = (window as any).__USER_MANAGER__;
+            const mgr = (window as Window & typeof globalThis & Record<string, unknown>).__USER_MANAGER__;
             await mgr?.loginWithEmailPassword?.(
                 "test@example.com",
                 "password",
@@ -173,7 +173,7 @@ export async function initializeBrowserPage(
 
         // Wait for authentication to complete
         await page.waitForFunction(
-            () => !!(window as any).__USER_MANAGER__?.getCurrentUser?.(),
+            () => !!(window as Window & typeof globalThis & Record<string, unknown>).__USER_MANAGER__?.getCurrentUser?.(),
             null,
             { timeout: 60000 },
         );
@@ -191,7 +191,7 @@ export async function initializeBrowserPage(
  */
 export async function reconnectProvider(page: Page, providerVar: string = "__PROVIDER__"): Promise<void> {
     await page.evaluate(async ({ pv }) => {
-        const win = window as any;
+        const win = window as Window & typeof globalThis & Record<string, unknown>;
         const provider = win[pv] as HocuspocusProvider;
         if (!provider) return;
 
@@ -247,15 +247,15 @@ export async function createMinimalYjsConnection(
     return await page.evaluate(
         async ({ pid, docVar, providerVar, enableLogging, importPath }) => {
             const { createMinimalProjectConnection } = await import(
-                importPath as any
+                importPath as string
             );
             const conn = await createMinimalProjectConnection(pid);
-            (window as any)[docVar] = conn.doc;
+            (window as Window & typeof globalThis & Record<string, unknown>)[docVar] = conn.doc;
             const provider = conn.provider as HocuspocusProvider;
-            (window as any)[providerVar] = provider;
+            (window as Window & typeof globalThis & Record<string, unknown>)[providerVar] = provider;
 
             if (enableLogging) {
-                provider.on("status", (e: any) => console.log(`[${providerVar}] status`, e.status));
+                provider.on("status", (e: { status: string }) => console.log(`[${providerVar}] status`, e.status));
                 provider.on(
                     "synced",
                     (data: { state: boolean; }) => console.log(`[${providerVar}] synced`, data.state),
@@ -264,7 +264,7 @@ export async function createMinimalYjsConnection(
                     `[${providerVar}] init isSynced=`,
                     provider.isSynced,
                     "url=",
-                    (provider as any).configuration?.url,
+                    (provider as unknown as { configuration?: { url: string } }).configuration?.url,
                 );
             }
             try {
@@ -303,21 +303,21 @@ export async function setupUpdateTracking(
 
     await page.evaluate(
         ({ docVar, counterVar, counterV2Var }) => {
-            const doc = (window as any)[docVar];
+            const doc = (window as Window & typeof globalThis & Record<string, unknown>)[docVar];
             if (!doc) {
                 console.error(`setupUpdateTracking: ${docVar} not found`);
                 return;
             }
 
-            (window as any)[counterVar] = 0;
-            (window as any)[counterV2Var] = 0;
+            (window as Window & typeof globalThis & Record<string, unknown>)[counterVar] = 0;
+            (window as Window & typeof globalThis & Record<string, unknown>)[counterV2Var] = 0;
 
             doc.on("update", () => {
-                (window as any)[counterVar]++;
+                (window as Window & typeof globalThis & Record<string, unknown>)[counterVar]++;
             });
 
             doc.on("updateV2", () => {
-                (window as any)[counterV2Var]++;
+                (window as Window & typeof globalThis & Record<string, unknown>)[counterV2Var]++;
             });
         },
         { docVar, counterVar, counterV2Var },
@@ -459,9 +459,9 @@ export interface TwoFullBrowserPagesResult {
  */
 export async function prepareTwoFullBrowserPages(
     browser: Browser,
-    testInfo: any,
+    testInfo: { title: string },
     initialItems: string[],
-    TestHelpers: any,
+    TestHelpers: { expectEmptyOutliner: (page: Page) => Promise<void> },
 ): Promise<TwoFullBrowserPagesResult> {
     // Create first browser context
     const context1 = await browser.newContext();
@@ -493,7 +493,7 @@ export async function prepareTwoFullBrowserPages(
     // Wait for page1 to initialize Yjs client and project
     await page1.waitForFunction(
         () => {
-            const yjsStore = (window as any).__YJS_STORE__;
+            const yjsStore = (window as Window & typeof globalThis & Record<string, unknown>).__YJS_STORE__;
             const client = yjsStore?.yjsClient;
             if (!client) {
                 console.log("page1: yjsClient not found");
@@ -504,7 +504,7 @@ export async function prepareTwoFullBrowserPages(
                 console.log("page1: project not found");
                 return false;
             }
-            const items = project.items as any;
+            const items = project.items as unknown as { length: number };
             const pageCount = items?.length ?? 0;
             console.log(`page1: Yjs client initialized, pageCount=${pageCount}`);
             return !!(project && items);
@@ -531,8 +531,7 @@ export async function prepareTwoFullBrowserPages(
         localStorage.setItem("SKIP_TEST_CONTAINER_SEED", "true");
         localStorage.setItem("VITE_YJS_ENABLE_WS", "true");
         localStorage.setItem("VITE_YJS_FORCE_WS", "true");
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (window as any).__E2E__ = true;
+        (window as Window & typeof globalThis & Record<string, unknown>).__E2E__ = true;
     });
 
     // Navigate page2 to the same URL as page1
@@ -541,13 +540,13 @@ export async function prepareTwoFullBrowserPages(
     // Authenticate page2
     await page2.waitForFunction(
         () => {
-            return !!(window as any).__USER_MANAGER__;
+            return !!(window as Window & typeof globalThis & Record<string, unknown>).__USER_MANAGER__;
         },
         { timeout: 60000 },
     );
 
     await page2.evaluate(async () => {
-        const mgr = (window as any).__USER_MANAGER__;
+        const mgr = (window as Window & typeof globalThis & Record<string, unknown>).__USER_MANAGER__;
         if (mgr?.loginWithEmailPassword) {
             await mgr.loginWithEmailPassword("test@example.com", "password");
         }
@@ -556,7 +555,7 @@ export async function prepareTwoFullBrowserPages(
     // Wait for page2 authentication to complete
     await page2.waitForFunction(
         () => {
-            const mgr = (window as any).__USER_MANAGER__;
+            const mgr = (window as Window & typeof globalThis & Record<string, unknown>).__USER_MANAGER__;
             return !!(mgr && mgr.getCurrentUser && mgr.getCurrentUser());
         },
         { timeout: 60000 },
@@ -565,7 +564,7 @@ export async function prepareTwoFullBrowserPages(
     // Wait for page2 to initialize Yjs client and appStore
     await page2.waitForFunction(
         () => {
-            const yjsStore = (window as any).__YJS_STORE__;
+            const yjsStore = (window as Window & typeof globalThis & Record<string, unknown>).__YJS_STORE__;
             const client = yjsStore?.yjsClient;
             if (!client) {
                 console.log("page2: yjsClient not found");
@@ -576,7 +575,7 @@ export async function prepareTwoFullBrowserPages(
                 console.log("page2: project or items not found");
                 return false;
             }
-            const appStore = (window as any).appStore;
+            const appStore = (window as Window & typeof globalThis & Record<string, unknown>).appStore;
             if (!appStore) {
                 console.log("page2: appStore not found");
                 return false;

--- a/client/src/stores/EditorOverlayStore.test.ts
+++ b/client/src/stores/EditorOverlayStore.test.ts
@@ -2,18 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Local minimal replica to avoid importing .svelte.ts in tests
 class TestEditorOverlayStore {
-    cursors: Record<string, any> = {};
-    cursorInstances = new Map<string, any>();
+    cursors: Record<string, { cursorId: string, itemId: string, offset: number, isActive: boolean, userId: string }> = {};
+    cursorInstances = new Map<string, { itemId: string, offset: number, isActive: boolean, userId: string }>();
     cursorHistory: string[] = [];
-    selections: Record<string, any> = {};
+    selections: Record<string, { startItemId: string, startOffset: number, endItemId: string, endOffset: number, userId?: string }> = {};
     activeItemId: string | null = null;
     cursorVisible = true;
     animationPaused = false;
-    private timerId: any;
+    private timerId: ReturnType<typeof setInterval> | undefined;
     private genUUID() {
         return Math.random().toString(36).slice(2);
     }
-    addCursor({ itemId, offset, isActive, userId = "local" }: any) {
+    addCursor({ itemId, offset, isActive, userId = "local" }: { itemId: string, offset: number, isActive: boolean, userId?: string }) {
         const id = this.genUUID();
         this.cursorInstances.set(id, { itemId, offset, isActive, userId });
         this.cursors = { ...this.cursors, [id]: { cursorId: id, itemId, offset, isActive, userId } };
@@ -36,26 +36,26 @@ class TestEditorOverlayStore {
         return id ? this.cursors[id] : null;
     }
     clearCursorForItem(itemId: string) {
-        const keep = Object.entries(this.cursors).filter((entry: [string, any]) => entry[1].itemId !== itemId);
+        const keep = Object.entries(this.cursors).filter((entry: [string, { itemId: string, userId: string }]) => entry[1].itemId !== itemId);
         this.cursors = Object.fromEntries(keep);
     }
-    setSelection(sel: any) {
+    setSelection(sel: { startItemId: string, startOffset: number, endItemId: string, endOffset: number, userId?: string }) {
         const key = `${sel.startItemId}-${sel.endItemId}-${sel.userId || "local"}`;
         this.selections = { ...this.selections, [key]: sel };
     }
     clearCursorAndSelection(userId = "local", clearSelections = false) {
         this.cursors = Object.fromEntries(
-            Object.entries(this.cursors).filter((entry: [string, any]) => entry[1].userId !== userId),
+            Object.entries(this.cursors).filter((entry: [string, { itemId: string, userId: string }]) => entry[1].userId !== userId),
         );
         if (clearSelections) {
             this.selections = Object.fromEntries(
-                Object.entries(this.selections).filter((entry: [string, any]) => entry[1].userId !== userId),
+                Object.entries(this.selections).filter((entry: [string, { userId?: string }]) => entry[1].userId !== userId),
             );
         }
     }
     clearSelectionForUser(userId = "local") {
         this.selections = Object.fromEntries(
-            Object.entries(this.selections).filter(([key, s]: any) =>
+            Object.entries(this.selections).filter(([key, s]: [string, { userId?: string }]) =>
                 !key.includes(`-${userId}`) && s.userId !== userId
             ),
         );

--- a/client/src/stores/EditorOverlayStore.test.ts
+++ b/client/src/stores/EditorOverlayStore.test.ts
@@ -2,10 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Local minimal replica to avoid importing .svelte.ts in tests
 class TestEditorOverlayStore {
-    cursors: Record<string, { cursorId: string, itemId: string, offset: number, isActive: boolean, userId: string }> = {};
-    cursorInstances = new Map<string, { itemId: string, offset: number, isActive: boolean, userId: string }>();
+    cursors: Record<string, { cursorId: string; itemId: string; offset: number; isActive: boolean; userId: string; }> =
+        {};
+    cursorInstances = new Map<string, { itemId: string; offset: number; isActive: boolean; userId: string; }>();
     cursorHistory: string[] = [];
-    selections: Record<string, { startItemId: string, startOffset: number, endItemId: string, endOffset: number, userId?: string }> = {};
+    selections: Record<
+        string,
+        { startItemId: string; startOffset: number; endItemId: string; endOffset: number; userId?: string; }
+    > = {};
     activeItemId: string | null = null;
     cursorVisible = true;
     animationPaused = false;
@@ -13,7 +17,14 @@ class TestEditorOverlayStore {
     private genUUID() {
         return Math.random().toString(36).slice(2);
     }
-    addCursor({ itemId, offset, isActive, userId = "local" }: { itemId: string, offset: number, isActive: boolean, userId?: string }) {
+    addCursor(
+        { itemId, offset, isActive, userId = "local" }: {
+            itemId: string;
+            offset: number;
+            isActive: boolean;
+            userId?: string;
+        },
+    ) {
         const id = this.genUUID();
         this.cursorInstances.set(id, { itemId, offset, isActive, userId });
         this.cursors = { ...this.cursors, [id]: { cursorId: id, itemId, offset, isActive, userId } };
@@ -36,26 +47,34 @@ class TestEditorOverlayStore {
         return id ? this.cursors[id] : null;
     }
     clearCursorForItem(itemId: string) {
-        const keep = Object.entries(this.cursors).filter((entry: [string, { itemId: string, userId: string }]) => entry[1].itemId !== itemId);
+        const keep = Object.entries(this.cursors).filter((entry: [string, { itemId: string; userId: string; }]) =>
+            entry[1].itemId !== itemId
+        );
         this.cursors = Object.fromEntries(keep);
     }
-    setSelection(sel: { startItemId: string, startOffset: number, endItemId: string, endOffset: number, userId?: string }) {
+    setSelection(
+        sel: { startItemId: string; startOffset: number; endItemId: string; endOffset: number; userId?: string; },
+    ) {
         const key = `${sel.startItemId}-${sel.endItemId}-${sel.userId || "local"}`;
         this.selections = { ...this.selections, [key]: sel };
     }
     clearCursorAndSelection(userId = "local", clearSelections = false) {
         this.cursors = Object.fromEntries(
-            Object.entries(this.cursors).filter((entry: [string, { itemId: string, userId: string }]) => entry[1].userId !== userId),
+            Object.entries(this.cursors).filter((entry: [string, { itemId: string; userId: string; }]) =>
+                entry[1].userId !== userId
+            ),
         );
         if (clearSelections) {
             this.selections = Object.fromEntries(
-                Object.entries(this.selections).filter((entry: [string, { userId?: string }]) => entry[1].userId !== userId),
+                Object.entries(this.selections).filter((entry: [string, { userId?: string; }]) =>
+                    entry[1].userId !== userId
+                ),
             );
         }
     }
     clearSelectionForUser(userId = "local") {
         this.selections = Object.fromEntries(
-            Object.entries(this.selections).filter(([key, s]: [string, { userId?: string }]) =>
+            Object.entries(this.selections).filter(([key, s]: [string, { userId?: string; }]) =>
                 !key.includes(`-${userId}`) && s.userId !== userId
             ),
         );

--- a/client/src/stores/GeneralStore_pageExists.test.ts
+++ b/client/src/stores/GeneralStore_pageExists.test.ts
@@ -16,7 +16,7 @@ describe("GeneralStore Page Existence", () => {
 
         // Force manual cache rebuild if observers are not firing in test env
         // Accessing private method via any casting for testing
-        (store as any)._rebuildPageNamesCache();
+        (store as unknown as { _rebuildPageNamesCache: () => void })._rebuildPageNamesCache();
 
         expect(store.pageExists("Page A")).toBe(true);
         expect(store.pageExists("page a")).toBe(true); // Case insensitive
@@ -24,7 +24,7 @@ describe("GeneralStore Page Existence", () => {
 
         // Add another page
         project.addPage("Page B", "user1");
-        (store as any)._rebuildPageNamesCache();
+        (store as unknown as { _rebuildPageNamesCache: () => void })._rebuildPageNamesCache();
         expect(store.pageExists("Page B")).toBe(true);
 
         // Rename logic is harder to simulate via Project helper as it doesn't expose renamePage.
@@ -42,7 +42,7 @@ describe("GeneralStore Page Existence", () => {
         expect(itemA).toBeDefined();
         if (itemA) {
             itemA.updateText("Page A Renamed");
-            (store as any)._rebuildPageNamesCache();
+            (store as unknown as { _rebuildPageNamesCache: () => void })._rebuildPageNamesCache();
             // Check if cache updates
             expect(store.pageExists("Page A")).toBe(false);
             expect(store.pageExists("Page A Renamed")).toBe(true);
@@ -51,7 +51,7 @@ describe("GeneralStore Page Existence", () => {
         // Delete page
         if (itemA) {
             itemA.delete();
-            (store as any)._rebuildPageNamesCache();
+            (store as unknown as { _rebuildPageNamesCache: () => void })._rebuildPageNamesCache();
             expect(store.pageExists("Page A Renamed")).toBe(false);
         }
     });

--- a/client/src/stores/GeneralStore_pageExists.test.ts
+++ b/client/src/stores/GeneralStore_pageExists.test.ts
@@ -16,7 +16,7 @@ describe("GeneralStore Page Existence", () => {
 
         // Force manual cache rebuild if observers are not firing in test env
         // Accessing private method via any casting for testing
-        (store as unknown as { _rebuildPageNamesCache: () => void })._rebuildPageNamesCache();
+        (store as unknown as { _rebuildPageNamesCache: () => void; })._rebuildPageNamesCache();
 
         expect(store.pageExists("Page A")).toBe(true);
         expect(store.pageExists("page a")).toBe(true); // Case insensitive
@@ -24,7 +24,7 @@ describe("GeneralStore Page Existence", () => {
 
         // Add another page
         project.addPage("Page B", "user1");
-        (store as unknown as { _rebuildPageNamesCache: () => void })._rebuildPageNamesCache();
+        (store as unknown as { _rebuildPageNamesCache: () => void; })._rebuildPageNamesCache();
         expect(store.pageExists("Page B")).toBe(true);
 
         // Rename logic is harder to simulate via Project helper as it doesn't expose renamePage.
@@ -42,7 +42,7 @@ describe("GeneralStore Page Existence", () => {
         expect(itemA).toBeDefined();
         if (itemA) {
             itemA.updateText("Page A Renamed");
-            (store as unknown as { _rebuildPageNamesCache: () => void })._rebuildPageNamesCache();
+            (store as unknown as { _rebuildPageNamesCache: () => void; })._rebuildPageNamesCache();
             // Check if cache updates
             expect(store.pageExists("Page A")).toBe(false);
             expect(store.pageExists("Page A Renamed")).toBe(true);
@@ -51,7 +51,7 @@ describe("GeneralStore Page Existence", () => {
         // Delete page
         if (itemA) {
             itemA.delete();
-            (store as unknown as { _rebuildPageNamesCache: () => void })._rebuildPageNamesCache();
+            (store as unknown as { _rebuildPageNamesCache: () => void; })._rebuildPageNamesCache();
             expect(store.pageExists("Page A Renamed")).toBe(false);
         }
     });

--- a/client/src/tests/importExport.test.ts
+++ b/client/src/tests/importExport.test.ts
@@ -16,14 +16,14 @@ describe("Import/Export Service", () => {
             importMarkdownIntoProject(markdown, project);
 
             // There should be 1 page created in the project
-            expect((project.items as any).length).toBe(1);
+            expect(project.items.length).toBe(1);
 
-            const page = (project.items as any)[0];
+            const page = project.items.at(0)!;
             expect(page.text).toBe("ImportedPage");
 
             // There should be 1 child item in the page
-            expect((page.items as any).length).toBe(1);
-            expect((page.items as any)[0].text).toBe("Child");
+            expect(page.items.length).toBe(1);
+            expect(page.items.at(0)!.text).toBe("Child");
         });
 
         it("should import nested markdown with multiple levels", () => {
@@ -33,19 +33,19 @@ describe("Import/Export Service", () => {
             importMarkdownIntoProject(markdown, project);
 
             // There should be 1 page created in the project
-            expect((project.items as any).length).toBe(1);
+            expect(project.items.length).toBe(1);
 
-            const page = (project.items as any)[0];
+            const page = project.items.at(0)!;
             expect(page.text).toBe("Parent");
 
             // There should be 1 child item in the page
-            expect((page.items as any).length).toBe(1);
-            const child = (page.items as any)[0];
+            expect(page.items.length).toBe(1);
+            const child = page.items.at(0)!;
             expect(child.text).toBe("Child");
 
             // There should be 1 grandchild item in the child item
-            expect((child.items as any).length).toBe(1);
-            expect((child.items as any)[0].text).toBe("Grand");
+            expect(child.items.length).toBe(1);
+            expect(child.items.at(0)!.text).toBe("Grand");
         });
 
         it("should import multiple root items correctly", () => {
@@ -56,19 +56,19 @@ describe("Import/Export Service", () => {
 
             // In the current implementation, only the first indent 0 item is created as a page,
             // and subsequent indent 0 items are created as children of the first page
-            expect((project.items as any).length).toBe(1);
+            expect(project.items.length).toBe(1);
 
-            const page = (project.items as any)[0];
+            const page = project.items.at(0)!;
             expect(page.text).toBe("FirstPage");
 
             // There should be 2 child items in the page (Child1 and SecondItem)
-            expect((page.items as any).length).toBe(2);
-            expect((page.items as any)[0].text).toBe("Child1");
-            expect((page.items as any)[1].text).toBe("SecondItem");
+            expect(page.items.length).toBe(2);
+            expect(page.items.at(0)!.text).toBe("Child1");
+            expect(page.items.at(1)!.text).toBe("SecondItem");
 
             // There should be 1 child item in SecondItem
-            expect((page.items as any)[1].items.length).toBe(1);
-            expect((page.items as any)[1].items[0].text).toBe("Child2");
+            expect(page.items.at(1)!.items.length).toBe(1);
+            expect(page.items.at(1)!.items[0].text).toBe("Child2");
         });
     });
 
@@ -80,14 +80,14 @@ describe("Import/Export Service", () => {
             importOpmlIntoProject(opml, project);
 
             // There should be 1 page created in the project
-            expect((project.items as any).length).toBe(1);
+            expect(project.items.length).toBe(1);
 
-            const page = (project.items as any)[0];
+            const page = project.items.at(0)!;
             expect(page.text).toBe("Imported");
 
             // There should be 1 child item in the page
-            expect((page.items as any).length).toBe(1);
-            expect((page.items as any)[0].text).toBe("Child");
+            expect(page.items.length).toBe(1);
+            expect(page.items.at(0)!.text).toBe("Child");
         });
     });
 
@@ -95,7 +95,7 @@ describe("Import/Export Service", () => {
         it("should export project to markdown", () => {
             const project = Project.createInstance("Test Project");
             const page = project.addPage("TestPage", "test");
-            const child = (page.items as any).addNode("test");
+            const child = page.items.addNode("test");
             child.updateText("Child Item");
 
             const markdown = exportProjectToMarkdown(project);
@@ -106,7 +106,7 @@ describe("Import/Export Service", () => {
         it("should export project to OPML", () => {
             const project = Project.createInstance("Test Project");
             const page = project.addPage("TestPage", "test");
-            const child = (page.items as any).addNode("test");
+            const child = page.items.addNode("test");
             child.updateText("Child Item");
 
             const opml = exportProjectToOpml(project);

--- a/client/src/tests/scheduleService.test.ts
+++ b/client/src/tests/scheduleService.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 it("calls createSchedule API", async () => {
     // Set up mock fetch response
     const mockResponse = { scheduleId: "test-schedule-id" };
-    (global.fetch as any).mockResolvedValueOnce({
+    vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockResponse),
     });
@@ -51,7 +51,7 @@ it("calls listSchedules API", async () => {
         { id: "schedule1", strategy: "one_shot", params: {}, nextRunAt: Date.now() + 60000 },
         { id: "schedule2", strategy: "recurring", params: {}, nextRunAt: Date.now() + 120000 },
     ];
-    (global.fetch as any).mockResolvedValueOnce({
+    vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ schedules: mockSchedules }),
     });
@@ -81,7 +81,7 @@ it("calls listSchedules API", async () => {
 it("calls cancelSchedule API", async () => {
     // Set up mock fetch response
     const mockResponse = { success: true };
-    (global.fetch as any).mockResolvedValueOnce({
+    vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockResponse),
     });
@@ -108,7 +108,7 @@ it("calls cancelSchedule API", async () => {
 
 it("calls updateSchedule API", async () => {
     const mockResponse = { success: true };
-    (global.fetch as any).mockResolvedValueOnce({
+    vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve(mockResponse),
     });
@@ -138,8 +138,7 @@ it("calls updateSchedule API", async () => {
 });
 
 it("calls exportSchedulesIcal API", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global.fetch as any).mockResolvedValueOnce({
+    vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
         headers: {
             get: (key: string) => key === "Content-Disposition" ? 'attachment; filename="test.ics"' : null,


### PR DESCRIPTION
[Issues]
Addresses parts of the `TODO: Fix these issues incrementally and convert back to errors` from `client/eslint.config.js` by cleaning up `@typescript-eslint/no-explicit-any` instances.

[Changes]
Refactored several specific testing and store-related files to eliminate `any` types:
- `client/src/tests/importExport.test.ts`: Removed `(project.items as any)[0]` in favor of using `project.items.at(0)!`.
- `client/src/stores/EditorOverlayStore.test.ts`: Fully typed `cursors`, `selections`, and mock instance structures.
- `client/src/stores/GeneralStore_pageExists.test.ts`: Properly typed the `store._rebuildPageNamesCache()` internal invocation.
- `client/src/tests/scheduleService.test.ts`: Replaced `(global.fetch as any)` with `vi.mocked(global.fetch)`.

[Verification Results]
Verified locally by running the test suite (`npm run test:unit`) on the modified files, observing all passing tests, and checking ESLint reports (`npx eslint`) showing a reduction in warning count for these files.

---
*PR created automatically by Jules for task [9439582585577553099](https://jules.google.com/task/9439582585577553099) started by @kitamura-tetsuo*