### PR TITLE
feat(fmt): support label-first external links [label URL] (FMT-c93d46f2)

### DIFF
--- a/client/e2e/core/fmt-label-url-links-c93d46f2.spec.ts
+++ b/client/e2e/core/fmt-label-url-links-c93d46f2.spec.ts
@@ -1,0 +1,50 @@
+import "../utils/registerAfterEachSnapshot";
+import { registerCoverageHooks } from "../utils/registerCoverageHooks";
+registerCoverageHooks();
+/** @feature FMT-c93d46f2
+ *  Title   : Label-first URL links
+ *  Source  : docs/client-features.yaml
+ */
+
+import { expect, test } from "@playwright/test";
+import { TestHelpers } from "../utils/testHelpers";
+
+test.describe("Label-first URL links", () => {
+    test.beforeEach(async ({ page }, testInfo) => {
+        await TestHelpers.seedProjectAndNavigate(page, testInfo);
+    });
+
+    test("converts [label URL] to link with label text", async ({ page }) => {
+        await TestHelpers.seedProjectAndNavigate(page, test.info(), [
+            "Please see [Example Site https://example.com]",
+        ]);
+
+        await TestHelpers.waitForOutlinerItems(page);
+
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(firstItemId).not.toBeNull();
+
+        const firstItemHtml = await page.locator(`.outliner-item[data-item-id="${firstItemId}"]`).locator(".item-text")
+            .innerHTML();
+        expect(firstItemHtml).toContain('<a href="https://example.com"');
+        expect(firstItemHtml).toContain(">Example Site</a>");
+        expect(firstItemHtml).not.toContain(">https://example.com</a>");
+    });
+
+    test("supports multi-word labels before the URL", async ({ page }) => {
+        await TestHelpers.seedProjectAndNavigate(page, test.info(), [
+            "Source code is at [Yjs on GitHub https://github.com/yjs/yjs]",
+        ]);
+
+        await TestHelpers.waitForOutlinerItems(page);
+
+        const firstItemId = await TestHelpers.getItemIdByIndex(page, 1);
+        expect(firstItemId).not.toBeNull();
+
+        const firstItemHtml = await page.locator(`.outliner-item[data-item-id="${firstItemId}"]`).locator(".item-text")
+            .innerHTML();
+        expect(firstItemHtml).toContain('<a href="https://github.com/yjs/yjs"');
+        expect(firstItemHtml).toContain(">Yjs on GitHub</a>");
+        expect(firstItemHtml).not.toContain('class="internal-link');
+    });
+});

--- a/client/src/utils/ScrapboxFormatter.test.ts
+++ b/client/src/utils/ScrapboxFormatter.test.ts
@@ -236,6 +236,62 @@ describe("ScrapboxFormatter", () => {
             });
         });
 
