### PR TITLE
fix: Remove artificial 3-second delay on demo page load

### DIFF
--- a/client/src/routes/demo/+page.svelte
+++ b/client/src/routes/demo/+page.svelte
@@ -34,16 +34,6 @@
             yjsStore.yjsClient = client as import("../../yjs/YjsClient").YjsClient;
             const project = client.getProject();
             store.project = project;
-
-            // Wait for the page list to sync (3 seconds max)
-            let retries = 0;
-            while (retries < 30) {
-                if ((store.project?.items?.length || 0) > 0) {
-                    break;
-                }
-                await new Promise(r => setTimeout(r, 100));
-                retries++;
-            }
         } catch (err) {
             console.error("Failed to initialize demo:", err);
             error = err instanceof Error ? err.message : "An error occurred while loading the demo.";


### PR DESCRIPTION
[Issues]
- The demo page (`/demo`) artificially delayed loading for 3 seconds for all users.
- The initialization logic contained a polling loop that checked `store.project?.items?.length`. Since `items` is an instance of the `Items` iterable class and not an Array, `length` was evaluated incorrectly in some contexts, causing the loop to always exhaust its 30 retries (100ms each).

[Changes]
- Removed the `while (retries < 30)` polling loop completely from `client/src/routes/demo/+page.svelte`.
- Svelte's native reactivity (via the `{#if store.project && pages}` block) now correctly handles rendering the page list automatically as soon as the Yjs document data arrives, eliminating the need for manual polling.

[Verification Results]
- `npm run test:unit` in the `client` directory passed.
- `npm run build` in the `client` directory passed without regressions.
- The UI properly delegates loading state to reactive Svelte components rather than blocking execution asynchronously.

---
*PR created automatically by Jules for task [5314862012181922962](https://jules.google.com/task/5314862012181922962) started by @kitamura-tetsuo*