### PR TITLE
Refactor: Resolve explicit any ESLint warnings in client tests and setups

### DIFF
--- a/client/src/lib/Cursor.selection.test.ts
+++ b/client/src/lib/Cursor.selection.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Item } from "../schema/app-schema";
+import type { SelectionRange } from "../stores/EditorOverlayStore.svelte";
 import { Cursor } from "./Cursor";
 
 // Helper to manage mock selection state
@@ -13,7 +14,7 @@ vi.mock("../stores/EditorOverlayStore.svelte", () => ({
         update: vi.fn(),
         set: vi.fn(),
         updateCursor: vi.fn(),
-        setCursor: vi.fn((opts: any) => `cursor-${opts.itemId}-${Math.random()}`),
+        setCursor: vi.fn((opts: { itemId: string; }) => `cursor-${opts.itemId}-${Math.random()}`),
         setActiveItem: vi.fn(),
         getTextareaRef: vi.fn(() => ({
             focus: vi.fn(),
@@ -50,7 +51,7 @@ vi.mock("../stores/store.svelte", () => ({
 
 // Mock cursor utility functions
 vi.mock("./cursor", async (importOriginal) => {
-    const actual: any = await importOriginal();
+    const actual = await importOriginal() as Record<string, unknown>;
     return {
         ...actual,
         findNextItem: (itemId: string) => {
@@ -65,7 +66,7 @@ vi.mock("./cursor", async (importOriginal) => {
         },
         getSelectionForUser: () => mockSelection,
         hasSelection: () => !!mockSelection,
-        searchItem: (root: any, itemId: string) => {
+        searchItem: (root: unknown, itemId: string) => {
             if (itemId === "item1") return { id: "item1", text: "Hello" };
             if (itemId === "item2") return { id: "item2", text: "World" };
             if (itemId === "item3") return { id: "item3", text: "Test" };
@@ -120,12 +121,13 @@ describe("Cursor Selection Reproduction", () => {
         });
 
         // Spy on findTarget to return mock items
-        vi.spyOn(cursor as any, "findTarget").mockImplementation(() => {
+        vi.spyOn(cursor as unknown as { findTarget: () => unknown; }, "findTarget").mockImplementation(() => {
             return mockItems.find(i => i.id === cursor.itemId);
         });
 
         // Ensure getTargetText works
-        vi.spyOn(cursor as any, "getTargetText").mockImplementation((target: any) => target?.text || "");
+        vi.spyOn(cursor as unknown as { getTargetText: (target: { text?: string; }) => string; }, "getTargetText")
+            .mockImplementation((target: { text?: string; }) => target?.text || "");
     });
 
     afterEach(() => {
@@ -153,14 +155,14 @@ describe("Cursor Selection Reproduction", () => {
             const { editorOverlayStore } = await import("../stores/EditorOverlayStore.svelte");
 
             // Initial selection: 0->1
-            mockSelection = {
+            mockSelection = ({
                 startItemId: "item1",
                 startOffset: 0,
                 endItemId: "item1",
                 endOffset: 1,
                 isReversed: false,
                 userId: "test-user",
-            };
+            } as unknown) as import("../stores/EditorOverlayStore.svelte").SelectionState;
             cursor.offset = 1;
 
             cursor.extendSelectionRight();
@@ -179,14 +181,14 @@ describe("Cursor Selection Reproduction", () => {
             const { editorOverlayStore } = await import("../stores/EditorOverlayStore.svelte");
 
             // Initial selection: 2->1 (reversed)
-            mockSelection = {
+            mockSelection = ({
                 startItemId: "item1",
                 startOffset: 2,
                 endItemId: "item1",
                 endOffset: 1,
                 isReversed: true,
                 userId: "test-user",
-            };
+            } as unknown) as import("../stores/EditorOverlayStore.svelte").SelectionState;
             cursor.offset = 1;
 
             cursor.extendSelectionRight();
@@ -246,14 +248,14 @@ describe("Cursor Selection Reproduction", () => {
             const { editorOverlayStore } = await import("../stores/EditorOverlayStore.svelte");
 
             // Initial selection: 5->4 (reversed)
-            mockSelection = {
+            mockSelection = ({
                 startItemId: "item1",
                 startOffset: 5,
                 endItemId: "item1",
                 endOffset: 4,
                 isReversed: true,
                 userId: "test-user",
-            };
+            } as unknown) as import("../stores/EditorOverlayStore.svelte").SelectionState;
             cursor.offset = 4;
 
             cursor.extendSelectionLeft();
@@ -272,14 +274,14 @@ describe("Cursor Selection Reproduction", () => {
             const { editorOverlayStore } = await import("../stores/EditorOverlayStore.svelte");
 
             // Initial selection: 0->1 (normal)
-            mockSelection = {
+            mockSelection = ({
                 startItemId: "item1",
                 startOffset: 0,
                 endItemId: "item1",
                 endOffset: 1,
                 isReversed: false,
                 userId: "test-user",
-            };
+            } as unknown) as import("../stores/EditorOverlayStore.svelte").SelectionState;
             cursor.offset = 1;
 
             cursor.extendSelectionLeft();
@@ -321,14 +323,14 @@ describe("Cursor Selection Reproduction", () => {
             // Or assume we had 0->1 and shrank to 0->0.
 
             // Let's start with 0->1
-            mockSelection = {
+            mockSelection = ({
                 startItemId: "item1",
                 startOffset: 1, // Anchor at 1
                 endItemId: "item1",
                 endOffset: 1, // Focus at 1 (shrunk)
                 isReversed: false,
                 userId: "test-user",
-            };
+            } as unknown) as import("../stores/EditorOverlayStore.svelte").SelectionState;
             cursor.offset = 1;
 
             // Move left past anchor (1)
@@ -348,14 +350,14 @@ describe("Cursor Selection Reproduction", () => {
             const { editorOverlayStore } = await import("../stores/EditorOverlayStore.svelte");
 
             // Initial selection: 1->1 (was reversed)
-            mockSelection = {
+            mockSelection = ({
                 startItemId: "item1",
                 startOffset: 1,
                 endItemId: "item1",
                 endOffset: 1,
                 isReversed: true,
                 userId: "test-user",
-            };
+            } as unknown) as import("../stores/EditorOverlayStore.svelte").SelectionState;
             cursor.offset = 1;
 
             // Move right past anchor

--- a/client/src/lib/yjs/service.test.ts
+++ b/client/src/lib/yjs/service.test.ts
@@ -48,10 +48,10 @@ describe("yjsService", () => {
                 this.users = updatedUsers;
             },
         };
-        (globalThis as any).presenceStore = presenceStore;
+        (globalThis as unknown as { presenceStore: unknown; }).presenceStore = presenceStore;
         const unbind = yjsService.bindProjectPresence(awareness);
         awareness.setLocalStateField("user", { userId: "u1", name: "Alice" });
-        expect((presenceStore.users["u1"] as any).userName).toBe("Alice");
+        expect((presenceStore.users["u1"] as { userName?: string; }).userName).toBe("Alice");
         awareness.setLocalStateField("user", null);
         unbind();
     });
@@ -80,7 +80,7 @@ describe("yjsService", () => {
                 this.selections = updatedSelections;
             },
         };
-        (globalThis as any).editorOverlayStore = editorOverlayStore;
+        (globalThis as unknown as { editorOverlayStore: unknown; }).editorOverlayStore = editorOverlayStore;
         const unbind = yjsService.bindPagePresence(awareness);
 
         // seed local state (ignored by overlay sync)
@@ -88,17 +88,17 @@ describe("yjsService", () => {
         awareness.setLocalStateField("presence", { cursor: { itemId: "root", offset: 0 } });
 
         // simulate remote collaborator
-        const states = (awareness as any).getStates();
+        const states = awareness.getStates();
         states.set(42, {
             user: { userId: "u2", name: "Bob" },
             presence: { cursor: { itemId: "i1", offset: 0 } },
         });
-        (awareness as any).emit("change", [{ added: new Set([42]), updated: new Set(), removed: new Set() }, "test"]);
+        awareness.emit("change", [{ added: new Set([42]), updated: new Set(), removed: new Set() }, "test"]);
 
         const cursor = Object.values(editorOverlayStore.cursors).find(c => c.userId === "u2");
         expect(cursor?.itemId).toBe("i1");
 
-        (awareness as any).emit("change", [{ added: new Set(), updated: new Set(), removed: new Set([42]) }, "test"]);
+        awareness.emit("change", [{ added: new Set(), updated: new Set(), removed: new Set([42]) }, "test"]);
         unbind();
     });
 });

--- a/client/src/lib/yjsService.svelte.ts
+++ b/client/src/lib/yjsService.svelte.ts
@@ -61,16 +61,16 @@ class Registry {
 let registry: Registry;
 if (
     typeof window !== "undefined"
-    && ((window as any).__YJS_CLIENT_REGISTRY__ || (window as any).__FLUID_CLIENT_REGISTRY__)
+    && (window.__YJS_CLIENT_REGISTRY__ || window.__FLUID_CLIENT_REGISTRY__)
 ) {
-    registry = ((window as any).__YJS_CLIENT_REGISTRY__
-        || (window as any).__FLUID_CLIENT_REGISTRY__) as Registry;
+    registry = (window.__YJS_CLIENT_REGISTRY__
+        || window.__FLUID_CLIENT_REGISTRY__) as Registry;
 } else {
     registry = new Registry();
     if (typeof window !== "undefined") {
-        (window as any).__YJS_CLIENT_REGISTRY__ = registry;
+        window.__YJS_CLIENT_REGISTRY__ = registry;
         // Legacy alias for components still reading FLUID registry
-        (window as any).__FLUID_CLIENT_REGISTRY__ = registry;
+        window.__FLUID_CLIENT_REGISTRY__ = registry;
     }
 }
 
@@ -93,7 +93,7 @@ function isTestEnvironment(): boolean {
 
     // Fallback to runtime checks (for E2E tests where MODE might not be "test")
     if (typeof window !== "undefined") {
-        const win = window as any;
+        const win = window;
         const ls = win.localStorage;
 
         const isTestLs = ls?.getItem?.("VITE_IS_TEST");
@@ -208,8 +208,8 @@ export async function createNewProject(projectName: string, existingProjectId?: 
     yjsStore.yjsClient = client;
 
     if (typeof window !== "undefined") {
-        (window as any).__CURRENT_PROJECT__ = project;
-        (window as any).__CURRENT_PROJECT_TITLE__ = projectName;
+        window.__CURRENT_PROJECT__ = project;
+        window.__CURRENT_PROJECT_TITLE__ = projectName;
     }
 
     return client;
@@ -446,7 +446,7 @@ export async function createClient(containerId?: string): Promise<YjsClient> {
     if (!userId && isTest) userId = "test-user-id";
     const resolvedId = containerId || uuid();
     const title = typeof window !== "undefined"
-        ? (((window as any).__CURRENT_PROJECT_TITLE__ as string | undefined) ?? "Test Project")
+        ? ((window.__CURRENT_PROJECT_TITLE__ as string | undefined) ?? "Test Project")
         : "Test Project";
 
     const project = Project.createInstance(title);
@@ -521,7 +521,7 @@ export async function getUserContainers(): Promise<{
 
 // Testing hooks
 if (process.env.NODE_ENV === "test" && typeof window !== "undefined") {
-    (window as any).__YJS_SERVICE__ = {
+    window.__YJS_SERVICE__ = {
         createNewProject,
         getClientByProjectTitle,
         createClient,

--- a/client/src/schema/app-schema.iterable.test.ts
+++ b/client/src/schema/app-schema.iterable.test.ts
@@ -4,7 +4,7 @@ import { Item, Project } from "./app-schema";
 // Mock: Among the stores Cursor depends on, only currentPage is used in this test
 vi.mock("../stores/store.svelte", () => ({
     store: {
-        currentPage: undefined as any,
+        currentPage: undefined as import("./app-schema").Item | undefined,
         subscribe: vi.fn(),
         update: vi.fn(),
         set: vi.fn(),
@@ -20,7 +20,7 @@ describe("Items.asArrayLike iterable characteristics", () => {
         const project = Project.createInstance("iterable-test");
 
         // Create items equivalent to 2 pages directly under the root
-        const rootItems: any = (project as any).items;
+        const rootItems = project.items;
         const a = rootItems.addNode("user");
         a.updateText("A");
         const b = rootItems.addNode("user");
@@ -52,7 +52,7 @@ describe("Items.asArrayLike iterable characteristics", () => {
 describe("Cursor.searchItem recursion over children (no exceptions)", () => {
     it("findTarget() locates deep child without throwing", () => {
         const project = Project.createInstance("cursor-search");
-        const rootItems: any = (project as any).items;
+        const rootItems = project.items;
 
         const page = rootItems.addNode("user");
         page.updateText("Page");
@@ -63,17 +63,20 @@ describe("Cursor.searchItem recursion over children (no exceptions)", () => {
         c2.updateText("child-2");
 
         // Set the currentPage referenced by Cursor
-        (generalStore as any).currentPage = page as Item;
+        (generalStore as { currentPage?: Item; }).currentPage = page as Item;
 
-        const cursor = new Cursor("cur-1", {
-            itemId: c2.id,
-            offset: 0,
-            isActive: true,
-            userId: "u1",
-        } as any);
+        const cursor = new Cursor(
+            "cur-1",
+            {
+                itemId: c2.id,
+                offset: 0,
+                isActive: true,
+                userId: "u1",
+            } as import("../stores/EditorOverlayStore.svelte").SelectionState,
+        );
 
         // Ensure no exception is thrown and the target is found
-        let found: any;
+        let found: Item | null | undefined;
         expect(() => {
             found = cursor.findTarget();
         }).not.toThrow();

--- a/client/src/types/global.d.ts
+++ b/client/src/types/global.d.ts
@@ -19,11 +19,16 @@ type Console = typeof console;
 declare global {
     interface Window {
         __CURRENT_PROJECT__?: Project;
+        __CURRENT_PROJECT_TITLE__?: string;
         generalStore?: GeneralStore;
         __YJS_SERVICE__?: unknown;
         __YJS_STORE__?: unknown;
+        __YJS_CLIENT_REGISTRY__?: unknown;
+        __FLUID_CLIENT_REGISTRY__?: unknown;
         __USER_MANAGER__?: UserManager;
         __selectionList?: SelectionRange[];
+        __FIRESTORE_STORE__?: unknown;
+        __E2E__?: boolean;
         appStore?: {
             project?: Project;
         };

--- a/client/vitest-setup-client.ts
+++ b/client/vitest-setup-client.ts
@@ -48,15 +48,15 @@ if (typeof globalThis.cancelAnimationFrame !== "function") {
 // ---- Vitest bootstrap: ensure a single firestoreStore instance shared across UI & tests ----
 try {
     // Ensure window exists
-    (globalThis as any).window ||= globalThis as any;
+    (globalThis as unknown as { window: Window; }).window ||= globalThis as unknown as Window;
     // Import the real store early so it can publish itself to window.__FIRESTORE_STORE__
     // and so subsequent imports (including Svelte-compiled graph) pick up the same instance.
     // Note: this path is relative to project root (vite config uses the same resolver in tests)
     const mod = await import("./src/stores/firestoreStore.svelte");
-    const fsStore = (mod as any).firestoreStore;
+    const fsStore = (mod as { firestoreStore?: unknown; }).firestoreStore;
     if (fsStore) {
-        (globalThis as any).window.__FIRESTORE_STORE__ ||= fsStore;
-        (globalThis as any).__FIRESTORE_STORE__ ||= fsStore;
+        ((globalThis as unknown as { window: Window; }).window as Window).__FIRESTORE_STORE__ ||= fsStore;
+        (globalThis as unknown as { __FIRESTORE_STORE__?: unknown; }).__FIRESTORE_STORE__ ||= fsStore;
     }
 } catch {
     // no-op: if import fails here, module will still set __FIRESTORE_STORE__ on first import
@@ -66,10 +66,10 @@ try {
 try {
     // Import the real yjsStore early so it can publish itself to window.__YJS_STORE__
     const yjsMod = await import("./src/stores/yjsStore.svelte");
-    const yjsStoreInstance = (yjsMod as any).yjsStore;
+    const yjsStoreInstance = (yjsMod as { yjsStore?: unknown; }).yjsStore;
     if (yjsStoreInstance) {
-        (globalThis as any).window.__YJS_STORE__ ||= yjsStoreInstance;
-        (globalThis as any).__YJS_STORE__ ||= yjsStoreInstance;
+        ((globalThis as unknown as { window: Window; }).window as Window).__YJS_STORE__ ||= yjsStoreInstance;
+        (globalThis as unknown as { __YJS_STORE__?: unknown; }).__YJS_STORE__ ||= yjsStoreInstance;
     }
 } catch {
     // no-op: if import fails here, module will still set __YJS_STORE__ on first import


### PR DESCRIPTION
[Issues]
Many files in the `client` workspace had `@typescript-eslint/no-explicit-any` ESLint warnings, primarily within test environments and setup scripts (`vitest-setup-client.ts`), affecting overall code health and adherence to stricter typing configurations.

[Changes]
* Added proper typing assertions (`unknown`, specific structural interfaces, and `SelectionState` imports) in:
  - `client/vitest-setup-client.ts`
  - `client/src/lib/Cursor.selection.test.ts`
  - `client/src/lib/yjs/service.test.ts`
  - `client/src/schema/app-schema.iterable.test.ts`
* Updated `client/src/types/global.d.ts` to extend the `Window` interface with custom properties, avoiding the need for `(window as any)` casting in general scripts.
* Updated `client/src/lib/yjsService.svelte.ts` to use proper `window` type definitions instead of mapping to `any`.

[Verification Results]
* `npm run test:unit` inside `client` completed entirely successfully.
* `npm run lint` displays far fewer warnings across the refactored files.
* `npm run build` completed successfully without any compilation blockers or typing conflicts.

---
*PR created automatically by Jules for task [12665694814247255359](https://jules.google.com/task/12665694814247255359) started by @kitamura-tetsuo*