### PR TITLE
test(server): add regression coverage for demo room anonymous websocket access

### DIFF
--- a/server/tests/hocuspocus-demo-access.test.ts
+++ b/server/tests/hocuspocus-demo-access.test.ts
@@ -1,0 +1,119 @@
+import { HocuspocusProvider } from "@hocuspocus/provider";
+import { expect } from "chai";
+import sinon from "sinon";
+import WebSocket from "ws";
+import * as Y from "yjs";
+import { loadConfig } from "../src/config.js";
+import { startServer } from "../src/server.js";
+
+// @ts-ignore
+global.WebSocket = WebSocket;
+
+// Regression coverage for the public demo room (`projects/demo`).
+// The demo page is served to signed-out users, so the websocket server must
+// accept the connection without a verifiable Firebase ID token. This flow
+// broke in production twice (#2982, #2986) because it had no test coverage:
+// the client sends a dummy token ("1") to make HocuspocusProvider emit its
+// Auth message, and the server must short-circuit auth before verifying it.
+describe("Hocuspocus demo room anonymous access", () => {
+    let httpServer: any;
+    let provider: HocuspocusProvider;
+    let port: number;
+    let checkAccessStub: sinon.SinonStub;
+    let verifyTokenStub: sinon.SinonStub;
+    let shutdown: () => Promise<void>;
+
+    beforeEach(async () => {
+        checkAccessStub = sinon.stub().resolves(false);
+        // Rejects like production would for the dummy "1" token; demo rooms must never reach it
+        verifyTokenStub = sinon.stub().rejects(new Error("invalid token (test stub)"));
+
+        process.env.DISABLE_PERSISTENCE = "true";
+
+        const config = loadConfig({ PORT: "0", LOG_LEVEL: "silent" });
+        const res = await startServer(config, undefined, {
+            checkContainerAccess: checkAccessStub,
+            verifyIdTokenCached: verifyTokenStub,
+        });
+        httpServer = res.server;
+        shutdown = res.shutdown;
+
+        await new Promise<void>(resolve => {
+            if (httpServer.listening) resolve();
+            else httpServer.on("listening", resolve);
+        });
+        port = (httpServer.address() as any).port;
+    });
+
+    afterEach(async () => {
+        provider?.destroy();
+        if (shutdown) await shutdown();
+        sinon.restore();
+        delete process.env.DISABLE_PERSISTENCE;
+    });
+
+    const waitForAuthenticated = (p: HocuspocusProvider) =>
+        new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error("Timed out waiting for authenticated event")), 8000);
+            p.on("authenticated", () => {
+                clearTimeout(timeout);
+                resolve();
+            });
+            p.on("authenticationFailed", (data: unknown) => {
+                clearTimeout(timeout);
+                reject(new Error(`authenticationFailed: ${JSON.stringify(data)}`));
+            });
+        });
+
+    it("authenticates the demo room exactly like the production client (url ?token=1, provider token '1')", async () => {
+        // Mirrors createProjectConnection() in client/src/lib/yjs/connection.ts
+        provider = new HocuspocusProvider({
+            url: `ws://127.0.0.1:${port}/projects/demo?token=1`,
+            name: "projects/demo",
+            document: new Y.Doc(),
+            token: "1",
+        });
+
+        await waitForAuthenticated(provider);
+
+        // Demo access must not consult Firebase token verification or Firestore ACLs
+        expect(verifyTokenStub.called).to.equal(false);
+        expect(checkAccessStub.called).to.equal(false);
+    });
+
+    it("authenticates the demo room without a token in the upgrade URL", async () => {
+        // Reconnects may omit the URL token and send it only in the Auth payload
+        provider = new HocuspocusProvider({
+            url: `ws://127.0.0.1:${port}/projects/demo`,
+            name: "projects/demo",
+            document: new Y.Doc(),
+            token: "1",
+        });
+
+        await waitForAuthenticated(provider);
+        expect(verifyTokenStub.called).to.equal(false);
+    });
+
+    it("still rejects non-demo rooms that present the dummy demo token", async () => {
+        provider = new HocuspocusProvider({
+            url: `ws://127.0.0.1:${port}/projects/123?token=1`,
+            name: "projects/123",
+            document: new Y.Doc(),
+            token: "1",
+        });
+
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error("Timed out waiting for auth rejection")), 8000);
+            const done = () => {
+                clearTimeout(timeout);
+                resolve();
+            };
+            provider.on("authenticationFailed", done);
+            provider.on("disconnect", done);
+            provider.on("authenticated", () => {
+                clearTimeout(timeout);
+                reject(new Error("Dummy token must not authenticate a non-demo room"));
+            });
+        });
+    });
+});


### PR DESCRIPTION
## [Issues] Problems discovered and areas for improvement

Observed the production demo environment (https://outliner-d57b0.web.app/demo) with a headless browser: the page is stuck at **"Loading Demo..."** and the console shows `[yjs-conn] projects/demo authenticationFailed`. The websocket connects to `wss://outliner-yjs-ws.outliner-online.com/projects/demo?token=1` and then fails authentication.

Investigation against current `main`:
- Running the hocuspocus server from `main` locally and connecting exactly like the production client (dummy token `"1"` in the upgrade URL and in the Hocuspocus Auth payload) **succeeds** — the demo bypass added in #2986 works.
- Therefore the live failure is a **stale deployment**: `outliner-yjs-ws.outliner-online.com` is still running an image from before #2986 (`build-server.yml` pushes `yjs-ws-server:latest` on merge, but the host has not picked it up). Redeploying the server image should resolve the production symptom.
- Root gap on the code side: the demo anonymous-access flow broke in production **twice** (#2982, #2986) because no test exercises it. `server/tests/hocuspocus-auth-bypass.test.ts` only covers blocking cases; there was zero positive coverage for `projects/demo`.

## [Changes]

Added `server/tests/hocuspocus-demo-access.test.ts` (Mocha + Chai + Sinon, in-process server via `startServer`, no mocks of Hocuspocus itself):

1. **Production-client flow**: connects to `projects/demo` with `?token=1` in the URL and provider token `"1"` (mirroring `createProjectConnection` in `client/src/lib/yjs/connection.ts`), asserts the `authenticated` event fires and that neither `verifyIdTokenCached` nor `checkContainerAccess` is consulted.
2. **Reconnect flow**: same, but without any token in the upgrade URL (token arrives only in the Auth payload — the exact case #2986 fixed).
3. **Security guard**: the dummy `"1"` token must still be rejected for non-demo rooms (`projects/123`).

No production code changed. The new file is picked up by the default `scripts/run-server-tests.sh` glob (it is not in the exclusion list) and exits cleanly.

## [Verification Results]

- New test file: `3 passing (54ms)`, process exits cleanly without `--exit`.
- Full default server suite (same glob + excludes as `scripts/run-server-tests.sh`): **56 passing**, exit code 0, including the new describe block.
- `npx tsc --noEmit` in `server/`: clean.
- `dprint fmt`: no changes needed (pre-commit hooks passed).
- Client typechecks (`client` and `client/e2e`) report only pre-existing errors in `src/yjs/YjsClient.ts` and `src/lib/yjs/testHelpers.ts`, untouched by this PR.

## Note for operators

The production fix itself is already merged (#2986); the demo page will keep failing until the websocket server host pulls the new `ghcr.io/.../yjs-ws-server:latest` image. This PR ensures the demo flow cannot silently regress again once redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)