### PR TITLE
feat(fmt): auto-link bare URLs in item text (FMT-3ad6e710)

### DIFF
--- a/client/e2e/core/fmt-plain-url-autolink-3ad6e710.spec.ts
+++ b/client/e2e/core/fmt-plain-url-autolink-3ad6e710.spec.ts
@@ -1,0 +1,49 @@
+import "../utils/registerAfterEachSnapshot";
+import { registerCoverageHooks } from "../utils/registerCoverageHooks";
+registerCoverageHooks();
+/** @feature FMT-3ad6e710
+ *  Title   : Plain URL auto-link
+ *  Source  : docs/client-features.yaml
+ */
+
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("Plain URL auto-link", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.seedProjectAndNavigate(page, testInfo);
+    });
+
+    test("converts a bare URL in item text to a clickable link", async ({ page }) => {
+        await TestHelpers.seedProjectAndNavigate(page, test.info(), [
+            "Visit https://example.com for details",
+        ]);
+
+        await TestHelpers.waitForOutlinerItems(page);
+
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(firstItemId).not.toBeNull();
+
+        const firstItemHtml = await page.locator(`.outliner-item[data-item-id="${firstItemId}"]`).locator(".item-text")
+            .innerHTML();
+        expect(firstItemHtml).toContain('<a href="https://example.com"');
+        expect(firstItemHtml).toContain('target="_blank"');
+        expect(firstItemHtml).toContain(">https://example.com</a>");
+    });
+
+    test("excludes trailing punctuation from the linked URL", async ({ page }) => {
+        await TestHelpers.seedProjectAndNavigate(page, test.info(), [
+            "Read https://example.com/page.",
+        ]);
+
+        await TestHelpers.waitForOutlinerItems(page);
+
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(firstItemId).not.toBeNull();
+
+        const firstItemHtml = await page.locator(`.outliner-item[data-item-id="${firstItemId}"]`).locator(".item-text")
+            .innerHTML();
+        expect(firstItemHtml).toContain('<a href="https://example.com/page"');
+        expect(firstItemHtml).toContain(">https://example.com/page</a>.");
+    });
+});

--- a/client/src/utils/ScrapboxFormatter.test.ts
+++ b/client/src/utils/ScrapboxFormatter.test.ts
@@ -236,6 +236,70 @@ describe("ScrapboxFormatter", () => {
             });
         });
 
+        describe("bare URL auto-link", () => {
+            it("should convert a bare URL to a clickable link", () => {
+                const input = "Visit https://example.com for details";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    'Visit <a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a> for details',
+                );
+            });
+
+            it("should link a bare URL with a path and query string", () => {
+                const input = "See https://example.com/a/b?q=1&x=2 now";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    'See <a href="https://example.com/a/b?q=1&amp;x=2" target="_blank" rel="noopener noreferrer">https://example.com/a/b?q=1&amp;x=2</a> now',
+                );
+            });
+
+            it("should exclude trailing sentence punctuation from the URL", () => {
+                const input = "Read https://example.com/page.";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    'Read <a href="https://example.com/page" target="_blank" rel="noopener noreferrer">https://example.com/page</a>.',
+                );
+            });
+
+            it("should link multiple bare URLs in one line", () => {
+                const input = "http://a.example and https://b.example";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    '<a href="http://a.example" target="_blank" rel="noopener noreferrer">http://a.example</a>'
+                        + ' and <a href="https://b.example" target="_blank" rel="noopener noreferrer">https://b.example</a>',
+                );
+            });
+
+            it("should not double-process URLs inside bracketed links", () => {
+                const input = "[https://example.com Example Site]";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    '<a href="https://example.com" target="_blank" rel="noopener noreferrer">Example Site</a>',
+                );
+            });
+
+            it("should not link URLs inside code spans", () => {
+                const input = "`https://example.com`";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe("<code>https://example.com</code>");
+            });
+
+            it("should link bare URLs inside bold text", () => {
+                const input = "[[see https://example.com here]]";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    '<strong>see <a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a> here</strong>',
+                );
+            });
+        });
+
         describe("formatting combinations", () => {
             it("should handle bold text with internal links", () => {
                 const input = "[[bold text with [internal-link]]]";
@@ -359,6 +423,29 @@ describe("ScrapboxFormatter", () => {
             expect(tokens[0].content).toBe("https://example.com");
             expect(tokens[0].url).toBe("https://example.com");
         });
+
+        it("should tokenize bare URLs as links", () => {
+            const input = "Visit https://example.com now";
+            const tokens = ScrapboxFormatter.tokenize(input);
+
+            expect(tokens).toHaveLength(3);
+            expect(tokens[0].type).toBe("text");
+            expect(tokens[0].content).toBe("Visit ");
+            expect(tokens[1].type).toBe("link");
+            expect(tokens[1].content).toBe("https://example.com");
+            expect(tokens[1].url).toBe("https://example.com");
+            expect(tokens[2].type).toBe("text");
+            expect(tokens[2].content).toBe(" now");
+        });
+
+        it("should not emit a duplicate token for the URL inside a bracketed link", () => {
+            const input = "[https://example.com Example Site]";
+            const tokens = ScrapboxFormatter.tokenize(input);
+
+            expect(tokens).toHaveLength(1);
+            expect(tokens[0].type).toBe("link");
+            expect(tokens[0].url).toBe("https://example.com");
+        });
     });
 
     describe("hasFormatting", () => {
@@ -372,6 +459,10 @@ describe("ScrapboxFormatter", () => {
 
         it("should return false for plain text", () => {
             expect(ScrapboxFormatter.hasFormatting("plain text")).toBe(false);
+        });
+
+        it("should detect bare URLs", () => {
+            expect(ScrapboxFormatter.hasFormatting("Visit https://example.com now")).toBe(true);
         });
     });
 });

--- a/client/src/utils/ScrapboxFormatter.ts
+++ b/client/src/utils/ScrapboxFormatter.ts
@@ -238,6 +238,13 @@ export class ScrapboxFormatter {
             }
         });
 
