### PR TITLE
refactor: fix strict type warnings by properly typing window globals and removing `any`

### DIFF
--- a/client/src/lib/Cursor.selection.test.ts
+++ b/client/src/lib/Cursor.selection.test.ts
@@ -13,7 +13,9 @@ vi.mock("../stores/EditorOverlayStore.svelte", () => ({
         update: vi.fn(),
         set: vi.fn(),
         updateCursor: vi.fn(),
-        setCursor: vi.fn((opts: import("../stores/EditorOverlayStore.svelte").CursorPosition) => `cursor-${opts.itemId}-${Math.random()}`),
+        setCursor: vi.fn((opts: import("../stores/EditorOverlayStore.svelte").CursorPosition) =>
+            `cursor-${opts.itemId}-${Math.random()}`
+        ),
         setActiveItem: vi.fn(),
         getTextareaRef: vi.fn(() => ({
             focus: vi.fn(),
@@ -120,12 +122,20 @@ describe("Cursor Selection Reproduction", () => {
         });
 
         // Spy on findTarget to return mock items
-        vi.spyOn(cursor as unknown as { findTarget: () => import("../schema/app-schema").Item | undefined }, "findTarget").mockImplementation(() => {
+        vi.spyOn(
+            cursor as unknown as { findTarget: () => import("../schema/app-schema").Item | undefined; },
+            "findTarget",
+        ).mockImplementation(() => {
             return mockItems.find(i => i.id === cursor.itemId);
         });
 
         // Ensure getTargetText works
-        vi.spyOn(cursor as unknown as { getTargetText: (target: import("../schema/app-schema").Item | undefined) => string }, "getTargetText").mockImplementation((target: import("../schema/app-schema").Item | undefined) => target?.text || "");
+        vi.spyOn(
+            cursor as unknown as {
+                getTargetText: (target: import("../schema/app-schema").Item | undefined) => string;
+            },
+            "getTargetText",
+        ).mockImplementation((target: import("../schema/app-schema").Item | undefined) => target?.text || "");
     });
 
     afterEach(() => {

--- a/client/src/lib/Cursor.selection.test.ts
+++ b/client/src/lib/Cursor.selection.test.ts
@@ -13,7 +13,7 @@ vi.mock("../stores/EditorOverlayStore.svelte", () => ({
         update: vi.fn(),
         set: vi.fn(),
         updateCursor: vi.fn(),
-        setCursor: vi.fn((opts: any) => `cursor-${opts.itemId}-${Math.random()}`),
+        setCursor: vi.fn((opts: import("../stores/EditorOverlayStore.svelte").CursorPosition) => `cursor-${opts.itemId}-${Math.random()}`),
         setActiveItem: vi.fn(),
         getTextareaRef: vi.fn(() => ({
             focus: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock("../stores/store.svelte", () => ({
 
 // Mock cursor utility functions
 vi.mock("./cursor", async (importOriginal) => {
-    const actual: any = await importOriginal();
+    const actual = await importOriginal() as Record<string, unknown>;
     return {
         ...actual,
         findNextItem: (itemId: string) => {
@@ -65,7 +65,7 @@ vi.mock("./cursor", async (importOriginal) => {
         },
         getSelectionForUser: () => mockSelection,
         hasSelection: () => !!mockSelection,
-        searchItem: (root: any, itemId: string) => {
+        searchItem: (root: import("../schema/app-schema").Item, itemId: string) => {
             if (itemId === "item1") return { id: "item1", text: "Hello" };
             if (itemId === "item2") return { id: "item2", text: "World" };
             if (itemId === "item3") return { id: "item3", text: "Test" };
@@ -120,12 +120,12 @@ describe("Cursor Selection Reproduction", () => {
         });
 
         // Spy on findTarget to return mock items
-        vi.spyOn(cursor as any, "findTarget").mockImplementation(() => {
+        vi.spyOn(cursor as unknown as { findTarget: () => import("../schema/app-schema").Item | undefined }, "findTarget").mockImplementation(() => {
             return mockItems.find(i => i.id === cursor.itemId);
         });
 
         // Ensure getTargetText works
-        vi.spyOn(cursor as any, "getTargetText").mockImplementation((target: any) => target?.text || "");
+        vi.spyOn(cursor as unknown as { getTargetText: (target: import("../schema/app-schema").Item | undefined) => string }, "getTargetText").mockImplementation((target: import("../schema/app-schema").Item | undefined) => target?.text || "");
     });
 
     afterEach(() => {

--- a/client/src/lib/yjs/service.test.ts
+++ b/client/src/lib/yjs/service.test.ts
@@ -48,10 +48,10 @@ describe("yjsService", () => {
                 this.users = updatedUsers;
             },
         };
-        (globalThis as typeof globalThis & { presenceStore?: typeof presenceStore }).presenceStore = presenceStore;
+        (globalThis as typeof globalThis & { presenceStore?: typeof presenceStore; }).presenceStore = presenceStore;
         const unbind = yjsService.bindProjectPresence(awareness);
         awareness.setLocalStateField("user", { userId: "u1", name: "Alice" });
-        expect((presenceStore.users["u1"] as { userName?: string }).userName).toBe("Alice");
+        expect((presenceStore.users["u1"] as { userName?: string; }).userName).toBe("Alice");
         awareness.setLocalStateField("user", null);
         unbind();
     });
@@ -80,7 +80,8 @@ describe("yjsService", () => {
                 this.selections = updatedSelections;
             },
         };
-        (globalThis as typeof globalThis & { editorOverlayStore?: typeof editorOverlayStore }).editorOverlayStore = editorOverlayStore;
+        (globalThis as typeof globalThis & { editorOverlayStore?: typeof editorOverlayStore; }).editorOverlayStore =
+            editorOverlayStore;
         const unbind = yjsService.bindPagePresence(awareness);
 
         // seed local state (ignored by overlay sync)
@@ -88,17 +89,25 @@ describe("yjsService", () => {
         awareness.setLocalStateField("presence", { cursor: { itemId: "root", offset: 0 } });
 
         // simulate remote collaborator
-        const states = (awareness as unknown as { getStates: () => Map<number, unknown> }).getStates();
+        const states = (awareness as unknown as { getStates: () => Map<number, unknown>; }).getStates();
         states.set(42, {
             user: { userId: "u2", name: "Bob" },
             presence: { cursor: { itemId: "i1", offset: 0 } },
         });
-        (awareness as unknown as { emit: (event: string, args: unknown[]) => void }).emit("change", [{ added: new Set([42]), updated: new Set(), removed: new Set() }, "test"]);
+        (awareness as unknown as { emit: (event: string, args: unknown[]) => void; }).emit("change", [{
+            added: new Set([42]),
+            updated: new Set(),
+            removed: new Set(),
+        }, "test"]);
 
         const cursor = Object.values(editorOverlayStore.cursors).find(c => c.userId === "u2");
         expect(cursor?.itemId).toBe("i1");
 
-        (awareness as unknown as { emit: (event: string, args: unknown[]) => void }).emit("change", [{ added: new Set(), updated: new Set(), removed: new Set([42]) }, "test"]);
+        (awareness as unknown as { emit: (event: string, args: unknown[]) => void; }).emit("change", [{
+            added: new Set(),
+            updated: new Set(),
+            removed: new Set([42]),
+        }, "test"]);
         unbind();
     });
 });

--- a/client/src/lib/yjs/service.test.ts
+++ b/client/src/lib/yjs/service.test.ts
@@ -48,10 +48,10 @@ describe("yjsService", () => {
                 this.users = updatedUsers;
             },
         };
-        (globalThis as any).presenceStore = presenceStore;
+        (globalThis as typeof globalThis & { presenceStore?: typeof presenceStore }).presenceStore = presenceStore;
         const unbind = yjsService.bindProjectPresence(awareness);
         awareness.setLocalStateField("user", { userId: "u1", name: "Alice" });
-        expect((presenceStore.users["u1"] as any).userName).toBe("Alice");
+        expect((presenceStore.users["u1"] as { userName?: string }).userName).toBe("Alice");
         awareness.setLocalStateField("user", null);
         unbind();
     });
@@ -80,7 +80,7 @@ describe("yjsService", () => {
                 this.selections = updatedSelections;
             },
         };
-        (globalThis as any).editorOverlayStore = editorOverlayStore;
+        (globalThis as typeof globalThis & { editorOverlayStore?: typeof editorOverlayStore }).editorOverlayStore = editorOverlayStore;
         const unbind = yjsService.bindPagePresence(awareness);
 
         // seed local state (ignored by overlay sync)
@@ -88,17 +88,17 @@ describe("yjsService", () => {
         awareness.setLocalStateField("presence", { cursor: { itemId: "root", offset: 0 } });
 
         // simulate remote collaborator
-        const states = (awareness as any).getStates();
+        const states = (awareness as unknown as { getStates: () => Map<number, unknown> }).getStates();
         states.set(42, {
             user: { userId: "u2", name: "Bob" },
             presence: { cursor: { itemId: "i1", offset: 0 } },
         });
-        (awareness as any).emit("change", [{ added: new Set([42]), updated: new Set(), removed: new Set() }, "test"]);
+        (awareness as unknown as { emit: (event: string, args: unknown[]) => void }).emit("change", [{ added: new Set([42]), updated: new Set(), removed: new Set() }, "test"]);
 
         const cursor = Object.values(editorOverlayStore.cursors).find(c => c.userId === "u2");
         expect(cursor?.itemId).toBe("i1");
 
-        (awareness as any).emit("change", [{ added: new Set(), updated: new Set(), removed: new Set([42]) }, "test"]);
+        (awareness as unknown as { emit: (event: string, args: unknown[]) => void }).emit("change", [{ added: new Set(), updated: new Set(), removed: new Set([42]) }, "test"]);
         unbind();
     });
 });

--- a/client/src/lib/yjsService.svelte.ts
+++ b/client/src/lib/yjsService.svelte.ts
@@ -61,16 +61,16 @@ class Registry {
 let registry: Registry;
 if (
     typeof window !== "undefined"
-    && ((window as any).__YJS_CLIENT_REGISTRY__ || (window as any).__FLUID_CLIENT_REGISTRY__)
+    && (window.__YJS_CLIENT_REGISTRY__ || window.__FLUID_CLIENT_REGISTRY__)
 ) {
-    registry = ((window as any).__YJS_CLIENT_REGISTRY__
-        || (window as any).__FLUID_CLIENT_REGISTRY__) as Registry;
+    registry = (window.__YJS_CLIENT_REGISTRY__
+        || window.__FLUID_CLIENT_REGISTRY__) as Registry;
 } else {
     registry = new Registry();
     if (typeof window !== "undefined") {
-        (window as any).__YJS_CLIENT_REGISTRY__ = registry;
+        window.__YJS_CLIENT_REGISTRY__ = registry;
         // Legacy alias for components still reading FLUID registry
-        (window as any).__FLUID_CLIENT_REGISTRY__ = registry;
+        window.__FLUID_CLIENT_REGISTRY__ = registry;
     }
 }
 
@@ -93,7 +93,7 @@ function isTestEnvironment(): boolean {
 
     // Fallback to runtime checks (for E2E tests where MODE might not be "test")
     if (typeof window !== "undefined") {
-        const win = window as any;
+        const win = window;
         const ls = win.localStorage;
 
         const isTestLs = ls?.getItem?.("VITE_IS_TEST");
@@ -208,8 +208,8 @@ export async function createNewProject(projectName: string, existingProjectId?: 
     yjsStore.yjsClient = client;
 
     if (typeof window !== "undefined") {
-        (window as any).__CURRENT_PROJECT__ = project;
-        (window as any).__CURRENT_PROJECT_TITLE__ = projectName;
+        window.__CURRENT_PROJECT__ = project;
+        window.__CURRENT_PROJECT_TITLE__ = projectName;
     }
 
     return client;
@@ -446,7 +446,7 @@ export async function createClient(containerId?: string): Promise<YjsClient> {
     if (!userId && isTest) userId = "test-user-id";
     const resolvedId = containerId || uuid();
     const title = typeof window !== "undefined"
-        ? (((window as any).__CURRENT_PROJECT_TITLE__ as string | undefined) ?? "Test Project")
+        ? ((window.__CURRENT_PROJECT_TITLE__ as string | undefined) ?? "Test Project")
         : "Test Project";
 
     const project = Project.createInstance(title);
@@ -521,7 +521,7 @@ export async function getUserContainers(): Promise<{
 
 // Testing hooks
 if (process.env.NODE_ENV === "test" && typeof window !== "undefined") {
-    (window as any).__YJS_SERVICE__ = {
+    window.__YJS_SERVICE__ = {
         createNewProject,
         getClientByProjectTitle,
         createClient,

--- a/client/src/schema/app-schema.iterable.test.ts
+++ b/client/src/schema/app-schema.iterable.test.ts
@@ -4,7 +4,7 @@ import { Item, Project } from "./app-schema";
 // Mock: Among the stores Cursor depends on, only currentPage is used in this test
 vi.mock("../stores/store.svelte", () => ({
     store: {
-        currentPage: undefined as any,
+        currentPage: undefined as Item | undefined,
         subscribe: vi.fn(),
         update: vi.fn(),
         set: vi.fn(),
@@ -20,7 +20,7 @@ describe("Items.asArrayLike iterable characteristics", () => {
         const project = Project.createInstance("iterable-test");
 
         // Create items equivalent to 2 pages directly under the root
-        const rootItems: any = (project as any).items;
+        const rootItems = project.items as unknown as { addNode: (type: string) => Item, length: number } & Iterable<Item>;
         const a = rootItems.addNode("user");
         a.updateText("A");
         const b = rootItems.addNode("user");
@@ -52,7 +52,7 @@ describe("Items.asArrayLike iterable characteristics", () => {
 describe("Cursor.searchItem recursion over children (no exceptions)", () => {
     it("findTarget() locates deep child without throwing", () => {
         const project = Project.createInstance("cursor-search");
-        const rootItems: any = (project as any).items;
+        const rootItems = project.items as unknown as { addNode: (type: string) => Item, length: number } & Iterable<Item>;
 
         const page = rootItems.addNode("user");
         page.updateText("Page");
@@ -63,17 +63,17 @@ describe("Cursor.searchItem recursion over children (no exceptions)", () => {
         c2.updateText("child-2");
 
         // Set the currentPage referenced by Cursor
-        (generalStore as any).currentPage = page as Item;
+        (generalStore as { currentPage?: Item }).currentPage = page;
 
         const cursor = new Cursor("cur-1", {
             itemId: c2.id,
             offset: 0,
             isActive: true,
             userId: "u1",
-        } as any);
+        } as import("../stores/EditorOverlayStore.svelte").CursorPosition);
 
         // Ensure no exception is thrown and the target is found
-        let found: any;
+        let found: Item | undefined;
         expect(() => {
             found = cursor.findTarget();
         }).not.toThrow();

--- a/client/src/schema/app-schema.iterable.test.ts
+++ b/client/src/schema/app-schema.iterable.test.ts
@@ -20,7 +20,9 @@ describe("Items.asArrayLike iterable characteristics", () => {
         const project = Project.createInstance("iterable-test");
 
         // Create items equivalent to 2 pages directly under the root
-        const rootItems = project.items as unknown as { addNode: (type: string) => Item, length: number } & Iterable<Item>;
+        const rootItems = project.items as unknown as
+            & { addNode: (type: string) => Item; length: number; }
+            & Iterable<Item>;
         const a = rootItems.addNode("user");
         a.updateText("A");
         const b = rootItems.addNode("user");
@@ -52,7 +54,9 @@ describe("Items.asArrayLike iterable characteristics", () => {
 describe("Cursor.searchItem recursion over children (no exceptions)", () => {
     it("findTarget() locates deep child without throwing", () => {
         const project = Project.createInstance("cursor-search");
-        const rootItems = project.items as unknown as { addNode: (type: string) => Item, length: number } & Iterable<Item>;
+        const rootItems = project.items as unknown as
+            & { addNode: (type: string) => Item; length: number; }
+            & Iterable<Item>;
 
         const page = rootItems.addNode("user");
         page.updateText("Page");
@@ -63,14 +67,17 @@ describe("Cursor.searchItem recursion over children (no exceptions)", () => {
         c2.updateText("child-2");
 
         // Set the currentPage referenced by Cursor
-        (generalStore as { currentPage?: Item }).currentPage = page;
+        (generalStore as { currentPage?: Item; }).currentPage = page;
 
-        const cursor = new Cursor("cur-1", {
-            itemId: c2.id,
-            offset: 0,
-            isActive: true,
-            userId: "u1",
-        } as import("../stores/EditorOverlayStore.svelte").CursorPosition);
+        const cursor = new Cursor(
+            "cur-1",
+            {
+                itemId: c2.id,
+                offset: 0,
+                isActive: true,
+                userId: "u1",
+            } as import("../stores/EditorOverlayStore.svelte").CursorPosition,
+        );
 
         // Ensure no exception is thrown and the target is found
         let found: Item | undefined;

--- a/client/src/types/global.d.ts
+++ b/client/src/types/global.d.ts
@@ -18,6 +18,11 @@ type Console = typeof console;
 // Window extension for test environment globals
 declare global {
     interface Window {
+        __CURRENT_PROJECT_TITLE__?: string;
+        __E2E__?: boolean;
+        __YJS_CLIENT_REGISTRY__?: import("../lib/yjsService.svelte").Registry;
+        __FLUID_CLIENT_REGISTRY__?: import("../lib/yjsService.svelte").Registry;
+        __FIRESTORE_STORE__?: unknown;
         __CURRENT_PROJECT__?: Project;
         generalStore?: GeneralStore;
         __YJS_SERVICE__?: unknown;

--- a/client/vitest-setup-client.ts
+++ b/client/vitest-setup-client.ts
@@ -48,15 +48,15 @@ if (typeof globalThis.cancelAnimationFrame !== "function") {
 // ---- Vitest bootstrap: ensure a single firestoreStore instance shared across UI & tests ----
 try {
     // Ensure window exists
-    (globalThis as any).window ||= globalThis as any;
+    globalThis.window ||= globalThis as unknown as Window & typeof globalThis;
     // Import the real store early so it can publish itself to window.__FIRESTORE_STORE__
     // and so subsequent imports (including Svelte-compiled graph) pick up the same instance.
     // Note: this path is relative to project root (vite config uses the same resolver in tests)
     const mod = await import("./src/stores/firestoreStore.svelte");
-    const fsStore = (mod as any).firestoreStore;
+    const fsStore = (mod as { firestoreStore?: unknown }).firestoreStore;
     if (fsStore) {
-        (globalThis as any).window.__FIRESTORE_STORE__ ||= fsStore;
-        (globalThis as any).__FIRESTORE_STORE__ ||= fsStore;
+        window.__FIRESTORE_STORE__ ||= fsStore;
+        (globalThis as typeof globalThis & { __FIRESTORE_STORE__?: unknown }).__FIRESTORE_STORE__ ||= fsStore;
     }
 } catch {
     // no-op: if import fails here, module will still set __FIRESTORE_STORE__ on first import
@@ -66,10 +66,10 @@ try {
 try {
     // Import the real yjsStore early so it can publish itself to window.__YJS_STORE__
     const yjsMod = await import("./src/stores/yjsStore.svelte");
-    const yjsStoreInstance = (yjsMod as any).yjsStore;
+    const yjsStoreInstance = (yjsMod as { yjsStore?: unknown }).yjsStore;
     if (yjsStoreInstance) {
-        (globalThis as any).window.__YJS_STORE__ ||= yjsStoreInstance;
-        (globalThis as any).__YJS_STORE__ ||= yjsStoreInstance;
+        window.__YJS_STORE__ ||= yjsStoreInstance;
+        (globalThis as typeof globalThis & { __YJS_STORE__?: unknown }).__YJS_STORE__ ||= yjsStoreInstance;
     }
 } catch {
     // no-op: if import fails here, module will still set __YJS_STORE__ on first import

--- a/client/vitest-setup-client.ts
+++ b/client/vitest-setup-client.ts
@@ -53,10 +53,10 @@ try {
     // and so subsequent imports (including Svelte-compiled graph) pick up the same instance.
     // Note: this path is relative to project root (vite config uses the same resolver in tests)
     const mod = await import("./src/stores/firestoreStore.svelte");
-    const fsStore = (mod as { firestoreStore?: unknown }).firestoreStore;
+    const fsStore = (mod as { firestoreStore?: unknown; }).firestoreStore;
     if (fsStore) {
         window.__FIRESTORE_STORE__ ||= fsStore;
-        (globalThis as typeof globalThis & { __FIRESTORE_STORE__?: unknown }).__FIRESTORE_STORE__ ||= fsStore;
+        (globalThis as typeof globalThis & { __FIRESTORE_STORE__?: unknown; }).__FIRESTORE_STORE__ ||= fsStore;
     }
 } catch {
     // no-op: if import fails here, module will still set __FIRESTORE_STORE__ on first import
@@ -66,10 +66,10 @@ try {
 try {
     // Import the real yjsStore early so it can publish itself to window.__YJS_STORE__
     const yjsMod = await import("./src/stores/yjsStore.svelte");
-    const yjsStoreInstance = (yjsMod as { yjsStore?: unknown }).yjsStore;
+    const yjsStoreInstance = (yjsMod as { yjsStore?: unknown; }).yjsStore;
     if (yjsStoreInstance) {
         window.__YJS_STORE__ ||= yjsStoreInstance;
-        (globalThis as typeof globalThis & { __YJS_STORE__?: unknown }).__YJS_STORE__ ||= yjsStoreInstance;
+        (globalThis as typeof globalThis & { __YJS_STORE__?: unknown; }).__YJS_STORE__ ||= yjsStoreInstance;
     }
 } catch {
     // no-op: if import fails here, module will still set __YJS_STORE__ on first import


### PR DESCRIPTION
[Issues]
The codebase had multiple ESLint warnings related to strict TypeScript types (`@typescript-eslint/no-explicit-any`). Previous attempts to solve this resulted in overly complex inline type assertions or unsafe spreads. The `no-console` ESLint disable rules were also mistakenly targeted for removal earlier in the process, which could cause CI failures since the project relies on them.

[Changes]
- Augmented the `Window` interface in `client/src/types/global.d.ts` to properly include repository-specific properties like `__YJS_CLIENT_REGISTRY__`, `__FLUID_CLIENT_REGISTRY__`, `__E2E__`, `__FIRESTORE_STORE__`, `__CURRENT_PROJECT_TITLE__`, and `__YJS_SERVICE__`.
- Updated `client/src/lib/yjsService.svelte.ts`, `client/vitest-setup-client.ts`, `client/src/lib/Cursor.selection.test.ts`, `client/src/lib/yjs/service.test.ts`, and `client/src/schema/app-schema.iterable.test.ts` to replace `any` with these cleaner type declarations and structural castings, resolving strict ESLint warnings safely.
- Avoided removing `eslint-disable-next-line no-console` comments, maintaining the intended linting behavior for error reporting.

[Verification Results]
- `npx eslint client/src/lib/Cursor.selection.test.ts client/src/lib/yjs/service.test.ts client/src/lib/yjsService.svelte.ts client/src/schema/app-schema.iterable.test.ts client/vitest-setup-client.ts` produces no warnings for `any`.
- `npm run test:unit --prefix client` ran successfully.
- `npm run build --prefix client` ran successfully.
- Code is formatted correctly using `dprint`.

---
*PR created automatically by Jules for task [14318890358150995875](https://jules.google.com/task/14318890358150995875) started by @kitamura-tetsuo*