### PR TITLE
fix: drop unimplemented checkboxes feature from demo and fix link rendering

### DIFF
--- a/client/e2e/core/dmo-demo-project-feature-tour-7d3e9a1c.spec.ts
+++ b/client/e2e/core/dmo-demo-project-feature-tour-7d3e9a1c.spec.ts
@@ -17,7 +17,6 @@ test.describe("Demo project feature tour", () => {
                 "Demo",
                 "Formatting",
                 "Outliner Basics",
-                "Checkboxes and Tasks",
                 "Internal Links",
                 "Search and Commands",
                 "Selection and Clipboard",

--- a/client/src/utils/ScrapboxFormatter.test.ts
+++ b/client/src/utils/ScrapboxFormatter.test.ts
@@ -124,6 +124,18 @@ describe("ScrapboxFormatter", () => {
                 );
                 expect(result).toContain('data-page="test-page-name"');
             });
+it("should handle text that looks like checkboxes (prevent internal link formatting)", () => {
+                const input1 = "[ ] empty checkbox";
+                const input2 = "[x] checked checkbox";
+                const input3 = "[X] checked uppercase";
+                const input4 = "[ x ] with spaces";
+
+                expect(ScrapboxFormatter.formatToHtml(input1)).toBe("[ ] empty checkbox");
+                expect(ScrapboxFormatter.formatToHtml(input2)).toBe("[x] checked checkbox");
+                expect(ScrapboxFormatter.formatToHtml(input3)).toBe("[X] checked uppercase");
+                expect(ScrapboxFormatter.formatToHtml(input4)).toBe("[ x ] with spaces");
+            });
+
 
             it("should generate correct HTML for project internal links", () => {
                 const input = "[/project-name/page-name]";

--- a/client/src/utils/ScrapboxFormatter.test.ts
+++ b/client/src/utils/ScrapboxFormatter.test.ts
@@ -124,7 +124,7 @@ describe("ScrapboxFormatter", () => {
                 );
                 expect(result).toContain('data-page="test-page-name"');
             });
-it("should handle text that looks like checkboxes (prevent internal link formatting)", () => {
+            it("should handle text that looks like checkboxes (prevent internal link formatting)", () => {
                 const input1 = "[ ] empty checkbox";
                 const input2 = "[x] checked checkbox";
                 const input3 = "[X] checked uppercase";
@@ -135,7 +135,6 @@ it("should handle text that looks like checkboxes (prevent internal link formatt
                 expect(ScrapboxFormatter.formatToHtml(input3)).toBe("[X] checked uppercase");
                 expect(ScrapboxFormatter.formatToHtml(input4)).toBe("[ x ] with spaces");
             });
-
 
             it("should generate correct HTML for project internal links", () => {
                 const input = "[/project-name/page-name]";

--- a/client/src/utils/ScrapboxFormatter.ts
+++ b/client/src/utils/ScrapboxFormatter.ts
@@ -200,7 +200,7 @@ export class ScrapboxFormatter {
                 urlLast: true,
             },
             // Normal internal link (page-name format) - allow page names with hyphens
-            { type: "internalLink", start: "[", end: "]", regex: /\[([^[\]]+?)\]/g },
+            { type: "internalLink", start: "[", end: "]", regex: /\[(?!(?:\s*|\s*[xX]\s*)\])([^[\]]+?)\]/g },
             { type: "quote", start: "> ", end: "", regex: /^>\s(.*?)$/gm },
         ];
 
@@ -465,7 +465,7 @@ export class ScrapboxFormatter {
     private static readonly RX_HTML_CODE = /`(.*?)`/g;
     private static readonly RX_HTML_EXT_LINK = /\[(https?:\/\/[^\s\]]+)(?:\s+([^\]]*))?\]/g;
     private static readonly RX_HTML_EXT_LINK_REV = /\[([^[\]]*?)\s+(https?:\/\/[^\s\]]+)\]/g;
-    private static readonly RX_HTML_INT_LINK = /\[([^[\]]+?)\]/g;
+    private static readonly RX_HTML_INT_LINK = /\[(?!(?:\s*|\s*[xX]\s*)\])([^[\]]+?)\]/g;
 
     // Bare URL auto-link. Excludes whitespace, brackets and the \x01 placeholder
     // marker so already-processed constructs are never re-matched.
@@ -824,7 +824,7 @@ export class ScrapboxFormatter {
     private static readonly RX_CTRL_ITALIC = /(\[)(\/)(\s+)([^\]]*)(\])/g;
     private static readonly RX_CTRL_PROJECT_LINK = /(\[\/)([^\s\]]+)(\])/g;
     private static readonly RX_CTRL_EXT_LINK = /(\[)(https?:\/\/[^\s\]]+)(?:\s+([^\]]+))?(\])/g;
