### PR TITLE
refactor(client): update deprecated on:click syntax in LandingContent.svelte

### DIFF
--- a/client/src/components/LandingContent.svelte
+++ b/client/src/components/LandingContent.svelte
@@ -22,10 +22,10 @@
     </section>
 
     <section class="cta-section">
-        <button class="cta-button primary" on:click={login}>
+        <button class="cta-button primary" onclick={login}>
             Sign in with Google
         </button>
-        <button class="cta-button secondary" on:click={login}>
+        <button class="cta-button secondary" onclick={login}>
             Get Started
         </button>
     </section>


### PR DESCRIPTION
[Issues]
Svelte 4 `on:click` event directive syntax is deprecated in Svelte 5, causing `event_directive_deprecated` compilation warnings when running the build or `svelte-check`.

[Changes]
- Updated `on:click={login}` to the Svelte 5 native `onclick={login}` syntax in `client/src/components/LandingContent.svelte`.

[Verification Results]
- Ran `cd client && npx svelte-check` and confirmed the `event_directive_deprecated` warning for `LandingContent.svelte` is resolved.
- Ran `npm run test:unit` and `npm run build` in the `client` directory to ensure functionality remains intact without build regressions.

---
*PR created automatically by Jules for task [12673715877688598971](https://jules.google.com/task/12673715877688598971) started by @kitamura-tetsuo*