### PR TITLE
fix(client): remove literal whitespace from internal link markup

### DIFF
--- a/client/src/utils/ScrapboxFormatter.test.ts
+++ b/client/src/utils/ScrapboxFormatter.test.ts
@@ -410,6 +410,16 @@ describe("ScrapboxFormatter", () => {
         });
     });
 
+
+    describe("whitespace handling", () => {
+        it("should not contain newlines or excessive whitespace in link output", () => {
+            const input = "like [Formatting].";
+            const result = ScrapboxFormatter.formatToHtml(input);
+            expect(result).not.toContain("\n");
+            expect(result).not.toMatch(/ {2,}/);
+        });
+    });
+
     describe("tokenize", () => {
         it("should correctly tokenize internal links", () => {
             const input = "[test-page]";

--- a/client/src/utils/ScrapboxFormatter.test.ts
+++ b/client/src/utils/ScrapboxFormatter.test.ts
@@ -410,7 +410,6 @@ describe("ScrapboxFormatter", () => {
         });
     });
 
-
     describe("whitespace handling", () => {
         it("should not contain newlines or excessive whitespace in link output", () => {
             const input = "like [Formatting].";

--- a/client/src/utils/ScrapboxFormatter.ts
+++ b/client/src/utils/ScrapboxFormatter.ts
@@ -399,7 +399,8 @@ export class ScrapboxFormatter {
 
                             const escapedProjectName = this.escapeHtml(projectName);
                             const escapedPageName = this.escapeHtml(pageName);
-                            html += `<span class="link-preview-wrapper"><a href="/${escapedNormalized}" class="internal-link project-link ${existsClassTokens}" data-project="${escapedProjectName}" data-page="${escapedPageName}">${escapedNormalized}</a></span>`;
+                            html +=
+                                `<span class="link-preview-wrapper"><a href="/${escapedNormalized}" class="internal-link project-link ${existsClassTokens}" data-project="${escapedProjectName}" data-page="${escapedPageName}">${escapedNormalized}</a></span>`;
                         } else {
                             html +=
                                 `<a href="/${escapedNormalized}" class="internal-link project-link">${escapedNormalized}</a>`;
@@ -407,7 +408,8 @@ export class ScrapboxFormatter {
                     } else {
                         const existsClass = this.checkPageExists(rawContent) ? "page-exists" : "page-not-exists";
                         const projectPrefix = this.getProjectPrefix();
-                        html += `<span class="link-preview-wrapper"><a href="${projectPrefix}/${content}" class="internal-link ${existsClass}" data-page="${content}">${content}</a></span>`;
+                        html +=
+                            `<span class="link-preview-wrapper"><a href="${projectPrefix}/${content}" class="internal-link ${existsClass}" data-page="${content}">${content}</a></span>`;
                     }
                     break;
                 }
@@ -660,9 +662,11 @@ export class ScrapboxFormatter {
                     } else {
                         // Case of single page name (project internal link)
                         const existsClass = this.checkPageExists(path) ? "page-exists" : "page-not-exists";
-                        html = `<span class="link-preview-wrapper"><a href="/${this.escapeHtml(path)}" class="internal-link ${existsClass}" data-page="${
+                        html = `<span class="link-preview-wrapper"><a href="/${
                             this.escapeHtml(path)
-                        }">${this.escapeHtml(path)}</a></span>`;
+                        }" class="internal-link ${existsClass}" data-page="${this.escapeHtml(path)}">${
+                            this.escapeHtml(path)
+                        }</a></span>`;
                     }
                     return createPlaceholder(html);
                 });

--- a/client/src/utils/ScrapboxFormatter.ts
+++ b/client/src/utils/ScrapboxFormatter.ts
@@ -399,9 +399,7 @@ export class ScrapboxFormatter {
 
                             const escapedProjectName = this.escapeHtml(projectName);
                             const escapedPageName = this.escapeHtml(pageName);
-                            html += `<span class="link-preview-wrapper">
-                                <a href="/${escapedNormalized}" class="internal-link project-link ${existsClassTokens}" data-project="${escapedProjectName}" data-page="${escapedPageName}">${escapedNormalized}</a>
-                            </span>`;
+                            html += `<span class="link-preview-wrapper"><a href="/${escapedNormalized}" class="internal-link project-link ${existsClassTokens}" data-project="${escapedProjectName}" data-page="${escapedPageName}">${escapedNormalized}</a></span>`;
                         } else {
                             html +=
                                 `<a href="/${escapedNormalized}" class="internal-link project-link">${escapedNormalized}</a>`;
@@ -409,9 +407,7 @@ export class ScrapboxFormatter {
                     } else {
                         const existsClass = this.checkPageExists(rawContent) ? "page-exists" : "page-not-exists";
                         const projectPrefix = this.getProjectPrefix();
-                        html += `<span class="link-preview-wrapper">
-                            <a href="${projectPrefix}/${content}" class="internal-link ${existsClass}" data-page="${content}">${content}</a>
-                        </span>`;
+                        html += `<span class="link-preview-wrapper"><a href="${projectPrefix}/${content}" class="internal-link ${existsClass}" data-page="${content}">${content}</a></span>`;
                     }
                     break;
                 }
@@ -656,21 +652,17 @@ export class ScrapboxFormatter {
                         }
 
                         // Use LinkPreview component
-                        html = `<span class="link-preview-wrapper">
-                        <a href="/${
+                        html = `<span class="link-preview-wrapper"><a href="/${
                             this.escapeHtml(path)
                         }" class="internal-link project-link ${existsClass}" data-project="${
                             this.escapeHtml(projectName)
-                        }" data-page="${this.escapeHtml(pageName)}">${this.escapeHtml(path)}</a>
-                    </span>`;
+                        }" data-page="${this.escapeHtml(pageName)}">${this.escapeHtml(path)}</a></span>`;
                     } else {
                         // Case of single page name (project internal link)
                         const existsClass = this.checkPageExists(path) ? "page-exists" : "page-not-exists";
-                        html = `<span class="link-preview-wrapper">
-                        <a href="/${this.escapeHtml(path)}" class="internal-link ${existsClass}" data-page="${
+                        html = `<span class="link-preview-wrapper"><a href="/${this.escapeHtml(path)}" class="internal-link ${existsClass}" data-page="${
                             this.escapeHtml(path)
-                        }">${this.escapeHtml(path)}</a>
-                    </span>`;
+                        }">${this.escapeHtml(path)}</a></span>`;
                     }
                     return createPlaceholder(html);
                 });