+        // Bare URLs (not wrapped in brackets). URLs inside bracketed links or
+        // code spans start later than the enclosing match, so the overlap
+        // resolution below discards them in favor of the bracketed construct.
+        for (const { start, end, url } of ScrapboxFormatter.matchBareUrls(text)) {
+            matches.push({ type: "link", start, end, content: url, url });
+        }
+
         // Sort matches by start position
         matches.sort((a, b) => a.start - b.start);
 
@@ -448,6 +455,28 @@ export class ScrapboxFormatter {
     private static readonly RX_HTML_CODE = /`(.*?)`/g;
     private static readonly RX_HTML_EXT_LINK = /\[(https?:\/\/[^\s\]]+)(?:\s+([^\]]*))?\]/g;
     private static readonly RX_HTML_INT_LINK = /\[([^[\]]+?)\]/g;
+
+    // Bare URL auto-link. Excludes whitespace, brackets and the \x01 placeholder
+    // marker so already-processed constructs are never re-matched.
+    // eslint-disable-next-line no-control-regex
+    private static readonly RX_BARE_URL = /https?:\/\/[^\s\x01<>[\]"]+/g;
+
+    /**
+     * Matches bare (non-bracketed) URLs in plain text.
+     * Trailing sentence punctuation is excluded from the URL.
+     */
+    private static matchBareUrls(text: string): Array<{ start: number; end: number; url: string; }> {
+        if (!text.includes("://")) return [];
+
+        const matches: Array<{ start: number; end: number; url: string; }> = [];
+        ScrapboxFormatter.RX_BARE_URL.lastIndex = 0;
+        let match;
+        while ((match = ScrapboxFormatter.RX_BARE_URL.exec(text)) !== null) {
+            const url = match[0].replace(/[.,;:!?]+$/, "");
+            matches.push({ start: match.index, end: match.index + url.length, url });
+        }
+        return matches;
+    }
 
     /**
      * Function to match italics considering bracket balance
@@ -683,6 +712,26 @@ export class ScrapboxFormatter {
                 });
             }
 
+            // Bare URL auto-link - bracketed URLs and code spans were already
+            // replaced by placeholders above, so only plain-text URLs remain
+            if (input.includes("://")) {
+                const urlMatches = ScrapboxFormatter.matchBareUrls(input);
+                if (urlMatches.length > 0) {
+                    let result = "";
+                    let lastIndex = 0;
+                    for (const match of urlMatches) {
+                        result += input.substring(lastIndex, match.start);
+                        const escapedUrl = this.escapeHtml(ScrapboxFormatter.sanitizeUrl(match.url));
+                        const html =
+                            `<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${escapedUrl}</a>`;
+                        result += createPlaceholder(html);
+                        lastIndex = match.end;
+                    }
+                    result += input.substring(lastIndex);
+                    input = result;
+                }
+            }
+
             // Escape plain text parts
             input = this.escapeHtml(input);
 
@@ -909,6 +958,7 @@ export class ScrapboxFormatter {
             /<u>(.*?)<\/u>/.source, // Underline
             /\[(https?:\/\/[^\s\]]+)(?:\s+[^\]]+)?\]/.source, // External link
             /\[([^[\]/][^[\]]*?)\]/.source, // Internal link
+            /https?:\/\/\S+/.source, // Bare URL
             /^>\s(.*?)$/m.source, // Quote
         ].join("|"),
         "m",
@@ -927,7 +977,8 @@ export class ScrapboxFormatter {
         const mightHaveFormat = text.includes("[")
             || text.includes("`")
             || text.includes("<")
-            || text.includes(">");
+            || text.includes(">")
+            || text.includes("://");
 
         if (!mightHaveFormat) return false;
 

--- a/docs/client-features/fmt-plain-url-autolink-3ad6e710.yaml
+++ b/docs/client-features/fmt-plain-url-autolink-3ad6e710.yaml
@@ -1,0 +1,15 @@
+id: FMT-3ad6e710
+title: Plain URL auto-link
+title-ja: 裸URLの自動リンク
+description: Bare http/https URLs written in item text are automatically rendered as clickable external links without requiring brackets.
+category: text-formatting
+status: implemented
+acceptance:
+- A bare URL like https://example.com in item text renders as a link that opens in a new tab.
+- Bare URLs inside bold or italic ranges are still linked.
+- The raw URL text remains editable as plain text when the item is active.
+- Trailing sentence punctuation (.,;:!?) is not included in the linked URL.
+- URLs inside bracketed links [URL label] and code spans are not double-processed.
+tests:
+- client/e2e/core/fmt-plain-url-autolink-3ad6e710.spec.ts
+- client/src/utils/ScrapboxFormatter.test.ts

--- a/docs/client-features/fmt-url-label-links-a391b6c2.yaml
+++ b/docs/client-features/fmt-url-label-links-a391b6c2.yaml
@@ -5,7 +5,7 @@ description: Convert bracketed URL and label pairs into links that display only 
 category: text-formatting
 status: implemented
 acceptance:
-- Bracketed URLs without a label, like [URL], are converted to clickable links showing the URL text. Bare URLs outside brackets are not auto-linked.
+- Bracketed URLs without a label, like [URL], are converted to clickable links showing the URL text. Bare URLs outside brackets are auto-linked by FMT-3ad6e710.
 - Bracketed pairs [URL label] render the label text linked to the URL.
 - No URL text remains visible when a label is provided.
 tests:

--- a/server/src/demo-content.ts
+++ b/server/src/demo-content.ts
@@ -9,7 +9,7 @@ import { Item, Items, Project } from "./schema/app-schema.js";
 
 // Bump this whenever the demo template below changes so that already-seeded
 // demo documents are re-seeded on the next /api/seed-demo call.
-export const DEMO_TEMPLATE_VERSION = 6;
+export const DEMO_TEMPLATE_VERSION = 7;
 
 // Must match the demo room id (`projects/demo`) so that internal links
 // rendered from `project.title` resolve to /demo/<page> URLs.
@@ -56,7 +56,8 @@ export const demoPages: DemoPageTemplate[] = [
             "  You can [-strike through] text using a dash bracket.",
             "  Inline `code` uses backticks.",
             "  Formats can be combined, like [[bold with [/ italic] inside]].",
-            "Bracketed URLs become clickable links: [https://github.com/yjs/yjs]",
+            "Bare URLs become clickable links automatically: https://github.com/yjs/yjs",
+            "Bracketed URLs are links too: [https://github.com/yjs/yjs]",
             "Add a label after the URL to show friendly text: [https://github.com/yjs/yjs Yjs on GitHub]",
             "Try editing any line above to see the syntax behind it.",
         ],


### PR DESCRIPTION
## Summary

Implements plain (bare) URL auto-linking: `http`/`https` URLs written directly in item text now render as clickable external links (`target="_blank" rel="noopener noreferrer"`) without requiring bracket syntax. Follow-up to #3026, where the demo's bare-URL example was removed because the feature didn't exist.

## Implementation (`ScrapboxFormatter`)

- `matchBareUrls()` helper matches bare URLs and excludes trailing sentence punctuation (`.,;:!?`) from the link.
- `formatToHtmlAdvanced` / `processFormat`: bare URLs in the remaining plain text are linkified **after** all bracketed constructs and code spans have been replaced by placeholders, so `[URL label]` links and `\`code\`` are never double-processed. Because `processFormat` is recursive, bare URLs inside bold/italic ranges are linked too.
- `tokenize()` emits `link` tokens for bare URLs; the existing overlap-resolution discards URLs contained in bracketed matches.
- `hasFormatting()` fast path and pattern now detect `://` / `https?:\/\/`.
- Active items are unchanged: the raw URL stays editable as plain text (`formatWithControlChars` untouched).

## Docs / Demo

- New feature file `docs/client-features/fmt-plain-url-autolink-3ad6e710.yaml`.
- Updated the FMT-a391b6c2 acceptance note to reference the new feature.
- Demo Formatting page gets a bare-URL example line; `DEMO_TEMPLATE_VERSION` 6 → 7 so deployed demos reseed.

## Tests

- Unit: `ScrapboxFormatter.test.ts` — 52 passed (7 new formatToHtml cases, 2 new tokenize cases, 1 new hasFormatting case)
- Integration: `linkFormat.test.ts` — passed
- New E2E: `client/e2e/core/fmt-plain-url-autolink-3ad6e710.spec.ts` — 2 passed
- Server: `demo-seed-content.test.ts` — 6 passed
- Regression: `npm run test:e2e:basic` — 24 passed
- `npm run build` (client) — success

Note: `npx tsc --noEmit` reports pre-existing errors in `e2e/utils/testHelpers.ts` and `src/auth/UserManager.ts` that also occur on `main` (verified by stashing this change); they are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)