-    private static readonly RX_CTRL_INT_LINK = /(\[)([^[\]/-][^[\]]*?)(\])/g;
+    private static readonly RX_CTRL_INT_LINK = /(\[)(?!(?:\s*|\s*[xX]\s*)\])([^[\]/-][^[\]]*?)(\])/g;
     private static readonly RX_CTRL_QUOTE = /(^>\s)(.*?)$/gm;
 
     /**

--- a/docs/NON_GOALS.md
+++ b/docs/NON_GOALS.md
@@ -25,3 +25,9 @@ Offline editing will not be implemented. The Fluid Framework used for collaborat
 ### EXT-NON Plugin Architecture
 
 Outliner does not provide a plugin system or extension API. Loading or executing user-defined plugins is outside the project's scope.
+
+## Editing
+
+### Outline-item Checkboxes
+
+The application does not currently support `[ ]` or `[x]` inline checkboxes for outline items with completion rollups. (Standalone checklists exist as a separate feature, but are not integrated into the main Outliner outline items.)

--- a/server/src/demo-content.ts
+++ b/server/src/demo-content.ts
@@ -9,7 +9,7 @@ import { Item, Items, Project } from "./schema/app-schema.js";
 
 // Bump this whenever the demo template below changes so that already-seeded
 // demo documents are re-seeded on the next /api/seed-demo call.
-export const DEMO_TEMPLATE_VERSION = 8;
+export const DEMO_TEMPLATE_VERSION = 9;
 
 // Must match the demo room id (`projects/demo`) so that internal links
 // rendered from `project.title` resolve to /demo/<page> URLs.
@@ -34,7 +34,6 @@ export const demoPages: DemoPageTemplate[] = [
             "Feature tour:",
             "  [Formatting]: bold, italic, strike-through, code, and links.",
             "  [Outliner Basics]: items, indentation, and keyboard navigation.",
-            "  [Checkboxes and Tasks]: interactive checklists with completion status.",
             "  [Internal Links]: linking between pages, backlinks, and the graph view.",
             "  [Search and Commands]: full-text search and the inline command palette.",
             "  [Selection and Clipboard]: multi-item selection, box selection, copy and paste.",
@@ -78,20 +77,6 @@ export const demoPages: DemoPageTemplate[] = [
             "      Grandchild item",
             "    Another child",
             "Try reorganizing the tree above with Tab and Shift+Tab.",
-        ],
-    },
-    {
-        title: "Checkboxes and Tasks",
-        lines: [
-            "Type [ ] at the start of an item to turn it into a checkbox.",
-            "Click a checkbox to toggle it. Parent items reflect the completion status of their children.",
-            "Shopping list:",
-            "  [x] Milk",
-            "  [x] Bread",
-            "  [ ] Eggs",
-            "  [ ] Coffee",
-            "Your turn:",
-            "  [ ] Try checking this box",
         ],
     },
     {

--- a/server/tests/demo-seed-content.test.ts
+++ b/server/tests/demo-seed-content.test.ts
@@ -64,17 +64,6 @@ describe("Demo seed content", () => {
         expect(childTexts(child!.items)).to.deep.equal(["Grandchild item"]);
     });
 
-    it("seeds checkbox items on the tasks page", () => {
-        const tasks = findChildByText(project.items, "Checkboxes and Tasks");
-        expect(tasks).to.not.equal(undefined);
-
-        const list = findChildByText(tasks!.items, "Shopping list:");
-        expect(list).to.not.equal(undefined);
-
-        const entries = childTexts(list!.items);
-        expect(entries).to.deep.equal(["[x] Milk", "[x] Bread", "[ ] Eggs", "[ ] Coffee"]);
-    });
-
     it("seeds formatting examples covering bold, italic, strike-through and code", () => {
         const formatting = findChildByText(project.items, "Formatting");
         expect(formatting).to.not.equal(undefined);


### PR DESCRIPTION
[Issues] Resolves #3030

[Changes]
- Removed the "Checkboxes and Tasks" demo page and removed its references from tests and landing page.
- Updated the regex rules in `client/src/utils/ScrapboxFormatter.ts` to prevent text matching `[ ]`, `[x]`, and variations with spaces from being incorrectly rendered as internal links.
- Updated documentation in `docs/NON_GOALS.md` to clarify that inline item checkboxes with rollups are intentionally not yet implemented.

[Verification Results]
- `npm run test:unit -- ScrapboxFormatter` passed with new test assertions for checkbox formatting overrides.
- Client tests and E2E core features pass.
- Server tests pass.

---
*PR created automatically by Jules for task [8784611806471158915](https://jules.google.com/task/8784611806471158915) started by @kitamura-tetsuo*

close #3030

Related issue: https://github.com/kitamura-tetsuo/outliner/issues/3030