### PR TITLE
fix: ensure demo site reliably reseeds when document is unexpectedly empty

### DIFF
--- a/server/src/demo-api.ts
+++ b/server/src/demo-api.ts
@@ -35,8 +35,13 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                 const lastReset = metadata.get("lastReset") as number | undefined;
                 const templateVersion = metadata.get("templateVersion") as number | undefined;
 
+                const orderedTree = doc.getMap("orderedTree");
+                const keys = Array.from(orderedTree.keys());
+                const isEmpty = keys.length === 0 || (keys.length === 1 && keys[0] === "root");
+
                 if (
-                    !lastReset
+                    isEmpty
+                    || !lastReset
                     || (now - lastReset > RESET_INTERVAL_MS)
                     || templateVersion !== DEMO_TEMPLATE_VERSION
                 ) {

--- a/server/src/demo-content.ts
+++ b/server/src/demo-content.ts
@@ -2,7 +2,7 @@ import { Item, Items, Project } from "./schema/app-schema.js";
 
 // Bump this whenever the demo template below changes so that already-seeded
 // demo documents are re-seeded on the next /api/seed-demo call.
-export const DEMO_TEMPLATE_VERSION = 2;
+export const DEMO_TEMPLATE_VERSION = 3;
 
 // Must match the demo room id (`projects/demo`) so that internal links
 // rendered from `project.title` resolve to /demo/<page> URLs.


### PR DESCRIPTION
[Issues]
The production demo site (`/demo`) would sometimes render as completely empty ("No pages found"). This happened because the document's structure (`orderedTree` and `items`) was missing or cleared, but the metadata (`lastReset` and `templateVersion`) remained intact. As a result, the `demo-api.ts` seed logic incorrectly assumed the project had been reset within the last 24 hours and bypassed the seeding process, leaving the demo in a permanently empty state.

[Changes]
- Modified `server/src/demo-api.ts` to inspect the `orderedTree` Y.Map directly.
- Added logic to explicitly check if `orderedTree` is entirely empty or only contains the `"root"` key (`isEmpty`).
- Updated the reset condition to trigger a forced reseed if the document is empty (`isEmpty === true`), regardless of what `lastReset` or `templateVersion` dictates.
- Bumped `DEMO_TEMPLATE_VERSION` in `server/src/demo-content.ts` from `2` to `3` to guarantee an immediate reset across all deployments upon rollout.

[Verification Results]
- Verified logic manually by mocking the Y.Doc `orderedTree` state and tracing the reset condition.
- Ran full compilation (`npx tsc --noEmit`) without errors.
- Ran the server tests (`npm run test`) and all passed.
- Ran the client build (`npm run build`) and client tests (`npm run test:unit`) which completed successfully.

---
*PR created automatically by Jules for task [2906841061044658981](https://jules.google.com/task/2906841061044658981) started by @kitamura-tetsuo*