@@ -737,13 +729,11 @@ export class ScrapboxFormatter {
                     const projectPrefix = this.getProjectPrefix();
 
                     // Use LinkPreview component
-                    const html = `<span class="link-preview-wrapper">
-                    <a href="${projectPrefix}/${
+                    const html = `<span class="link-preview-wrapper"><a href="${projectPrefix}/${
                         this.escapeHtml(text)
                     }" class="internal-link ${existsClass}" data-page="${this.escapeHtml(text)}">${
                         this.escapeHtml(text)
-                    }</a>
-                </span>`;
+                    }</a></span>`;
                     return createPlaceholder(html);
                 });
             }


### PR DESCRIPTION
[Issues]
Fixes #3031

[Changes]
- Refactored five instances of `html += \`<span class="link-preview-wrapper">\n...\n</span>\`;` to single-line template strings in `client/src/utils/ScrapboxFormatter.ts` to prevent literal newlines from being emitted to the generated DOM.
- Added a regression test in `client/src/utils/ScrapboxFormatter.test.ts` to verify that outputting link formatting yields no newline characters or excess runs of spaces.

[Verification Results]
- `npm run test:unit` passed across all `ScrapboxFormatter.test.ts` suites (including the newly added regression test).
- Local code formatting was checked.
- No build breakages were encountered.

---
*PR created automatically by Jules for task [9875379014026689416](https://jules.google.com/task/9875379014026689416) started by @kitamura-tetsuo*

close #3031

Related issue: https://github.com/kitamura-tetsuo/outliner/issues/3031