### PR TITLE
chore(deps-dev): properly bump @stryker-mutator/core to 9.6.1 with plugin sync

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9563,12 +9563,14 @@
             "license": "MIT"
         },
         "node_modules/@stryker-mutator/api": {
-            "version": "9.6.0",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
+            "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "mutation-testing-metrics": "3.7.2",
-                "mutation-testing-report-schema": "3.7.2",
+                "mutation-testing-metrics": "3.7.3",
+                "mutation-testing-report-schema": "3.7.3",
                 "tslib": "~2.8.0",
                 "typed-inject": "~5.0.0"
             },
@@ -9616,29 +9618,6 @@
             "engines": {
                 "node": ">=20.0.0"
             }
-        },
-        "node_modules/@stryker-mutator/core/node_modules/@stryker-mutator/api": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
-            "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "mutation-testing-metrics": "3.7.3",
-                "mutation-testing-report-schema": "3.7.3",
-                "tslib": "~2.8.0",
-                "typed-inject": "~5.0.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@stryker-mutator/core/node_modules/@stryker-mutator/util": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.1.tgz",
-            "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
-            "dev": true,
-            "license": "Apache-2.0"
         },
         "node_modules/@stryker-mutator/core/node_modules/commander": {
             "version": "14.0.2",
@@ -9707,23 +9686,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/@stryker-mutator/core/node_modules/mutation-testing-metrics": {
-            "version": "3.7.3",
-            "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz",
-            "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "mutation-testing-report-schema": "3.7.3"
-            }
-        },
-        "node_modules/@stryker-mutator/core/node_modules/mutation-testing-report-schema": {
-            "version": "3.7.3",
-            "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz",
-            "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
         "node_modules/@stryker-mutator/core/node_modules/strip-final-newline": {
             "version": "4.0.0",
             "dev": true,
@@ -9759,83 +9721,63 @@
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@stryker-mutator/instrumenter/node_modules/@stryker-mutator/api": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
-            "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "mutation-testing-metrics": "3.7.3",
-                "mutation-testing-report-schema": "3.7.3",
-                "tslib": "~2.8.0",
-                "typed-inject": "~5.0.0"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@stryker-mutator/instrumenter/node_modules/@stryker-mutator/util": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.1.tgz",
-            "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/@stryker-mutator/instrumenter/node_modules/mutation-testing-metrics": {
-            "version": "3.7.3",
-            "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz",
-            "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "mutation-testing-report-schema": "3.7.3"
-            }
-        },
-        "node_modules/@stryker-mutator/instrumenter/node_modules/mutation-testing-report-schema": {
-            "version": "3.7.3",
-            "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz",
-            "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
         "node_modules/@stryker-mutator/typescript-checker": {
-            "version": "9.6.0",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@stryker-mutator/typescript-checker/-/typescript-checker-9.6.1.tgz",
+            "integrity": "sha512-dCFJDoFixFe7cbilsukb7a5jpn9JRSPef7/vgx+xfaf4gPf/neDVbci8E/YSvxmcFveuPHdeUxioocA1CKZqrg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@stryker-mutator/api": "9.6.0",
-                "@stryker-mutator/util": "9.6.0",
+                "@stryker-mutator/api": "9.6.1",
+                "@stryker-mutator/util": "9.6.1",
                 "semver": "~7.7.0"
             },
             "engines": {
                 "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "@stryker-mutator/core": "9.6.0",
+                "@stryker-mutator/core": "9.6.1",
                 "typescript": ">=3.6"
             }
         },
         "node_modules/@stryker-mutator/util": {
-            "version": "9.6.0",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.1.tgz",
+            "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/@stryker-mutator/vitest-runner": {
-            "version": "9.6.0",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@stryker-mutator/vitest-runner/-/vitest-runner-9.6.1.tgz",
+            "integrity": "sha512-eyUHTCf3Ui+SUn/tpFJwzw6MV391kyBLZk/cDHFUfKFELqKMLbvd7e81axArlApKqO6cOnLfrxlwED+2SRN0ow==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@stryker-mutator/api": "9.6.0",
-                "@stryker-mutator/util": "9.6.0",
+                "@stryker-mutator/api": "9.6.1",
+                "@stryker-mutator/util": "9.6.1",
+                "semver": "^7.7.4",
                 "tslib": "~2.8.0"
             },
             "engines": {
                 "node": ">=14.18.0"
             },
             "peerDependencies": {
-                "@stryker-mutator/core": "9.6.0",
+                "@stryker-mutator/core": "9.6.1",
                 "vitest": ">=2.0.0"
+            }
+        },
+        "node_modules/@stryker-mutator/vitest-runner/node_modules/semver": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@svar-ui/core-locales": {
@@ -16275,15 +16217,19 @@
             "license": "Apache-2.0"
         },
         "node_modules/mutation-testing-metrics": {
-            "version": "3.7.2",
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz",
+            "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "mutation-testing-report-schema": "3.7.2"
+                "mutation-testing-report-schema": "3.7.3"
             }
         },
         "node_modules/mutation-testing-report-schema": {
-            "version": "3.7.2",
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz",
+            "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==",
             "dev": true,
             "license": "Apache-2.0"
         },


### PR DESCRIPTION
[Issues]
- PR #2951 bumped `@stryker-mutator/core` from 9.6.0 to 9.6.1 but did not properly resolve the peer dependency plugins in the `package-lock.json`. This usually leads to CI installation failures because NPM strict peer resolution prevents `@stryker-mutator/typescript-checker` and `@stryker-mutator/vitest-runner` (which expect `9.6.0`) from accepting `9.6.1` if they are not also synced.

[Changes]
- Ran `npm update @stryker-mutator/typescript-checker @stryker-mutator/vitest-runner` to cleanly align and deduplicate all Stryker packages across the repository.
- Checked in the updated `package-lock.json` containing synced versions.

[Verification Results]
- `npm ci` completes without any ERESOLVE peer dependency errors.
- `npm run test:unit` in `client` passes with 0 failures.
- `npm run build` in `client` completes successfully.

---
*PR created automatically by Jules for task [9155008927097852606](https://jules.google.com/task/9155008927097852606) started by @kitamura-tetsuo*