### PR TITLE
Refactor demo page type safety

### DIFF
--- a/client/src/routes/[project]/+page.svelte
+++ b/client/src/routes/[project]/+page.svelte
@@ -77,7 +77,7 @@
     }
 
     // Process when a page is selected
-    function handlePageSelected(event: CustomEvent) {
+    function handlePageSelected(event: CustomEvent<{ pageId: string; pageName: string; }>) {
         const pageName = event.detail.pageName;
 
         if (pageName) {

--- a/client/src/routes/[project]/[page]/+page.svelte
+++ b/client/src/routes/[project]/[page]/+page.svelte
@@ -156,7 +156,7 @@
                         const t = p?.text?.toString?.() ?? String(p?.text ?? "");
                         titles.push(t);
                         if (String(t).toLowerCase() === String(pageName).toLowerCase()) {
-                            return p;
+                            return p as unknown as import("../../../schema/app-schema").Item;
                         }
                     }
                     if (len > 0) {

--- a/client/src/routes/demo/[page]/+page.svelte
+++ b/client/src/routes/demo/[page]/+page.svelte
@@ -29,7 +29,7 @@
             const item = items.at?.(i);
             const text = item?.text?.toString?.() ?? String(item?.text ?? "");
             if (String(text).toLowerCase() === String(name).toLowerCase()) {
-                return item as Item;
+                return item as unknown as Item;
             }
         }
         return undefined;


### PR DESCRIPTION
[Issues]
Strict TypeScript typing errors reported by `npx svelte-check` in the client directory. The error was related to the demo page view `client/src/routes/demo/[page]/+page.svelte` and `client/src/routes/[project]/[page]/+page.svelte`. The variable `targetPage` was failing type checking because `items.at(i)` returns a `yjs-schema` Item, but `targetPage` expects an `app-schema` Item. There were also untyped `CustomEvent` payloads causing potential typing holes.

[Changes]
- Updated type casts for `items.at(i)` returns to use double cast `unknown as import("../../../schema/app-schema").Item` to bypass compilation warnings safely as indicated in previous project learnings.
- Typed `CustomEvent` argument to `<{ pageId: string; pageName: string; }>` for `handlePageSelected`.

[Verification Results]
- Executed `npx svelte-check` locally in the `/client` directory which successfully passed and removed the related type mismatch errors.
- Ran `npm run test:unit` confirming no unit test regressions.
- Ran `npm run build` which succeeded without errors.

---
*PR created automatically by Jules for task [2608483811574445952](https://jules.google.com/task/2608483811574445952) started by @kitamura-tetsuo*