### PR TITLE
feat(demo): add Selection/Publishing demo pages and demo sync policy doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This document consolidates the key development policies for this repository. Fol
 - **Feature IDs**: Use an 8-character hexadecimal UUID (e.g. `FTR-1a2b3c4d`) rather than sequential numbers.
 - `docs/client-features.yaml` and `docs/dev-features.yaml` are generated automatically.
 - Document intentionally omitted features in `docs/NON_GOALS.md`.
+- **Demo project**: The public `/demo` route is seeded from the template in `server/src/demo-content.ts` and must always demonstrate the current feature set. When you implement a new end-user feature, also add it to the demo template (extend an existing demo page or add a new feature page with a landing-page tour link) and bump `DEMO_TEMPLATE_VERSION`. See `docs/demo-project.md` for the full policy.
 - `docs/feature-map.md` is auto-generated; never edit it manually.
 - Regularly review and update documentation to avoid conflicts and keep best practices current.
 

--- a/client/e2e/core/dmo-demo-project-feature-tour-7d3e9a1c.spec.ts
+++ b/client/e2e/core/dmo-demo-project-feature-tour-7d3e9a1c.spec.ts
@@ -20,8 +20,10 @@ test.describe("Demo project feature tour", () => {
                 "Checkboxes and Tasks",
                 "Internal Links",
                 "Search and Commands",
+                "Selection and Clipboard",
                 "Collaboration",
                 "Comments and Votes",
+                "Publishing and Sharing",
                 "Advanced Features",
             ]
         ) {

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,3 +23,4 @@ The Outliner project is a real-time collaborative application built with the fol
 - [**State Management / state_management.md**](state_management.md): Guidelines on how state is managed across the application, particularly interacting with Yjs.
 - [**Production Setup / PRODUCTION_SETUP.md**](PRODUCTION_SETUP.md): Instructions and configurations for the production cloud backend.
 - [**Documentation / Documentation.md**](Documentation.md): Instructions for the documentation.
+- [**Demo Project / demo-project.md**](demo-project.md): How the public `/demo` feature tour is seeded, and the policy that every new end-user feature must also be added to the demo template.

--- a/docs/client-features/dmo-demo-project-feature-tour-7d3e9a1c.yaml
+++ b/docs/client-features/dmo-demo-project-feature-tour-7d3e9a1c.yaml
@@ -18,5 +18,6 @@ acceptance:
 - Internal links between demo pages resolve within the demo project
 - Selecting a page in the list opens it at /demo/<page> with the outliner view
 - The demo content resets every 24 hours or when the seed template version changes
-- The demo project is seeded with one page per feature group (formatting, outliner basics, checkboxes and tasks, internal links, search and commands, collaboration, comments and votes, advanced features)
+- The demo project is seeded with one page per feature group (formatting, outliner basics, checkboxes and tasks, internal links, search and commands, selection and clipboard, collaboration, comments and votes, publishing and sharing, advanced features)
+- When a new end-user feature is implemented, the demo template is extended to demonstrate it (see docs/demo-project.md)
 title-ja: デモプロジェクト機能ツアー

--- a/docs/demo-project.md
+++ b/docs/demo-project.md
@@ -1,0 +1,61 @@
+# Demo Project (Feature Tour)
+
+The public demo at <https://outliner-d57b0.web.app/demo> opens a shared, anonymous
+demo project (room `projects/demo`). It is the living showcase of the product:
+its purpose is to let anyone try **every end-user feature** without creating an
+account.
+
+## How it works
+
+- The demo content is defined as a template in
+  [`server/src/demo-content.ts`](../server/src/demo-content.ts) (`demoPages`).
+- Each entry in `demoPages` becomes one page of the demo project. The first
+  page (`Demo`) is the landing page and contains a "Feature tour" list with an
+  internal link to every other page.
+- The client calls `POST /api/seed-demo` when the demo route is opened
+  ([`client/src/lib/demoSeed.ts`](../client/src/lib/demoSeed.ts)). The server
+  ([`server/src/demo-api.ts`](../server/src/demo-api.ts)) re-seeds the shared
+  document when it is empty, when its content is older than 24 hours, or when
+  `DEMO_TEMPLATE_VERSION` has changed.
+- Tests:
+  - `server/tests/demo-seed-content.test.ts` validates the template structure.
+  - `client/e2e/core/dmo-demo-project-feature-tour-7d3e9a1c.spec.ts` validates
+    the `/demo` route end to end.
+- Feature spec: `docs/client-features/dmo-demo-project-feature-tour-7d3e9a1c.yaml`
+  (FTR-7d3e9a1c).
+
+## Policy: keep the demo in sync with the feature set
+
+**Intent: the demo project must always demonstrate the current feature set.
+Whenever a new end-user feature is added to the application, it must also be
+added to the demo project template.**
+
+When you implement a new end-user feature (anything recorded in
+`docs/client-features/`), extend the demo template as part of the same change:
+
+1. **Add demo content** in `server/src/demo-content.ts`:
+   - If the feature belongs to an existing feature group, add one or more
+     lines to that page (e.g. a new formatting syntax goes on the
+     `Formatting` page).
+   - If it opens a new feature group, add a new `DemoPageTemplate` entry with
+     a short, hands-on description ("try it" style), and add a corresponding
+     `[Page Title]: summary` link under "Feature tour:" on the landing page.
+2. **Bump `DEMO_TEMPLATE_VERSION`** so already-seeded demo documents are
+   re-seeded with the new content.
+3. **Update the tests**: the expected page list in
+   `client/e2e/core/dmo-demo-project-feature-tour-7d3e9a1c.spec.ts` and, when
+   the structure changes, `server/tests/demo-seed-content.test.ts`.
+
+Writing guidelines for demo pages:
+
+- Write content in English, in plain instructional sentences.
+- Prefer interactive examples the visitor can try immediately over abstract
+  descriptions.
+- Keep each page focused on one feature group; one page rarely needs more
+  than ~12 top-level lines. Indent lines by two spaces per nesting level.
+- Internal links use `[Page Title]` syntax and must match the `title` of
+  another `demoPages` entry exactly.
+
+Features that are intentionally not demonstrated (e.g. account management,
+admin tooling, or destructive operations) do not need demo pages; when in
+doubt, record the omission in `docs/NON_GOALS.md`.

--- a/server/src/demo-content.ts
+++ b/server/src/demo-content.ts
@@ -1,8 +1,15 @@
 import { Item, Items, Project } from "./schema/app-schema.js";
 
+// The public demo project is the living showcase of the product: every
+// end-user feature should be demonstrable on one of the pages below.
+// When you implement a new end-user feature, extend this template (add a
+// line to an existing page, or add a new feature page plus a landing-page
+// tour link) so the demo keeps covering the full feature set.
+// See docs/demo-project.md for the full policy.
+
 // Bump this whenever the demo template below changes so that already-seeded
 // demo documents are re-seeded on the next /api/seed-demo call.
-export const DEMO_TEMPLATE_VERSION = 3;
+export const DEMO_TEMPLATE_VERSION = 4;
 
 // Must match the demo room id (`projects/demo`) so that internal links
 // rendered from `project.title` resolve to /demo/<page> URLs.
@@ -29,8 +36,10 @@ export const demoPages: DemoPageTemplate[] = [
             "  [Checkboxes and Tasks]: interactive checklists with completion status.",
             "  [Internal Links]: linking between pages, backlinks, and the graph view.",
             "  [Search and Commands]: full-text search and the inline command palette.",
+            "  [Selection and Clipboard]: multi-item selection, box selection, copy and paste.",
             "  [Collaboration]: real-time editing with other users.",
             "  [Comments and Votes]: discussing and voting on items.",
+            "  [Publishing and Sharing]: read-only sharing, scheduled publishing, and snapshots.",
             "  [Advanced Features]: charts, SQL queries, aliases, and attachments.",
             "Give it a try! Everything in this project is editable.",
         ],
@@ -102,6 +111,23 @@ export const demoPages: DemoPageTemplate[] = [
         ],
     },
     {
+        title: "Selection and Clipboard",
+        lines: [
+            "Select text with the mouse or with Shift+Arrow keys.",
+            "Selections can span multiple items: keep extending past the end of an item.",
+            "Useful shortcuts:",
+            "  Ctrl+L selects the entire line under the cursor.",
+            "  Shift+Alt+Right expands the selection to the end of the line; Shift+Alt+Left shrinks it.",
+            "  Alt+Shift+Arrow keys (or Alt+Shift+mouse drag) create a box selection across items.",
+            "With an active selection you can:",
+            "  Copy and paste it, even when it spans multiple items.",
+            "  Delete the whole selection in one step.",
+            "  Drag and drop the selected text to move it.",
+            "  Apply formatting such as bold or italic to the selected range.",
+            "Try selecting across the items above and copying them.",
+        ],
+    },
+    {
         title: "Collaboration",
         lines: [
             "This demo is a shared, real-time collaborative space.",
@@ -124,6 +150,16 @@ export const demoPages: DemoPageTemplate[] = [
         ],
     },
     {
+        title: "Publishing and Sharing",
+        lines: [
+            "Pages and projects can be shared beyond the people editing them.",
+            "Sharing: generate a read-only token to share a project without giving edit access.",
+            "Scheduled publishing: schedule a page to be published automatically at a later time.",
+            "The schedule management page lists upcoming publishing tasks and lets you edit or cancel them.",
+            "Snapshots: the snapshot diff viewer shows how a page changed compared to earlier versions.",
+        ],
+    },
+    {
         title: "Advanced Features",
         lines: [
             "A quick tour of the more advanced capabilities.",
@@ -132,7 +168,6 @@ export const demoPages: DemoPageTemplate[] = [
             "Aliases: an item can mirror another item and stay in sync with the original.",
             "Attachments: drag and drop images or files onto an item to attach them.",
             "Schedule: the Schedule view shows date-tagged items as a timeline.",
-            "Sharing: projects can be shared with read-only tokens.",
         ],
     },
 ];


### PR DESCRIPTION
## Summary
- Extends the public demo project template (FTR-7d3e9a1c) with two new feature pages so the demo covers more of the feature set:
  - **Selection and Clipboard**: multi-item selection, box selection, selection shortcuts, copy/paste, drag-and-drop move, formatting a selection
  - **Publishing and Sharing**: read-only share tokens, scheduled publishing, schedule management, snapshot diff viewer
- Bumps `DEMO_TEMPLATE_VERSION` to 4 so already-seeded demo documents are re-seeded
- Adds **docs/demo-project.md** documenting the intent that the demo project must always demonstrate the current feature set: whenever a new end-user feature is implemented, it must also be added to the demo template (with step-by-step instructions)
- References the policy from AGENTS.md (Documentation section), docs/INDEX.md, and a header comment in `server/src/demo-content.ts`
- Updates the demo e2e page-list expectation and the FTR-7d3e9a1c feature yaml

## Testing
- `server/tests/demo-seed-content.test.ts` (Mocha): 6 passing
- `scripts/test.sh client/e2e/core/dmo-demo-project-feature-tour-7d3e9a1c.spec.ts`: 2 passed
- `npm run test:e2e:basic`: 24 passed
- `npm run build` (client): OK; server `tsc --noEmit`: OK
- Pre-existing type errors in `client` / `client/e2e` tsc are unchanged (verified identical with changes stashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)