+        describe("label-first external links: [label URL]", () => {
+            it("should render the label linked to the URL", () => {
+                const input = "[Example Site https://example.com]";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    '<a href="https://example.com" target="_blank" rel="noopener noreferrer">Example Site</a>',
+                );
+            });
+
+            it("should support multi-word labels", () => {
+                const input = "See [Yjs on GitHub https://github.com/yjs/yjs] for details";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    'See <a href="https://github.com/yjs/yjs" target="_blank" rel="noopener noreferrer">Yjs on GitHub</a> for details',
+                );
+            });
+
+            it("should fall back to URL text when the label is empty", () => {
+                const input = "[ https://example.com]";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    '<a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a>',
+                );
+            });
+
+            it("should let the URL-first pattern win when both parts are URLs", () => {
+                const input = "[https://a.example https://b.example]";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    '<a href="https://a.example" target="_blank" rel="noopener noreferrer">https://b.example</a>',
+                );
+            });
+
+            it("should render an image when the URL points to an image", () => {
+                const input = "[My Image https://example.com/pic.png]";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    '<img src="https://example.com/pic.png" alt="My Image" class="scrapbox-image" />',
+                );
+            });
+
+            it("should process formatting inside the label", () => {
+                const input = "[[[bold]] https://example.com]";
+                const result = ScrapboxFormatter.formatToHtml(input);
+
+                expect(result).toBe(
+                    '<a href="https://example.com" target="_blank" rel="noopener noreferrer"><strong>bold</strong></a>',
+                );
+            });
+        });
+
         describe("bare URL auto-link", () => {
             it("should convert a bare URL to a clickable link", () => {
                 const input = "Visit https://example.com for details";
@@ -445,6 +501,26 @@ describe("ScrapboxFormatter", () => {
             expect(tokens).toHaveLength(1);
             expect(tokens[0].type).toBe("link");
             expect(tokens[0].url).toBe("https://example.com");
+        });
+
+        it("should tokenize label-first links [label URL]", () => {
+            const input = "[Example Site https://example.com]";
+            const tokens = ScrapboxFormatter.tokenize(input);
+
+            expect(tokens).toHaveLength(1);
+            expect(tokens[0].type).toBe("link");
+            expect(tokens[0].content).toBe("Example Site");
+            expect(tokens[0].url).toBe("https://example.com");
+        });
+
+        it("should prefer the URL-first pattern when both parts are URLs", () => {
+            const input = "[https://a.example https://b.example]";
+            const tokens = ScrapboxFormatter.tokenize(input);
+
+            expect(tokens).toHaveLength(1);
+            expect(tokens[0].type).toBe("link");
+            expect(tokens[0].url).toBe("https://a.example");
+            expect(tokens[0].content).toBe("https://b.example");
         });
     });
 

--- a/client/src/utils/ScrapboxFormatter.ts
+++ b/client/src/utils/ScrapboxFormatter.ts
@@ -190,6 +190,15 @@ export class ScrapboxFormatter {
                 // Parse URL and optional label (allow if label is whitespace only)
                 regex: /\[(https?:\/\/[^\s\]]+)(?:\s+([^\]]*))?\]/g,
             },
+            {
+                type: "link",
+                start: "[",
+                end: "]",
+                // Reversed order: [label URL]. Listed after the URL-first
+                // pattern so that pattern wins when both could match.
+                regex: /\[([^[\]]*?)\s+(https?:\/\/[^\s\]]+)\]/g,
+                urlLast: true,
+            },
             // Normal internal link (page-name format) - allow page names with hyphens
             { type: "internalLink", start: "[", end: "]", regex: /\[([^[\]]+?)\]/g },
             { type: "quote", start: "> ", end: "", regex: /^>\s(.*?)$/gm },
