### PR TITLE
refactor: replace any with precise types in client lib and tests

### DIFF
--- a/client/src/lib/Cursor.selection.test.ts
+++ b/client/src/lib/Cursor.selection.test.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Item } from "../schema/app-schema";
 import { Cursor } from "./Cursor";
 
 // Helper to manage mock selection state
-let mockSelection: any = undefined;
+let mockSelection: import("../stores/EditorOverlayStore.svelte").SelectionState | undefined = undefined;
 
 // Mocks for stores
 vi.mock("../stores/EditorOverlayStore.svelte", () => ({

--- a/client/src/lib/cursor/CursorFormatting.ts
+++ b/client/src/lib/cursor/CursorFormatting.ts
@@ -5,11 +5,11 @@ import { escapeId } from "../../utils/domUtils";
 import { ScrapboxFormatter } from "../../utils/ScrapboxFormatter";
 
 export class CursorFormatting {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private cursor: any; // Holds an instance of the Cursor class
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(cursor: any) {
+    private cursor: import("../Cursor").Cursor;
+
+
+    constructor(cursor: import("../Cursor").Cursor) {
         this.cursor = cursor;
     }
 
@@ -115,8 +115,8 @@ export class CursorFormatting {
      * Apply Scrapbox syntax formatting to selection spanning multiple items
      */
     private applyScrapboxFormattingToMultipleItems(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        selection: any,
+
+        selection: import("../stores/EditorOverlayStore.svelte").SelectionState,
         formatType: "bold" | "italic" | "strikethrough" | "underline" | "code",
     ) {
         // Get start and end item IDs

--- a/client/src/lib/cursor/CursorFormatting.ts
+++ b/client/src/lib/cursor/CursorFormatting.ts
@@ -5,9 +5,7 @@ import { escapeId } from "../../utils/domUtils";
 import { ScrapboxFormatter } from "../../utils/ScrapboxFormatter";
 
 export class CursorFormatting {
-
     private cursor: import("../Cursor").Cursor;
-
 
     constructor(cursor: import("../Cursor").Cursor) {
         this.cursor = cursor;
@@ -115,7 +113,6 @@ export class CursorFormatting {
      * Apply Scrapbox syntax formatting to selection spanning multiple items
      */
     private applyScrapboxFormattingToMultipleItems(
-
         selection: import("../stores/EditorOverlayStore.svelte").SelectionState,
         formatType: "bold" | "italic" | "strikethrough" | "underline" | "code",
     ) {

--- a/client/src/lib/cursor/CursorSelection.ts
+++ b/client/src/lib/cursor/CursorSelection.ts
@@ -4,9 +4,7 @@ import { escapeId } from "../../utils/domUtils";
 // import { store as generalStore } from "../../stores/store.svelte"; // Not used
 
 export class CursorSelection {
-
     private cursor: import("../Cursor").Cursor;
-
 
     constructor(cursor: import("../Cursor").Cursor) {
         this.cursor = cursor;

--- a/client/src/lib/cursor/CursorSelection.ts
+++ b/client/src/lib/cursor/CursorSelection.ts
@@ -4,11 +4,11 @@ import { escapeId } from "../../utils/domUtils";
 // import { store as generalStore } from "../../stores/store.svelte"; // Not used
 
 export class CursorSelection {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private cursor: any; // Holds the instance of the Cursor class
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(cursor: any) {
+    private cursor: import("../Cursor").Cursor;
+
+
+    constructor(cursor: import("../Cursor").Cursor) {
         this.cursor = cursor;
     }
 

--- a/client/src/lib/yjs/tokenRefresh.ts
+++ b/client/src/lib/yjs/tokenRefresh.ts
@@ -44,7 +44,7 @@ export function refreshAuthAndReconnect(provider: TokenRefreshableProvider): () 
             // Update the URL with the new token so that future reconnections (which rely on the URL for handshake) pass
             // HocuspocusProvider re-uses the initial URL string, so if we don't update it, it sends the old/expired token.
 
-            const config = provider.configuration as { url?: string; websocketProvider?: { status?: string } };
+            const config = provider.configuration as { url?: string; websocketProvider?: { status?: string; }; };
             if (config?.url && typeof config.url === "string") {
                 const urlObj = new URL(config.url);
                 if (t) {

--- a/client/src/lib/yjs/tokenRefresh.ts
+++ b/client/src/lib/yjs/tokenRefresh.ts
@@ -43,8 +43,8 @@ export function refreshAuthAndReconnect(provider: TokenRefreshableProvider): () 
             }
             // Update the URL with the new token so that future reconnections (which rely on the URL for handshake) pass
             // HocuspocusProvider re-uses the initial URL string, so if we don't update it, it sends the old/expired token.
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const config = provider.configuration as any;
+
+            const config = provider.configuration as { url?: string; websocketProvider?: { status?: string } };
             if (config?.url && typeof config.url === "string") {
                 const urlObj = new URL(config.url);
                 if (t) {

--- a/client/src/tests/unit/yjs/YjsClient.spec.ts
+++ b/client/src/tests/unit/yjs/YjsClient.spec.ts
@@ -39,7 +39,13 @@ describe("YjsClient", () => {
         // Dynamically import HocuspocusProvider to use the mocked version
         const { HocuspocusProvider } = await import("@hocuspocus/provider");
 
-        provider = new HocuspocusProvider({ name: "mock-provider", document: doc, url: "ws://mock" } as import("@hocuspocus/provider").HocuspocusProviderConfiguration);
+        provider = new HocuspocusProvider(
+            {
+                name: "mock-provider",
+                document: doc,
+                url: "ws://mock",
+            } as import("@hocuspocus/provider").HocuspocusProviderConfiguration,
+        );
 
         // Create a simple mock for Project since we don't need its full logic for this test
         project = {

--- a/client/src/tests/unit/yjs/YjsClient.spec.ts
+++ b/client/src/tests/unit/yjs/YjsClient.spec.ts
@@ -25,10 +25,10 @@ describe("YjsClient", () => {
     const clientId = "test-client-id";
     const projectId = "test-project-id";
     let doc: Y.Doc;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let provider: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let project: any;
+
+    let provider: import("@hocuspocus/provider").HocuspocusProvider;
+
+    let project: { metadata: unknown; rootFolder: unknown; items: unknown; dispose: unknown; };
 
     beforeEach(async () => {
         // Reset mocks
@@ -38,8 +38,8 @@ describe("YjsClient", () => {
 
         // Dynamically import HocuspocusProvider to use the mocked version
         const { HocuspocusProvider } = await import("@hocuspocus/provider");
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        provider = new HocuspocusProvider({} as any);
+
+        provider = new HocuspocusProvider({ name: "mock-provider", document: doc, url: "ws://mock" } as import("@hocuspocus/provider").HocuspocusProviderConfiguration);
 
         // Create a simple mock for Project since we don't need its full logic for this test
         project = {

--- a/client/src/utils/pathUtils.ts
+++ b/client/src/utils/pathUtils.ts
@@ -5,6 +5,6 @@ import { resolve as kitResolve } from "$app/paths";
  * 'Expected 2 arguments, but got 1' errors with dynamic paths.
  */
 export function resolvePath(path: string): string {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return kitResolve(path as any, undefined as any);
+
+    return kitResolve(path as Parameters<typeof kitResolve>[0], undefined as Parameters<typeof kitResolve>[1]);
 }

--- a/client/src/utils/pathUtils.ts
+++ b/client/src/utils/pathUtils.ts
@@ -5,6 +5,5 @@ import { resolve as kitResolve } from "$app/paths";
  * 'Expected 2 arguments, but got 1' errors with dynamic paths.
  */
 export function resolvePath(path: string): string {
-
     return kitResolve(path as Parameters<typeof kitResolve>[0], undefined as Parameters<typeof kitResolve>[1]);
 }


### PR DESCRIPTION
[Issues]
ESLint warnings related to `@typescript-eslint/no-explicit-any` were present across several `client/src` files. These suppressions mask potential type issues and reduce code safety.

[Changes]
- Removed `@typescript-eslint/no-explicit-any` warning suppressions from:
  - `client/src/lib/Cursor.selection.test.ts`
  - `client/src/lib/cursor/CursorFormatting.ts`
  - `client/src/lib/cursor/CursorSelection.ts`
  - `client/src/lib/yjs/tokenRefresh.ts`
  - `client/src/tests/unit/yjs/YjsClient.spec.ts`
  - `client/src/utils/pathUtils.ts`
- Replaced `any` with explicit typings, such as `import("../Cursor").Cursor`, `import("../../stores/EditorOverlayStore.svelte").SelectionState`, `import("@hocuspocus/provider").HocuspocusProvider`, and `Parameters<typeof kitResolve>`.

[Verification Results]
- Ran `npx eslint .` in `client`: Warnings count decreased by 6.
- Ran `npm run test:unit --prefix client`: All tests passed.
- Ran `npm run build --prefix client`: Build succeeded without regression.

---
*PR created automatically by Jules for task [7659721111278468076](https://jules.google.com/task/7659721111278468076) started by @kitamura-tetsuo*