### PR TITLE
fix(demo): increase sync retry timeout for demo page load

### DIFF
--- a/client/src/routes/demo/[page]/+page.svelte
+++ b/client/src/routes/demo/[page]/+page.svelte
@@ -54,10 +54,10 @@
                 store.project = client.getProject() as unknown as import("../../../schema/app-schema").Project;
             }
 
-            // Wait for sync until the page is found (5 seconds max)
+            // Wait for sync until the page is found (15 seconds max, aligns with regular project page loader)
             let targetPage = findPage(name);
             let retries = 0;
-            while (!targetPage && retries < 50) {
+            while (!targetPage && retries < 150) {
                 await new Promise(r => setTimeout(r, 100));
                 targetPage = findPage(name);
                 retries++;


### PR DESCRIPTION
[Issues]\nThe demo page loading logic had a short synchronization timeout capped at 50 retries (5 seconds), which could cause premature loading failures and "Page not found" errors on slower connections or heavy initial syncs, compared to the regular project page loader which waits for up to 15 seconds.\n\n[Changes]\n- Increased `maxRetries` logic in `client/src/routes/demo/[page]/+page.svelte` from `retries < 50` to `retries < 150`.\n- Updated comment to reflect that the timeout is now 15 seconds, aligning with the regular project page loader.\n\n[Verification Results]\n- Manually verified the `demo/[page]/+page.svelte` route loads without throwing `Failed to load demo page` console errors when tested.\n- Passed all client unit tests (`cd client && npm run test:unit`).\n- Client production build completed successfully without regressions (`npm run build`).

---
*PR created automatically by Jules for task [3009037470976817278](https://jules.google.com/task/3009037470976817278) started by @kitamura-tetsuo*