@@ -216,8 +225,9 @@ export class ScrapboxFormatter {
 
                 // Save URL and label for links
                 if (pattern.type === "link") {
-                    const url = match[1];
-                    const rawLabel = match[2];
+                    const urlLast = "urlLast" in pattern && pattern.urlLast === true;
+                    const url = urlLast ? match[2] : match[1];
+                    const rawLabel = urlLast ? match[1] : match[2];
                     const label = rawLabel && rawLabel.trim() !== "" ? rawLabel.trim() : url;
                     matches.push({
                         type: pattern.type,
@@ -454,6 +464,7 @@ export class ScrapboxFormatter {
     private static readonly RX_HTML_STRIKETHROUGH = /\[-(.*?)\]/g;
     private static readonly RX_HTML_CODE = /`(.*?)`/g;
     private static readonly RX_HTML_EXT_LINK = /\[(https?:\/\/[^\s\]]+)(?:\s+([^\]]*))?\]/g;
+    private static readonly RX_HTML_EXT_LINK_REV = /\[([^[\]]*?)\s+(https?:\/\/[^\s\]]+)\]/g;
     private static readonly RX_HTML_INT_LINK = /\[([^[\]]+?)\]/g;
 
     // Bare URL auto-link. Excludes whitespace, brackets and the \x01 placeholder
@@ -565,11 +576,22 @@ export class ScrapboxFormatter {
             return placeholder;
         };
 
-        // Function to process formatting recursively
-        const processFormat = (input: string): string => {
-            // Fast path: if no formatting characters, just escape and return
+        // Restore placeholders to their stored HTML
+        const restorePlaceholders = (input: string): string => {
+            return input.replace(ScrapboxFormatter.RX_PLACEHOLDER, (match) => {
+                return globalPlaceholders.get(match) || match;
+            });
+        };
+
+        // Function to process formatting recursively.
+        // linkifyBareUrls is false when rendering link labels, where a bare
+        // URL must stay plain text instead of producing a nested anchor.
+        const processFormat = (input: string, linkifyBareUrls = true): string => {
+            // Fast path: if no formatting characters, just escape and return.
+            // Placeholders from outer passes (e.g. bold inside a link label)
+            // still need to be restored.
             if (!ScrapboxFormatter.hasFormatting(input)) {
-                return this.escapeHtml(input);
+                return restorePlaceholders(this.escapeHtml(input));
             }
 
             // Bold - process first, then recursively process content
@@ -671,22 +693,36 @@ export class ScrapboxFormatter {
             }
 
             // External link (allow if label is whitespace only)
-            if (input.includes("[http")) {
-                input = input.replace(ScrapboxFormatter.RX_HTML_EXT_LINK, (match, url, label) => {
-                    const trimmedLabel = label?.trim();
-                    const safeUrl = ScrapboxFormatter.sanitizeUrl(url);
-                    const escapedUrl = this.escapeHtml(safeUrl);
+            const renderExternalLink = (url: string, label: string | undefined): string => {
+                const trimmedLabel = label?.trim();
+                const safeUrl = ScrapboxFormatter.sanitizeUrl(url);
+                const escapedUrl = this.escapeHtml(safeUrl);
 
-                    if (ScrapboxFormatter.isImageUrl(safeUrl)) {
-                        const altText = trimmedLabel ? this.escapeHtml(trimmedLabel) : escapedUrl;
-                        const html = `<img src="${escapedUrl}" alt="${altText}" class="scrapbox-image" />`;
-                        return createPlaceholder(html);
-                    }
-
-                    const text = trimmedLabel ? processFormat(trimmedLabel) : escapedUrl;
-                    const html = `<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+                if (ScrapboxFormatter.isImageUrl(safeUrl)) {
+                    const altText = trimmedLabel ? this.escapeHtml(trimmedLabel) : escapedUrl;
+                    const html = `<img src="${escapedUrl}" alt="${altText}" class="scrapbox-image" />`;
                     return createPlaceholder(html);
-                });
+                }
+
+                const text = trimmedLabel ? processFormat(trimmedLabel, false) : escapedUrl;
+                const html = `<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+                return createPlaceholder(html);
+            };
+
+            if (input.includes("[http")) {
+                input = input.replace(
+                    ScrapboxFormatter.RX_HTML_EXT_LINK,
+                    (match, url, label) => renderExternalLink(url, label),
+                );
+            }
+
+            // External link with the label first: [label URL]
+            // Must run after the URL-first pattern and before internal links
+            if (input.includes("[") && input.includes("://")) {
+                input = input.replace(
+                    ScrapboxFormatter.RX_HTML_EXT_LINK_REV,
+                    (match, label, url) => renderExternalLink(url, label),
+                );
             }
 
             // Project internal links processed above
@@ -714,7 +750,7 @@ export class ScrapboxFormatter {
 
             // Bare URL auto-link - bracketed URLs and code spans were already
             // replaced by placeholders above, so only plain-text URLs remain
-            if (input.includes("://")) {
+            if (linkifyBareUrls && input.includes("://")) {
                 const urlMatches = ScrapboxFormatter.matchBareUrls(input);
                 if (urlMatches.length > 0) {
                     let result = "";
@@ -737,9 +773,7 @@ export class ScrapboxFormatter {
 
             // Restore placeholders to HTML tags
             // Optimization: Replace all placeholders in a single pass O(N) instead of O(N*M)
-            input = input.replace(ScrapboxFormatter.RX_PLACEHOLDER, (match) => {
-                return globalPlaceholders.get(match) || match;
-            });
+            input = restorePlaceholders(input);
 
             return input;
         };

--- a/docs/client-features/fmt-label-url-links-c93d46f2.yaml
+++ b/docs/client-features/fmt-label-url-links-c93d46f2.yaml
@@ -1,0 +1,15 @@
+id: FMT-c93d46f2
+title: Label-first URL links
+title-ja: ラベル先行URLリンク
+description: Bracketed pairs written as [label URL], with the label before the URL, render as links that display only the label text.
+category: text-formatting
+status: implemented
+acceptance:
+- A label that is itself a URL is rendered as plain link text, never as a nested link.
+- Bracketed pairs [label URL] render the label text linked to the URL.
+- Image URLs render as images with the label as alt text.
+- Multi-word labels are supported.
+- When both parts are URLs, the URL-first interpretation [URL label] wins.
+tests:
+- client/e2e/core/fmt-label-url-links-c93d46f2.spec.ts
+- client/src/utils/ScrapboxFormatter.test.ts

--- a/server/src/demo-content.ts
+++ b/server/src/demo-content.ts
@@ -9,7 +9,7 @@ import { Item, Items, Project } from "./schema/app-schema.js";
 
 // Bump this whenever the demo template below changes so that already-seeded
 // demo documents are re-seeded on the next /api/seed-demo call.
-export const DEMO_TEMPLATE_VERSION = 7;
+export const DEMO_TEMPLATE_VERSION = 8;
 
 // Must match the demo room id (`projects/demo`) so that internal links
 // rendered from `project.title` resolve to /demo/<page> URLs.
@@ -59,6 +59,7 @@ export const demoPages: DemoPageTemplate[] = [
             "Bare URLs become clickable links automatically: https://github.com/yjs/yjs",
             "Bracketed URLs are links too: [https://github.com/yjs/yjs]",
             "Add a label after the URL to show friendly text: [https://github.com/yjs/yjs Yjs on GitHub]",
+            "The label can also come first: [Yjs on GitHub https://github.com/yjs/yjs]",
             "Try editing any line above to see the syntax behind it.",
         ],
     },


### PR DESCRIPTION
## Summary

Implements the reversed bracketed link syntax `[label URL]` — label first, URL last — rendering the label text linked to the URL, mirroring the existing `[URL label]` form (FMT-a391b6c2). Follow-up to #3027.

## Implementation (`ScrapboxFormatter`)

- New `RX_HTML_EXT_LINK_REV` pattern `\[([^[\]]*?)\s+(https?:\/\/[^\s\]]+)\]` processed in `formatToHtmlAdvanced` **after** the URL-first pattern (so `[URL label]` wins when both could match, e.g. both parts are URLs) and **before** internal links (which previously swallowed `[label https://...]` as a page link).
- The URL-first and label-first handlers share a `renderExternalLink` helper (image URLs → `<img>` with label as alt; otherwise anchor with processed label).
- `tokenize()` gets a matching `urlLast` pattern emitting the same `link` tokens; existing overlap resolution keeps URL-first precedence.
- Active items are unchanged: brackets render as control characters around the raw text, as with other link forms.

## Latent bugs fixed (found by the new tests)

1. **Nested anchors**: since #3027, a link label that is itself a URL (e.g. `[https://a.example https://b.example]`) went through the bare-URL autolink pass and produced an `<a>` inside an `<a>`. `processFormat` now takes a `linkifyBareUrls` flag, disabled for label rendering.
2. **Placeholder leak**: the no-formatting fast path of `processFormat` returned without restoring `\x01HTML_n\x01` placeholders, so formatting placeholders inside labels (e.g. bold processed in an outer pass) leaked into the output. The fast path now restores placeholders via a shared `restorePlaceholders` helper.

## Docs / Demo

- New feature file `docs/client-features/fmt-label-url-links-c93d46f2.yaml`.
- Demo Formatting page gains `The label can also come first: [Yjs on GitHub https://github.com/yjs/yjs]`; `DEMO_TEMPLATE_VERSION` 7 → 8 so deployed demos reseed.

## Tests

- Unit: `ScrapboxFormatter.test.ts` — 60 passed (6 new formatToHtml cases, 2 new tokenize cases)
- New E2E: `fmt-label-url-links-c93d46f2.spec.ts` — 2 passed
- Regression E2E: `fmt-url-label-links-a391b6c2.spec.ts` (1 passed), `fmt-plain-url-autolink-3ad6e710.spec.ts` (2 passed), `npm run test:e2e:basic` (24 passed)
- Integration: `linkFormat.test.ts` — passed; Server: `demo-seed-content.test.ts` — 6 passed
- `npm run build` (client) — success; `tsc --noEmit` shows no errors in changed files (pre-existing unrelated errors on `main` remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)