### PR TITLE
refactor: fix ESLint no-restricted-globals warnings in globals.d.ts

### DIFF
--- a/client/e2e/globals.d.ts
+++ b/client/e2e/globals.d.ts
@@ -59,36 +59,36 @@ export const test = base.extend({
         // Set connection information for Firebase Emulator
         await page.addInitScript(() => {
             // Set test environment flag
-            window.localStorage.setItem("VITE_IS_TEST", "true");
+            globalThis.localStorage.setItem("VITE_IS_TEST", "true");
 
             // Enable Firebase Emulator
-            window.localStorage.setItem("VITE_USE_FIREBASE_EMULATOR", "true");
+            globalThis.localStorage.setItem("VITE_USE_FIREBASE_EMULATOR", "true");
 
             // Emulator connection info (from env vars, default is localhost)
-            window.localStorage.setItem(
+            globalThis.localStorage.setItem(
                 "VITE_FIREBASE_EMULATOR_HOST",
                 process.env.VITE_FIREBASE_EMULATOR_HOST || "localhost",
             );
-            window.localStorage.setItem(
+            globalThis.localStorage.setItem(
                 "VITE_FIRESTORE_EMULATOR_PORT",
                 process.env.VITE_FIRESTORE_EMULATOR_PORT || "58080",
             );
-            window.localStorage.setItem(
+            globalThis.localStorage.setItem(
                 "VITE_AUTH_EMULATOR_PORT",
                 process.env.VITE_AUTH_EMULATOR_PORT || "59099",
             );
 
             // Simulate authenticated state
             // User data for testing
-            window.mockUser = {
+            globalThis.mockUser = {
                 id: "test-user-id",
                 name: "Test User",
                 email: "test@example.com",
             };
 
             // Define environment variables that the test is looking for
-            if (typeof window !== "undefined") {
-                const globalObj = window as any;
+            if (typeof globalThis !== "undefined") {
+                const globalObj = globalThis as any;
 
                 // Set up the exact property name that the test is looking for
                 if (!globalObj["import.meta.env"]) {


### PR DESCRIPTION
[Issues]
- The codebase had a significant number of `no-restricted-globals` ESLint warnings generated in the `client/e2e` test files due to the usage of `window.`. 
- Fixing this across all files created an excessively large git diff that was hard to manage, but fixing it in the central setup file (`globals.d.ts`) is a high-value code health improvement.

[Changes]
- Modified `client/e2e/globals.d.ts` to replace explicit access to the `window` object with `globalThis` within the Playwright `page.addInitScript()` blocks and general script logic. This effectively silences the E2E test ESLint warnings for `no-restricted-globals` inside this file, as `globalThis` evaluates to the `window` object on the client-side while avoiding the linter penalty.

[Verification Results]
- Ran `npx eslint e2e/globals.d.ts` inside the `client` directory and confirmed 0 warnings (down from 8).
- Ran the full client unit test suite (`npm run test:unit`), verifying no regressions were introduced.
- Successfully executed the client build (`npm run build`).

---
*PR created automatically by Jules for task [13211962213887967762](https://jules.google.com/task/13211962213887967762) started by @kitamura-tetsuo*