### PR TITLE
feat(demo): add manual reset button and fix reseed corrupting the demo tree

### DIFF
--- a/client/e2e/core/dmo-demo-manual-reset-784f295f.spec.ts
+++ b/client/e2e/core/dmo-demo-manual-reset-784f295f.spec.ts
@@ -1,0 +1,37 @@
+import "../utils/registerAfterEachSnapshot";
+import { expect, test } from "@playwright/test";
+import { registerCoverageHooks } from "../utils/registerCoverageHooks";
+registerCoverageHooks();
+
+// FTR-784f295f: the /demo route has a button that manually triggers the
+// 24h demo content reset.
+test.describe("Demo manual reset button", () => {
+    test("clicking the reset button forces a reseed and confirms completion", async ({ page }) => {
+        await page.goto("/demo");
+
+        const pageList = page.getByTestId("demo-page-list");
+        await expect(pageList).toBeVisible({ timeout: 30000 });
+
+        const resetButton = page.getByTestId("demo-reset-button");
+        await expect(resetButton).toBeVisible();
+        await expect(resetButton).toBeEnabled();
+
+        // The forced reset must report reset=true even though the demo was
+        // just seeded by opening the route (i.e. well within the 24h window).
+        const [response] = await Promise.all([
+            page.waitForResponse(resp => resp.url().includes("/api/seed-demo") && resp.request().method() === "POST", {
+                timeout: 30000,
+            }),
+            resetButton.click(),
+        ]);
+        const body = await response.json();
+        expect(body.success).toBe(true);
+        expect(body.reset).toBe(true);
+
+        await expect(page.getByTestId("demo-reset-done")).toBeVisible({ timeout: 15000 });
+
+        // The reseeded demo content is still shown afterwards.
+        await expect(pageList.getByText("Demo", { exact: true }).first()).toBeVisible({ timeout: 15000 });
+        await expect(pageList.getByText("Formatting", { exact: true }).first()).toBeVisible({ timeout: 15000 });
+    });
+});

