### PR TITLE
fix(server): skip Secret Manager load when Admin SDK path is set and exists

### DIFF
--- a/server/src/firebase-init.ts
+++ b/server/src/firebase-init.ts
@@ -123,10 +123,12 @@ export function getServiceAccount() {
     };
 }
 
-const isEmulatorEnvironment = process.env.USE_FIREBASE_EMULATOR === "true"
-    || process.env.FIREBASE_AUTH_EMULATOR_HOST
-    || process.env.FIRESTORE_EMULATOR_HOST
-    || process.env.FIREBASE_EMULATOR_HOST;
+function getIsEmulatorEnvironment() {
+    return process.env.USE_FIREBASE_EMULATOR === "true"
+        || !!process.env.FIREBASE_AUTH_EMULATOR_HOST
+        || !!process.env.FIRESTORE_EMULATOR_HOST
+        || !!process.env.FIREBASE_EMULATOR_HOST;
+}
 
 async function waitForFirebaseEmulator(maxRetries = 30, initialDelay = 1000, maxDelay = 10000) {
     const isEmulator = process.env.FIREBASE_AUTH_EMULATOR_HOST
@@ -229,10 +231,27 @@ async function clearFirestoreEmulatorData() {
     }
 }
 
+function hasAdminSdkFile(): boolean {
+    if (process.env.FIREBASE_ADMIN_SDK_PATH) {
+        const candidates = [
+            path.resolve(process.env.FIREBASE_ADMIN_SDK_PATH),
+            path.resolve(__dirname, process.env.FIREBASE_ADMIN_SDK_PATH),
+            path.resolve(__dirname, "..", process.env.FIREBASE_ADMIN_SDK_PATH),
+        ];
+
+        for (const candidate of candidates) {
+            if (fs.existsSync(candidate)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 export async function initializeFirebase() {
     try {
-        // Load secrets from GCP Secret Manager if not in emulator environment
-        if (!isEmulatorEnvironment) {
+        // Load secrets from GCP Secret Manager if not in emulator environment and SDK file doesn't exist
+        if (!getIsEmulatorEnvironment() && !hasAdminSdkFile()) {
             await secretManager.loadSecrets([
                 "FIREBASE_PRIVATE_KEY",
                 "FIREBASE_PRIVATE_KEY_ID",
@@ -244,7 +263,7 @@ export async function initializeFirebase() {
 
         const serviceAccount = getServiceAccount();
 
-        if (!serviceAccount.project_id && !isEmulatorEnvironment) {
+        if (!serviceAccount.project_id && !getIsEmulatorEnvironment()) {
             logger.error(
                 "Firebase service account environment variables are not properly configured.",
             );
@@ -275,7 +294,7 @@ export async function initializeFirebase() {
             logger.warn("These environment variables should be set in .env.test and should not be set in production.");
         }
         if (
-            isEmulatorEnvironment
+            getIsEmulatorEnvironment()
             && (!serviceAccount.private_key || serviceAccount.private_key.includes("Your Private Key Here"))
         ) {
             admin.initializeApp({ projectId: serviceAccount.project_id });

--- a/server/tests/firebase-init.test.ts
+++ b/server/tests/firebase-init.test.ts
@@ -1,0 +1,87 @@
+import { expect } from "chai";
+import admin from "firebase-admin";
+import fs from "fs";
+import path from "path";
+import sinon from "sinon";
+import { fileURLToPath } from "url";
+import { initializeFirebase } from "../src/firebase-init.js";
+import { secretManager } from "../src/secret-manager.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe("firebase-init Secret Manager loading bypass", () => {
+    let originalEnv: NodeJS.ProcessEnv;
+    let loadSecretsStub: sinon.SinonStub;
+    let initializeAppStub: sinon.SinonStub;
+    let deleteAppStub: sinon.SinonStub;
+    let certStub: sinon.SinonStub;
+    const dummySdkPath = path.resolve(__dirname, "dummy-sdk-test.json");
+
+    beforeEach(() => {
+        originalEnv = { ...process.env };
+
+        // Mock Secret Manager
+        loadSecretsStub = sinon.stub(secretManager, "loadSecrets").resolves();
+
+        // Mock Firebase Admin
+        initializeAppStub = sinon.stub(admin, "initializeApp");
+        certStub = sinon.stub(admin.credential, "cert").returns({} as any);
+        deleteAppStub = sinon.stub().resolves();
+        sinon.stub(admin, "app").returns({ delete: deleteAppStub } as any);
+        sinon.stub(admin, "apps").get(() => []);
+
+        // By default, make it look like non-emulator environment to trigger Secret Manager load checks
+        delete process.env.USE_FIREBASE_EMULATOR;
+        delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
+        delete process.env.FIRESTORE_EMULATOR_HOST;
+        delete process.env.FIREBASE_EMULATOR_HOST;
+
+        process.env.NODE_ENV = "production";
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        process.env = originalEnv;
+        if (fs.existsSync(dummySdkPath)) {
+            fs.unlinkSync(dummySdkPath);
+        }
+    });
+
+    it("should load secrets when FIREBASE_ADMIN_SDK_PATH is not set", async () => {
+        delete process.env.FIREBASE_ADMIN_SDK_PATH;
+
+        await initializeFirebase();
+
+        expect(loadSecretsStub.calledOnce).to.be.true;
+    });
+
+    it("should load secrets when FIREBASE_ADMIN_SDK_PATH is set but the file does not exist", async () => {
+        process.env.FIREBASE_ADMIN_SDK_PATH = "./non-existent-sdk-file-xyz.json";
+
+        // Try-catch block since getServiceAccount might fail if no environment variables are present either
+        try {
+            await initializeFirebase();
+        } catch (error) {
+            // we only care whether loadSecrets was called before any failure
+        }
+
+        expect(loadSecretsStub.calledOnce).to.be.true;
+    });
+
+    it("should skip loading secrets when FIREBASE_ADMIN_SDK_PATH is set and the file exists", async () => {
+        // Create dummy SDK file
+        const dummySdkContent = {
+            type: "service_account",
+            project_id: "test-project-id",
+            private_key: "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADAN\n-----END PRIVATE KEY-----",
+        };
+        fs.writeFileSync(dummySdkPath, JSON.stringify(dummySdkContent), "utf-8");
+
+        process.env.FIREBASE_ADMIN_SDK_PATH = dummySdkPath;
+
+        await initializeFirebase();
+
+        expect(loadSecretsStub.called).to.be.false;
+    });
+});


### PR DESCRIPTION
This PR modifies firebase-init.ts to skip loading secrets from GCP Secret Manager when a valid Firebase Admin SDK credential file is provided via FIREBASE_ADMIN_SDK_PATH. It also introduces a unit test file to cover this behavior.