### PR TITLE
fix(demo): use correct italic and URL link syntax on the Formatting page

### DIFF
--- a/docs/client-features/fmt-url-label-links-a391b6c2.yaml
+++ b/docs/client-features/fmt-url-label-links-a391b6c2.yaml
@@ -5,9 +5,9 @@ description: Convert bracketed URL and label pairs into links that display only 
 category: text-formatting
 status: implemented
 acceptance:
+- Bracketed URLs without a label, like [URL], are converted to clickable links showing the URL text. Bare URLs outside brackets are not auto-linked.
 - Bracketed pairs [URL label] render the label text linked to the URL.
 - No URL text remains visible when a label is provided.
-- Plain URLs are converted to clickable links.
 tests:
 - client/e2e/core/fmt-url-label-links-a391b6c2.spec.ts
 - client/src/tests/integration/linkFormat.test.ts

--- a/server/src/demo-content.ts
+++ b/server/src/demo-content.ts
@@ -9,7 +9,7 @@ import { Item, Items, Project } from "./schema/app-schema.js";
 
 // Bump this whenever the demo template below changes so that already-seeded
 // demo documents are re-seeded on the next /api/seed-demo call.
-export const DEMO_TEMPLATE_VERSION = 5;
+export const DEMO_TEMPLATE_VERSION = 6;
 
 // Must match the demo room id (`projects/demo`) so that internal links
 // rendered from `project.title` resolve to /demo/<page> URLs.
@@ -52,11 +52,12 @@ export const demoPages: DemoPageTemplate[] = [
             "Click an item to see its raw text with the control characters visible.",
             "Examples:",
             "  You can make text [[bold]] using double brackets.",
-            "  You can make text [/italic] using a slash bracket.",
+            "  You can make text [/ italic] using a slash bracket with a space after the slash.",
             "  You can [-strike through] text using a dash bracket.",
             "  Inline `code` uses backticks.",
-            "  Formats can be combined, like [[bold with [/italic]]] inside.",
-            "URLs become clickable links: https://github.com/yjs/yjs",
+            "  Formats can be combined, like [[bold with [/ italic] inside]].",
+            "Bracketed URLs become clickable links: [https://github.com/yjs/yjs]",
+            "Add a label after the URL to show friendly text: [https://github.com/yjs/yjs Yjs on GitHub]",
             "Try editing any line above to see the syntax behind it.",
         ],
     },

--- a/server/tests/demo-seed-content.test.ts
+++ b/server/tests/demo-seed-content.test.ts
@@ -84,7 +84,7 @@ describe("Demo seed content", () => {
 
         const texts = childTexts(examples!.items).join("\n");
         expect(texts).to.contain("[[bold]]");
-        expect(texts).to.contain("[/italic]");
+        expect(texts).to.contain("[/ italic]");
         expect(texts).to.contain("[-strike through]");
         expect(texts).to.contain("`code`");
     });


### PR DESCRIPTION
## Problem

On https://outliner-d57b0.web.app/demo/Formatting, the italic and URL examples do not render:

- `[/italic]` (no space) is parsed as a **project internal link** (`[/project/page]`), not italic. The formatter requires a space: `[/ italic]` (see `ScrapboxFormatter.tokenize`, patterns for italic vs. internalLink).
- The bare URL `https://github.com/yjs/yjs` is never auto-linked; links require brackets: `[URL]` or `[URL label]`.

The demo template itself used unsupported syntax.

## Fix

- Use `[/ italic]` in the Formatting page examples and explain the required space.
- Use the proven combined-format pattern `[[bold with [/ italic] inside]]`.
- Replace the bare URL with `[https://github.com/yjs/yjs]` and add a labeled example `[https://github.com/yjs/yjs Yjs on GitHub]`.
- Bump `DEMO_TEMPLATE_VERSION` 5 → 6 so deployed demo documents reseed.
- Update the server seed test assertion accordingly.
- Correct the inaccurate "Plain URLs are converted to clickable links" acceptance line in `docs/client-features/fmt-url-label-links-a391b6c2.yaml` (bare URLs are not auto-linked; only bracketed URLs are).

All new demo lines use syntax already covered by `ScrapboxFormatter.test.ts` rendering tests.

## Tests

- `server/tests/demo-seed-content.test.ts` — 6 passing
- `server/tests/demo-manual-reset.test.ts` — 6 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)