--- a/client/src/lib/demoSeed.ts
+++ b/client/src/lib/demoSeed.ts
@@ -20,8 +20,11 @@ function resolveApiBaseUrl(): string {
  * Seed (or reset) the public demo project via the backend API.
  * Failures are logged but never thrown: the demo should still open
  * with whatever content is currently in the shared document.
+ *
+ * Pass `{ force: true }` to trigger the 24h reset manually, regardless of
+ * when the demo content was last seeded.
  */
-export async function seedDemo(): Promise<void> {
+export async function seedDemo(options: { force?: boolean; } = {}): Promise<void> {
     try {
         const apiBaseUrl = resolveApiBaseUrl();
         // Append /api/seed-demo, ensuring we don't double up on slashes
@@ -34,6 +37,7 @@ export async function seedDemo(): Promise<void> {
             headers: {
                 "Content-Type": "application/json",
             },
+            body: JSON.stringify({ force: options.force === true }),
         });
         if (!response.ok) {
             logger.warn(`Failed to seed demo: ${response.statusText}`);

--- a/client/src/lib/yjsService.svelte.ts
+++ b/client/src/lib/yjsService.svelte.ts
@@ -49,6 +49,10 @@ class Registry {
         this.map.set(this.key(k), v);
     }
 
+    delete(k: ClientKey) {
+        this.map.delete(this.key(k));
+    }
+
     entries() {
         return Array.from(this.map.entries());
     }
@@ -466,6 +470,22 @@ export function cleanupClient() {
         yjsStore.yjsClient?.dispose();
     } catch {}
     yjsStore.yjsClient = undefined;
+}
+
+/**
+ * Dispose the registered client for a project and drop it from the registry,
+ * so the next getClientByProjectTitle() call creates a fresh connection.
+ * Used by the demo manual reset to re-sync after the server reseeds the doc.
+ */
+export function removeClientByProjectId(projectId: string): void {
+    const key = keyFor(undefined, projectId);
+    const entry = registry.get(key);
+    if (entry) {
+        try {
+            entry[0]?.dispose();
+        } catch {}
+        registry.delete(key);
+    }
 }
 
 export async function deleteProject(projectId: string): Promise<boolean> {

--- a/client/src/routes/api/seed-demo/+server.ts
+++ b/client/src/routes/api/seed-demo/+server.ts
@@ -1,8 +1,16 @@
 import { json } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
-export const POST: RequestHandler = async () => {
+export const POST: RequestHandler = async ({ request }) => {
     try {
+        let force = false;
+        try {
+            const body = await request.json();
+            force = body?.force === true;
+        } catch {
+            // No/invalid JSON body: treat as a regular (non-forced) seed request
+        }
+
         let apiBaseUrl = process.env.VITE_YJS_API_URL;
 
         // Fallback to deriving the API URL from the WebSocket URL if available
@@ -20,7 +28,7 @@ export const POST: RequestHandler = async () => {
             headers: {
                 "Content-Type": "application/json",
             },
-            body: JSON.stringify({}),
+            body: JSON.stringify({ force }),
         });
 
         if (!response.ok) {

--- a/client/src/routes/demo/+page.svelte
+++ b/client/src/routes/demo/+page.svelte
@@ -3,12 +3,14 @@
     import { onDestroy, onMount } from "svelte";
     import PageList from "../../components/PageList.svelte";
     import { DEMO_PROJECT_NAME, seedDemo } from "../../lib/demoSeed";
-    import { getYjsClientByProjectTitle } from "../../services";
+    import { getYjsClientByProjectTitle, removeYjsClientByProjectId } from "../../services";
     import { store } from "../../stores/store.svelte";
     import { yjsStore } from "../../stores/yjsStore.svelte";
     import { resolvePath } from "../../utils/pathUtils";
 
     let isLoading = $state(true);
+    let isResetting = $state(false);
+    let resetDone = $state(false);
     let error: string | undefined = $state(undefined);
 
     // Reactive page list (depends on store.pagesVersion)
@@ -39,6 +41,25 @@
             error = err instanceof Error ? err.message : "An error occurred while loading the demo.";
         } finally {
             isLoading = false;
+        }
+    }
+
+    // Manually trigger the reset that otherwise runs every 24 hours, then
+    // reconnect with a fresh client so the page list reflects the reseeded
+    // content instead of relying on live sync into the old document state.
+    async function resetDemo() {
+        if (isResetting) return;
+        try {
+            isResetting = true;
+            resetDone = false;
+            await seedDemo({ force: true });
+            removeYjsClientByProjectId(DEMO_PROJECT_NAME);
+            yjsStore.yjsClient = undefined;
+            store.project = undefined;
+            await initializeDemo();
+            resetDone = error === undefined;
+        } finally {
+            isResetting = false;
         }
     }
 
@@ -81,10 +102,23 @@
 
         <div class="flex items-center justify-between">
             <h1 class="text-2xl font-bold">Public Demo Project</h1>
+            <button
+                onclick={resetDemo}
+                disabled={isResetting || isLoading}
+                data-testid="demo-reset-button"
+                class="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+                {isResetting ? "Resetting..." : "Reset demo content"}
+            </button>
         </div>
         <p class="mt-1 text-sm text-gray-500">
-            This is a public, collaborative demo project. Each page demonstrates a group of features. Content resets every 24 hours.
+            This is a public, collaborative demo project. Each page demonstrates a group of features. Content resets every 24 hours, or immediately with the reset button.
         </p>
+        {#if resetDone}
+            <p class="mt-1 text-sm text-green-600" data-testid="demo-reset-done">
+                Demo content has been reset.
+            </p>
+        {/if}
     </div>
 
     {#if isLoading}

--- a/client/src/services/index.ts
+++ b/client/src/services/index.ts
@@ -15,6 +15,7 @@ export {
     createClient as createYjsClient,
     createNewProject as createNewYjsProject,
     getClientByProjectTitle as getYjsClientByProjectTitle,
+    removeClientByProjectId as removeYjsClientByProjectId,
 } from "../lib/yjsService.svelte";
 
 // SnapshotService

--- a/docs/client-features/dmo-demo-manual-reset-784f295f.yaml
+++ b/docs/client-features/dmo-demo-manual-reset-784f295f.yaml
@@ -1,0 +1,21 @@
+id: FTR-784f295f
+title: Demo Manual Reset Button
+description: The /demo route has a reset button that manually triggers the same demo content reset that otherwise runs automatically every 24 hours.
+category: demo
+status: implemented
+components:
+- src/lib/demoSeed.ts
+- src/routes/api/seed-demo/+server.ts
+- src/routes/demo/+page.svelte
+services:
+- server/src/demo-api.ts
+tests:
+- client/e2e/core/dmo-demo-manual-reset-784f295f.spec.ts
+- server/tests/demo-manual-reset.test.ts
+acceptance:
+- Clicking the button sends a forced seed request (POST /api/seed-demo with force=true) and re-seeds the demo content immediately, even if the last reset was less than 24 hours ago
+- Repeated resets keep the shared demo document loadable (the template is rebuilt with sequential writes in the live document, so the YTree root marker survives)
+- The /demo project page shows a "Reset demo content" button
+- The button is disabled while the reset is in progress and a confirmation message is shown when it completes
+- Without force, the seeding behavior is unchanged (reset only when empty, older than 24 hours, or template version changed)
+title-ja: デモ手動初期化ボタン

--- a/docs/demo-project.md
+++ b/docs/demo-project.md
@@ -17,10 +17,18 @@ account.
   ([`server/src/demo-api.ts`](../server/src/demo-api.ts)) re-seeds the shared
   document when it is empty, when its content is older than 24 hours, or when
   `DEMO_TEMPLATE_VERSION` has changed.
+- The demo project page also shows a "Reset demo content" button that sends
+  `POST /api/seed-demo` with `{ "force": true }`, triggering the same reset
+  immediately regardless of the 24-hour schedule (FTR-784f295f).
 - Tests:
   - `server/tests/demo-seed-content.test.ts` validates the template structure.
+  - `server/tests/demo-manual-reset.test.ts` validates the reset policy
+    (including the forced reset) and that repeated reseeds keep the shared
+    document loadable.
   - `client/e2e/core/dmo-demo-project-feature-tour-7d3e9a1c.spec.ts` validates
     the `/demo` route end to end.
+  - `client/e2e/core/dmo-demo-manual-reset-784f295f.spec.ts` validates the
+    manual reset button.
 - Feature spec: `docs/client-features/dmo-demo-project-feature-tour-7d3e9a1c.yaml`
   (FTR-7d3e9a1c).
 

--- a/server/src/demo-api.ts
+++ b/server/src/demo-api.ts
@@ -1,19 +1,39 @@
 import express from "express";
 import * as Y from "yjs";
-import { buildDemoProject, DEMO_PROJECT_TITLE, DEMO_TEMPLATE_VERSION } from "./demo-content.js";
+import { DEMO_PROJECT_TITLE, DEMO_TEMPLATE_VERSION, populateDemoProject } from "./demo-content.js";
 import { logger } from "./logger.js";
+import { Project } from "./schema/app-schema.js";
 
 type HocuspocusInstance = any;
 
 const DEMO_PROJECT_ID = "demo";
 const RESET_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
+export interface DemoResetState {
+    isEmpty: boolean;
+    lastReset: number | undefined;
+    templateVersion: number | undefined;
+    now: number;
+    force: boolean;
+}
+
+// Decide whether the shared demo document must be re-seeded. `force` is the
+// manual trigger of the same reset that otherwise runs on the 24h schedule.
+export function shouldResetDemo(state: DemoResetState): boolean {
+    return state.force
+        || state.isEmpty
+        || !state.lastReset
+        || (state.now - state.lastReset > RESET_INTERVAL_MS)
+        || state.templateVersion !== DEMO_TEMPLATE_VERSION;
+}
+
 export function createDemoRouter(hocuspocus: HocuspocusInstance) {
     const router = express.Router();
 
     router.post("/seed-demo", async (req, res): Promise<void> => {
         try {
-            logger.info({ event: "seed_demo_request" });
+            const force = req.body?.force === true;
+            logger.info({ event: "seed_demo_request", force });
 
             const projectRoom = `projects/${DEMO_PROJECT_ID}`;
 
@@ -28,7 +48,6 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                     throw new Error("Failed to get document from direct connection");
                 }
 
-                let shouldReset = false;
                 const now = Date.now();
 
                 const metadata = doc.getMap("metadata") as Y.Map<any>;
@@ -39,17 +58,10 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                 const keys = Array.from(orderedTree.keys());
                 const isEmpty = keys.length === 0 || (keys.length === 1 && keys[0] === "root");
 
-                if (
-                    isEmpty
-                    || !lastReset
-                    || (now - lastReset > RESET_INTERVAL_MS)
-                    || templateVersion !== DEMO_TEMPLATE_VERSION
-                ) {
-                    shouldReset = true;
-                }
+                const shouldReset = shouldResetDemo({ isEmpty, lastReset, templateVersion, now, force });
 
                 if (shouldReset) {
-                    logger.info({ event: "seed_demo_resetting", lastReset, templateVersion, now });
+                    logger.info({ event: "seed_demo_resetting", lastReset, templateVersion, now, force });
 
                     await directConnection.transact((document: any) => {
                         const ydoc = document as unknown as Y.Doc;
@@ -68,12 +80,13 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                         meta.set("lastReset", now);
                         meta.set("templateVersion", DEMO_TEMPLATE_VERSION);
 
-                        // Build the full demo project (all feature pages) in a
-                        // temporary valid instance first
-                        const tempProject = buildDemoProject("seed-server");
-
-                        // Apply the properly initialized project document into the real shared document
-                        Y.applyUpdate(ydoc, Y.encodeStateAsUpdate(tempProject.ydoc));
+                        // Rebuild the template directly in the live document.
+                        // The orderedTree map is empty at this point, so
+                        // Project.fromDoc re-initializes the YTree as a
+                        // sequential write of this client (see demo-content.ts
+                        // for why applying a fresh doc's update is unsafe).
+                        const project = Project.fromDoc(ydoc);
+                        populateDemoProject(project, "seed-server");
                     });
                 } else {
                     logger.info({ event: "seed_demo_no_reset_needed", lastReset, templateVersion, now });

--- a/server/src/demo-content.ts
+++ b/server/src/demo-content.ts
@@ -9,7 +9,7 @@ import { Item, Items, Project } from "./schema/app-schema.js";
 
 // Bump this whenever the demo template below changes so that already-seeded
 // demo documents are re-seeded on the next /api/seed-demo call.
-export const DEMO_TEMPLATE_VERSION = 4;
+export const DEMO_TEMPLATE_VERSION = 5;
 
 // Must match the demo room id (`projects/demo`) so that internal links
 // rendered from `project.title` resolve to /demo/<page> URLs.
@@ -29,6 +29,7 @@ export const demoPages: DemoPageTemplate[] = [
         lines: [
             "Welcome to the Outliner Demo!",
             "This is a public, collaborative demo project. Anyone can edit it, and the content resets every 24 hours.",
+            'You can also reset the content right now with the "Reset demo content" button at the top of the demo project page.',
             "Each page of this project demonstrates a group of features. Follow the links below to take the tour.",
             "Feature tour:",
             "  [Formatting]: bold, italic, strike-through, code, and links.",
@@ -172,13 +173,23 @@ export const demoPages: DemoPageTemplate[] = [
     },
 ];
 
-// Build a fully populated demo project from the template above.
-export function buildDemoProject(author = "seed-server"): Project {
-    const project = Project.createInstance(DEMO_PROJECT_TITLE);
+// Populate an existing, empty project with the demo template pages.
+// The reset endpoint calls this against the live shared document so that all
+// writes (including YTree re-initialization) are sequential operations of the
+// server client. Applying a fresh document's update instead would make the
+// YTree "root" marker a concurrent write, which can lose against tombstoned
+// entries from earlier resets and corrupt the tree.
+export function populateDemoProject(project: Project, author = "seed-server"): void {
     for (const pageTemplate of demoPages) {
         const page = project.addPage(pageTemplate.title, author);
         addLinesToPage(page, pageTemplate.lines, author);
     }
+}
+
+// Build a fully populated demo project from the template above.
+export function buildDemoProject(author = "seed-server"): Project {
+    const project = Project.createInstance(DEMO_PROJECT_TITLE);
+    populateDemoProject(project, author);
     return project;
 }
 

--- a/server/tests/demo-manual-reset.test.ts
+++ b/server/tests/demo-manual-reset.test.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai";
+import * as Y from "yjs";
+import { YTree } from "yjs-orderedtree";
+import { shouldResetDemo } from "../src/demo-api.js";
+import { DEMO_PROJECT_TITLE, DEMO_TEMPLATE_VERSION, demoPages, populateDemoProject } from "../src/demo-content.js";
+import { Project } from "../src/schema/app-schema.js";
+
+// FTR-784f295f: the demo reset button manually triggers the same reset that
+// otherwise runs on the 24h schedule.
+describe("Demo manual reset policy", () => {
+    const now = Date.now();
+    const fresh = {
+        isEmpty: false,
+        lastReset: now - 60 * 1000, // reset one minute ago
+        templateVersion: DEMO_TEMPLATE_VERSION,
+        now,
+        force: false,
+    };
+
+    it("does not reset a freshly seeded document without force", () => {
+        expect(shouldResetDemo(fresh)).to.equal(false);
+    });
+
+    it("resets a freshly seeded document when force is requested", () => {
+        expect(shouldResetDemo({ ...fresh, force: true })).to.equal(true);
+    });
+
+    it("still resets on the 24h schedule without force", () => {
+        const lastReset = now - 24 * 60 * 60 * 1000 - 1;
+        expect(shouldResetDemo({ ...fresh, lastReset })).to.equal(true);
+    });
+
+    it("still resets when the document is empty or has no reset metadata", () => {
+        expect(shouldResetDemo({ ...fresh, isEmpty: true })).to.equal(true);
+        expect(shouldResetDemo({ ...fresh, lastReset: undefined })).to.equal(true);
+    });
+
+    it("still resets when the template version changed", () => {
+        expect(shouldResetDemo({ ...fresh, templateVersion: DEMO_TEMPLATE_VERSION - 1 })).to.equal(true);
+    });
+});
+
+// The reset must rebuild the template with sequential writes in the live
+// document. The previous applyUpdate-from-a-fresh-doc approach made the YTree
+// "root" marker a concurrent write that could lose against tombstones from
+// earlier resets, leaving a document that YTree refuses to load.
+describe("Demo reseed keeps the shared document tree valid", () => {
+    // Mirrors the transact body of POST /api/seed-demo
+    function resetCycle(ydoc: Y.Doc): void {
+        const orderedTree = ydoc.getMap("orderedTree");
+        Array.from(orderedTree.keys()).forEach(key => orderedTree.delete(key));
+        const meta = ydoc.getMap("metadata");
+        meta.set("title", DEMO_PROJECT_TITLE);
+        meta.set("templateVersion", DEMO_TEMPLATE_VERSION);
+        populateDemoProject(Project.fromDoc(ydoc), "seed-server");
+    }
+
+    it("stays loadable by YTree across repeated reload-and-reset cycles", () => {
+        // Simulate the server reloading the persisted doc (new client id each
+        // time) and force-resetting it, several times in a row.
+        let persisted = (() => {
+            const doc = new Y.Doc();
+            resetCycle(doc);
+            return Y.encodeStateAsUpdate(doc);
+        })();
+
+        for (let cycle = 0; cycle < 5; cycle++) {
+            const reloaded = new Y.Doc();
+            Y.applyUpdate(reloaded, persisted);
+            resetCycle(reloaded);
+            persisted = Y.encodeStateAsUpdate(reloaded);
+        }
+
+        // A client syncing the final state must see a valid tree with one
+        // top-level page per template entry.
+        const synced = new Y.Doc();
+        Y.applyUpdate(synced, persisted);
+        const tree = new YTree(synced.getMap("orderedTree") as Y.Map<Y.Map<unknown>>);
+        const rootChildren = tree.getNodeChildrenFromKey("root");
+        expect(rootChildren.length).to.equal(demoPages.length);
+    });
+});


### PR DESCRIPTION
## Summary

- **Manual reset button (FTR-784f295f)**: the public `/demo` page now shows a "Reset demo content" button that triggers the 24-hour automatic reset on demand. It sends `POST /api/seed-demo` with `{ "force": true }`, reconnects the demo client, and shows a confirmation message.
- **Fix: repeated reseeds corrupted the shared demo document.** The previous reset cleared the maps and then applied a fresh document's update (`Y.applyUpdate(ydoc, Y.encodeStateAsUpdate(tempProject.ydoc))`). That made the YTree `root` marker a *concurrent* write each reset; depending on random client-id ordering it could lose against tombstones from earlier resets, after which `new YTree(map)` throws `[ytree] expected yMap to either be initialized for ytree or empty` on every client and the demo shows no pages. The reset now rebuilds the template with sequential writes directly in the live document (`Project.fromDoc` + `populateDemoProject`).
- Demo template landing page mentions the reset button; `DEMO_TEMPLATE_VERSION` bumped to 5.

## Tests

- `server/tests/demo-manual-reset.test.ts` (Mocha): force/24h/template-version reset policy, plus a reload-and-reset cycle test asserting the document stays loadable by YTree.
- `client/e2e/core/dmo-demo-manual-reset-784f295f.spec.ts` (Playwright): clicking the button returns `reset: true` within the 24h window and the page list still renders.
- Existing `dmo-demo-project-feature-tour` spec, `demo-seed-content` server tests, yjsService unit tests, and `test:e2e:basic` (24 specs) all pass. Verified 5 consecutive forced resets keep the tree valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)