### PR TITLE
chore(server): bump @hocuspocus/server from 3.4.4 to 4.1.0

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,7 +13,7 @@
                 "@google-cloud/secret-manager": "^6.1.3",
                 "@hocuspocus/extension-logger": "^4.1.0",
                 "@hocuspocus/extension-sqlite": "^4.1.0",
-                "@hocuspocus/server": "^3.4.3",
+                "@hocuspocus/server": "^4.1.0",
                 "@sentry/node": "^10.56.0",
                 "cors": "^2.8.6",
                 "express": "^5.2.1",
@@ -1576,9 +1576,9 @@
             }
         },
         "node_modules/@hocuspocus/common": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-3.4.4.tgz",
-            "integrity": "sha512-RykIJ0tsHHMP4Xk+4UCbc7SO5LgGxGUSTdbh6anJEsaALAyqinf1Nn5HYuMjLPolAmsar1v++m9zufR09NLpXA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-4.2.0.tgz",
+            "integrity": "sha512-031clELz+rW7MpmpFUFN7+vE52Gtk1wkrSVHyqydZgKSLf5AtrorliCf38cH65mGGltLR2/JrydzqOk2bVQhjw==",
             "license": "MIT",
             "dependencies": {
                 "lib0": "^0.2.87"
@@ -1596,35 +1596,6 @@
                 "yjs": "^13.6.8"
             }
         },
-        "node_modules/@hocuspocus/extension-database/node_modules/@hocuspocus/common": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-4.1.0.tgz",
-            "integrity": "sha512-SOBbu0GcBMbLo7IYRDZC6gvEcoATbEFIC5KqzvLanC6dZZLkv91pYEBli+Exs/G71ELL3iUjSwnaf+gksxcjFA==",
-            "license": "MIT",
-            "dependencies": {
-                "lib0": "^0.2.87"
-            }
-        },
-        "node_modules/@hocuspocus/extension-database/node_modules/@hocuspocus/server": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-4.1.0.tgz",
-            "integrity": "sha512-mp0Of76kRkK/u+9pKXPLNV4NI2Cyjql/jVnudVb0z6xAd/i7mBDTK88p1I1sNoX9yvCvhY7lQlrvVx6sMcl8Xw==",
-            "license": "MIT",
-            "dependencies": {
-                "@hocuspocus/common": "^4.1.0",
-                "async-mutex": "^0.5.0",
-                "crossws": "^0.4.4",
-                "kleur": "^4.1.4",
-                "lib0": "^0.2.47"
-            },
-            "engines": {
-                "node": ">=22"
-            },
-            "peerDependencies": {
-                "y-protocols": "^1.0.6",
-                "yjs": "^13.6.8"
-            }
-        },
         "node_modules/@hocuspocus/extension-logger": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/@hocuspocus/extension-logger/-/extension-logger-4.1.0.tgz",
@@ -1632,35 +1603,6 @@
             "license": "MIT",
             "dependencies": {
                 "@hocuspocus/server": "^4.1.0"
-            }
-        },
-        "node_modules/@hocuspocus/extension-logger/node_modules/@hocuspocus/common": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-4.1.0.tgz",
-            "integrity": "sha512-SOBbu0GcBMbLo7IYRDZC6gvEcoATbEFIC5KqzvLanC6dZZLkv91pYEBli+Exs/G71ELL3iUjSwnaf+gksxcjFA==",
-            "license": "MIT",
-            "dependencies": {
-                "lib0": "^0.2.87"
-            }
-        },
-        "node_modules/@hocuspocus/extension-logger/node_modules/@hocuspocus/server": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-4.1.0.tgz",
-            "integrity": "sha512-mp0Of76kRkK/u+9pKXPLNV4NI2Cyjql/jVnudVb0z6xAd/i7mBDTK88p1I1sNoX9yvCvhY7lQlrvVx6sMcl8Xw==",
-            "license": "MIT",
-            "dependencies": {
-                "@hocuspocus/common": "^4.1.0",
-                "async-mutex": "^0.5.0",
-                "crossws": "^0.4.4",
-                "kleur": "^4.1.4",
-                "lib0": "^0.2.47"
-            },
-            "engines": {
-                "node": ">=22"
-            },
-            "peerDependencies": {
-                "y-protocols": "^1.0.6",
-                "yjs": "^13.6.8"
             }
         },
         "node_modules/@hocuspocus/extension-sqlite": {
@@ -1690,28 +1632,20 @@
                 "yjs": "^13.6.8"
             }
         },
-        "node_modules/@hocuspocus/provider/node_modules/@hocuspocus/common": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-4.1.0.tgz",
-            "integrity": "sha512-SOBbu0GcBMbLo7IYRDZC6gvEcoATbEFIC5KqzvLanC6dZZLkv91pYEBli+Exs/G71ELL3iUjSwnaf+gksxcjFA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "lib0": "^0.2.87"
-            }
-        },
         "node_modules/@hocuspocus/server": {
-            "version": "3.4.4",
-            "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-3.4.4.tgz",
-            "integrity": "sha512-UV+oaONAejOzeYgUygNcgsc8RdZvSokVvAxluZJIisLACpRO/VsseQ5lWKDRwLd7Fn6+rHWDH3hGuQ1fdX1Ycg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-4.1.0.tgz",
+            "integrity": "sha512-mp0Of76kRkK/u+9pKXPLNV4NI2Cyjql/jVnudVb0z6xAd/i7mBDTK88p1I1sNoX9yvCvhY7lQlrvVx6sMcl8Xw==",
             "license": "MIT",
             "dependencies": {
-                "@hocuspocus/common": "^3.4.4",
-                "async-lock": "^1.3.1",
+                "@hocuspocus/common": "^4.1.0",
                 "async-mutex": "^0.5.0",
+                "crossws": "^0.4.4",
                 "kleur": "^4.1.4",
-                "lib0": "^0.2.47",
-                "ws": "^8.5.0"
+                "lib0": "^0.2.47"
+            },
+            "engines": {
+                "node": ">=22"
             },
             "peerDependencies": {
                 "y-protocols": "^1.0.6",
@@ -4104,12 +4038,6 @@
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/async-lock": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
-            "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
-            "license": "MIT"
         },
         "node_modules/async-mutex": {
             "version": "0.5.0",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
         "@google-cloud/secret-manager": "^6.1.3",
         "@hocuspocus/extension-logger": "^4.1.0",
         "@hocuspocus/extension-sqlite": "^4.1.0",
-        "@hocuspocus/server": "^3.4.3",
+        "@hocuspocus/server": "^4.1.0",
         "@sentry/node": "^10.56.0",
         "cors": "^2.8.6",
         "express": "^5.2.1",

--- a/server/src/demo-api.ts
+++ b/server/src/demo-api.ts
@@ -71,31 +71,39 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                         size: orderedTree.size,
                     });
 
-                    await directConnection.transact(async (document: any) => {
-                        const ydoc = document as unknown as Y.Doc;
+                    // Apply the reset directly on the live document — do NOT wrap it in
+                    // directConnection.transact(). Since @hocuspocus/server 4.x that helper
+                    // runs the callback inside a single Yjs transaction, but yjs-orderedtree
+                    // relies on its observeDeep handler firing between successive tree
+                    // mutations to refresh its internal computedMap. Batching the
+                    // populateDemoProject() tree writes (createNode + setNodeOrderToEnd) into
+                    // one transaction leaves new nodes missing from that map and throws
+                    // "Cannot read properties of undefined (reading 'parent')". Running each
+                    // tree operation as its own transaction (3.x behaviour) keeps it in sync;
+                    // the directConnection.disconnect() in the finally block persists the result.
+                    const ydoc = doc as unknown as Y.Doc;
 
-                        // Clear orderedTree completely
-                        ydoc.getMap("orderedTree").clear();
+                    // Clear orderedTree completely
+                    ydoc.getMap("orderedTree").clear();
 
-                        // Clear items map completely (if it exists from previous versions)
-                        ydoc.getMap("items").clear();
+                    // Clear items map completely (if it exists from previous versions)
+                    ydoc.getMap("items").clear();
 
-                        // Re-initialize metadata
-                        const meta = ydoc.getMap("metadata");
-                        meta.set("title", DEMO_PROJECT_TITLE);
-                        meta.set("lastReset", now);
-                        meta.set("templateVersion", DEMO_TEMPLATE_VERSION);
+                    // Re-initialize metadata
+                    const meta = ydoc.getMap("metadata");
+                    meta.set("title", DEMO_PROJECT_TITLE);
+                    meta.set("lastReset", now);
+                    meta.set("templateVersion", DEMO_TEMPLATE_VERSION);
 
-                        // Rebuild the template directly in the live document.
-                        // The orderedTree map is empty at this point, so
-                        // Project.fromDoc re-initializes the YTree as a
-                        // sequential write of this client (see demo-content.ts
-                        // for why applying a fresh doc's update is unsafe).
-                        const project = Project.fromDoc(ydoc);
-                        populateDemoProject(project, "seed-server");
+                    // Rebuild the template directly in the live document.
+                    // The orderedTree map is empty at this point, so
+                    // Project.fromDoc re-initializes the YTree as a
+                    // sequential write of this client (see demo-content.ts
+                    // for why applying a fresh doc's update is unsafe).
+                    const project = Project.fromDoc(ydoc);
+                    populateDemoProject(project, "seed-server");
 
-                        logger.info({ event: "seed_demo_populated", pages: project.items.length });
-                    });
+                    logger.info({ event: "seed_demo_populated", pages: project.items.length });
                 } else {
                     logger.info({ event: "seed_demo_no_reset_needed", lastReset, templateVersion, now });
                 }

--- a/server/src/demo-api.ts
+++ b/server/src/demo-api.ts
@@ -71,36 +71,60 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                         size: orderedTree.size,
                     });
 
-                    // Apply the reset directly on the live document — do NOT wrap it in
-                    // directConnection.transact(). Since @hocuspocus/server 4.x that helper
-                    // runs the callback inside a single Yjs transaction, but yjs-orderedtree
-                    // relies on its observeDeep handler firing between successive tree
-                    // mutations to refresh its internal computedMap. Batching the
-                    // populateDemoProject() tree writes (createNode + setNodeOrderToEnd) into
-                    // one transaction leaves new nodes missing from that map and throws
-                    // "Cannot read properties of undefined (reading 'parent')". Running each
-                    // tree operation as its own transaction (3.x behaviour) keeps it in sync;
-                    // the directConnection.disconnect() in the finally block persists the result.
                     const ydoc = doc as unknown as Y.Doc;
 
-                    // Clear orderedTree completely
-                    ydoc.getMap("orderedTree").clear();
+                    // Tear the tree down and re-create its root, capturing the Project
+                    // wrapper for the populate step below.
+                    //
+                    // Three YTree quirks force this exact shape (clear, then atomic root
+                    // re-init, then unbatched populate — each a separate transaction):
+                    //   1. Atomic teardown + root re-init. #3020 rebuilds the root as a fresh
+                    //      sequential write of this client (Project.fromDoc re-initializes the
+                    //      YTree because the cleared orderedTree is empty). That root creation
+                    //      is otherwise NOT transactional, so when this runs on the live demo
+                    //      document a stale observeDeep handler — left attached by an earlier
+                    //      Project.fromDoc() on the same doc — fires while "root" exists but its
+                    //      "_parentHistory" has not been set yet, throwing
+                    //      "Cannot read properties of undefined (reading 'entries')". Wrapping
+                    //      the re-init in a transaction makes that observer fire once, after the
+                    //      root is complete. (Repeated forced resets reproduce this; it is also
+                    //      latent on @hocuspocus/server 3.x.)
+                    let project!: Project;
+                    // Clear in a transaction SEPARATE from the root re-init below. The two
+                    // must not share a transaction: deleting and re-adding the "root" key in
+                    // one transaction makes Yjs treat it as an update, which YTree rejects with
+                    // "[ytree] The node should not be updated" (#3020 relies on root being a
+                    // fresh add, not an update).
+                    ydoc.transact(() => {
+                        // Clear orderedTree completely
+                        ydoc.getMap("orderedTree").clear();
 
-                    // Clear items map completely (if it exists from previous versions)
-                    ydoc.getMap("items").clear();
+                        // Clear items map completely (if it exists from previous versions)
+                        ydoc.getMap("items").clear();
 
-                    // Re-initialize metadata
-                    const meta = ydoc.getMap("metadata");
-                    meta.set("title", DEMO_PROJECT_TITLE);
-                    meta.set("lastReset", now);
-                    meta.set("templateVersion", DEMO_TEMPLATE_VERSION);
+                        // Re-initialize metadata
+                        const meta = ydoc.getMap("metadata");
+                        meta.set("title", DEMO_PROJECT_TITLE);
+                        meta.set("lastReset", now);
+                        meta.set("templateVersion", DEMO_TEMPLATE_VERSION);
+                    });
 
-                    // Rebuild the template directly in the live document.
-                    // The orderedTree map is empty at this point, so
-                    // Project.fromDoc re-initializes the YTree as a
-                    // sequential write of this client (see demo-content.ts
-                    // for why applying a fresh doc's update is unsafe).
-                    const project = Project.fromDoc(ydoc);
+                    // Re-create the root atomically (its two internal writes batched), so a
+                    // stale observer never sees a half-built root.
+                    ydoc.transact(() => {
+                        project = Project.fromDoc(ydoc);
+                    });
+
+                    //   2. Populate OUTSIDE that transaction. yjs-orderedtree relies on its
+                    //      observeDeep handler firing between successive tree mutations to
+                    //      refresh its internal computedMap; batching addPage/addNode
+                    //      (createNode + setNodeOrderToEnd) into one transaction leaves new
+                    //      nodes missing from that map and throws
+                    //      "Cannot read properties of undefined (reading 'parent')". Each tree
+                    //      write must therefore be its own transaction. (This is also why we no
+                    //      longer use directConnection.transact(), which since 4.x wraps the
+                    //      whole callback in one transaction.) directConnection.disconnect() in
+                    //      the finally block persists the result.
                     populateDemoProject(project, "seed-server");
 
                     logger.info({ event: "seed_demo_populated", pages: project.items.length });

--- a/server/src/seed-api.ts
+++ b/server/src/seed-api.ts
@@ -138,45 +138,57 @@ export function createSeedRouter(
                     throw new Error("Failed to get document from direct connection");
                 }
 
-                // Use transact for proper change handling
+                // Apply the seed mutations directly on the live document — do NOT
+                // wrap them in directConnection.transact(). Since @hocuspocus/server 4.x
+                // that helper runs the callback inside a single Yjs transaction, but
+                // yjs-orderedtree relies on its observeDeep handler firing between
+                // successive tree mutations to refresh its internal computedMap. Batching
+                // addPage/addNode (createNode + setNodeOrderToEnd) into one transaction
+                // leaves the new node missing from that map and throws
+                // "Cannot read properties of undefined (reading 'parent')". Running each
+                // tree operation as its own transaction (3.x behaviour) keeps it in sync;
+                // document updates still flow through the normal onStoreDocument path.
                 // Pages are stored directly within the single project document's YTree.
-                await directConnection.transact((document: any) => {
-                    const ydoc = document as unknown as Y.Doc;
+                const ydoc = doc as unknown as Y.Doc;
 
-                    // Set project title directly in metadata
-                    const metadata = ydoc.getMap("metadata");
-                    if (!metadata.get("title")) {
-                        metadata.set("title", projectName);
-                    }
+                // Set project title directly in metadata
+                const metadata = ydoc.getMap("metadata");
+                if (!metadata.get("title")) {
+                    metadata.set("title", projectName);
+                }
 
-                    // Create Project wrapper for YTree access
-                    const project = Project.fromDoc(ydoc);
-                    const items = project.items; // Items wrapper for YTree
+                // Create Project wrapper for YTree access
+                const project = Project.fromDoc(ydoc);
 
-                    // Create pages and add content
-                    for (const pageData of pages) {
-                        logger.info({ event: "seed_page", pageName: pageData.name });
+                // Create pages and add content
+                for (const pageData of pages) {
+                    logger.info({ event: "seed_page", pageName: pageData.name });
 
-                        // Create page node directly in the YTree
-                        const page = project.addPage(pageData.name, "seed-server");
+                    // Create page node directly in the YTree
+                    const page = project.addPage(pageData.name, "seed-server");
 
-                        // Add content items (lines) as children of the page
-                        if (pageData.lines && pageData.lines.length > 0) {
-                            const pageItems = page.items;
+                    // Add content items (lines) as children of the page
+                    if (pageData.lines && pageData.lines.length > 0) {
+                        const pageItems = page.items;
 
-                            for (const line of pageData.lines) {
-                                const item = pageItems.addNode("seed-server");
-                                item.text = line;
-                            }
-
-                            logger.info({
-                                event: "seed_items_added",
-                                pageName: pageData.name,
-                                itemCount: pageData.lines.length,
-                            });
+                        for (const line of pageData.lines) {
+                            const item = pageItems.addNode("seed-server");
+                            item.text = line;
                         }
+
+                        logger.info({
+                            event: "seed_items_added",
+                            pageName: pageData.name,
+                            itemCount: pageData.lines.length,
+                        });
                     }
-                });
+                }
+
+                // Flush the debounced onStoreDocument so the seed is persisted even
+                // though we keep the connection open below.
+                if (typeof (hocuspocus as any).flushPendingStores === "function") {
+                    (hocuspocus as any).flushPendingStores();
+                }
 
                 logger.info({ event: "seed_complete", projectName, pageCount: pages.length });
                 res.json({ success: true, projectName, pageCount: pages.length });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -33,6 +33,21 @@ interface ServerOverrides {
     verifyIdTokenCached?: typeof defaultVerifyToken;
 }
 
+// Normalize a `ws` message payload into the Uint8Array expected by
+// Hocuspocus ClientConnection.handleMessage(). `ws` delivers binary frames as a
+// Node Buffer by default, but may yield an ArrayBuffer or an array of Buffers
+// depending on its configuration; cover all three.
+function toUint8Array(data: ArrayBuffer | Buffer | Buffer[]): Uint8Array {
+    if (data instanceof ArrayBuffer) {
+        return new Uint8Array(data);
+    }
+    if (Array.isArray(data)) {
+        const merged = Buffer.concat(data);
+        return new Uint8Array(merged.buffer, merged.byteOffset, merged.byteLength);
+    }
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}
+
 export async function startServer(
     config: Config,
     logger = defaultLogger,
@@ -408,6 +423,25 @@ export async function startServer(
             roomCounts.set(documentName, (roomCounts.get(documentName) ?? 0) + 1);
             logger.info({ event: "ws_connection_accepted", room: documentName });
 
+            // 7. Hand over to Hocuspocus with minimal initial context (ip only).
+            //    Async auth (token verification + access check) is done in onAuthenticate hook.
+            //    Since @hocuspocus/server 4.x, handleConnection no longer attaches its own
+            //    'message'/'close' listeners to the socket; it returns a ClientConnection and we
+            //    must forward raw frames via handleMessage()/handleClose() from this integration.
+            //    The Node IncomingMessage is passed through to hooks untouched (the library only
+            //    reads request.url and request.headers), so we keep using it directly.
+            let clientConnection:
+                | { handleMessage(data: Uint8Array): void; handleClose(event?: any): void; }
+                | undefined;
+            try {
+                console.log(`[server] Handover to Hocuspocus: room=${documentName}, ip=${ip}`);
+                clientConnection = hocuspocus.handleConnection(ws, request as any, { ip });
+            } catch (e) {
+                /* eslint-disable-next-line no-console */ console.error("Error handling Hocuspocus connection:", e);
+                ws.close(1011);
+                return;
+            }
+
             ws.on("message", (data: any) => {
                 recordMessage();
                 const len = data.byteLength || data.length || 0;
@@ -419,10 +453,13 @@ export async function startServer(
                         documentName,
                     });
                     ws.close(4005, "MESSAGE_TOO_LARGE");
+                    return;
                 }
+                clientConnection!.handleMessage(toUint8Array(data));
             });
 
-            ws.on("close", () => {
+            ws.on("close", (code: number, reason: Buffer) => {
+                clientConnection?.handleClose({ code, reason: reason?.toString() });
                 totalSockets--;
                 if (totalSockets < 0) totalSockets = 0;
                 if (ip) {
@@ -436,16 +473,6 @@ export async function startServer(
                     else roomCounts.set(documentName, count);
                 }
             });
-
-            // 7. Immediately hand over to Hocuspocus with minimal initial context (ip only).
-            //    Async auth (token verification + access check) is done in onAuthenticate hook.
-            try {
-                console.log(`[server] Handover to Hocuspocus: room=${documentName}, ip=${ip}`);
-                hocuspocus.handleConnection(ws, request, { ip });
-            } catch (e) {
-                /* eslint-disable-next-line no-console */ console.error("Error handling Hocuspocus connection:", e);
-                ws.close(1011);
-            }
         });
     });
 

--- a/server/tests/seed-direct-connection.test.ts
+++ b/server/tests/seed-direct-connection.test.ts
@@ -96,4 +96,50 @@ describe("Seed via Hocuspocus direct connection (4.x regression)", () => {
         }
         expect(pageTitles).to.deep.equal(demoPages.map(p => p.title));
     });
+
+    // Repeated forced resets while a viewer keeps the demo document live in memory.
+    // This used to fail on the second reset with
+    // "Cannot read properties of undefined (reading 'entries')": a stale YTree
+    // observeDeep handler from an earlier Project.fromDoc() fired during the
+    // non-transactional root re-creation. The doc would then be stuck at size 1
+    // (root only), so every following reset failed too.
+    it("survives repeated forced resets with a viewer connected", async () => {
+        const forceReset = async () => {
+            const res = await fetch(`http://127.0.0.1:${port}/api/seed-demo`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ force: true }),
+            });
+            return { status: res.status, body: await res.json() as { success: boolean; reset: boolean; } };
+        };
+
+        // Seed once, then connect a viewer so the document stays loaded in memory.
+        await forceReset();
+        provider = new HocuspocusProvider({
+            url: `ws://127.0.0.1:${port}/projects/demo?token=1`,
+            name: "projects/demo",
+            document: new Y.Doc(),
+            token: "1",
+        });
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error("Timed out waiting for sync")), 8000);
+            provider!.on("synced", () => {
+                clearTimeout(timeout);
+                resolve();
+            });
+        });
+
+        // Every forced reset must succeed, not just the first.
+        for (let i = 0; i < 3; i++) {
+            const { status, body } = await forceReset();
+            expect(status, `reset ${i} status`).to.equal(200);
+            expect(body.success, `reset ${i} success`).to.equal(true);
+            expect(body.reset, `reset ${i} reset`).to.equal(true);
+        }
+
+        // The viewer must still see the full template after the resets.
+        await new Promise(r => setTimeout(r, 1000));
+        const items = Project.fromDoc(provider.document).items;
+        expect(items.length).to.equal(demoPages.length);
+    });
 });

--- a/server/tests/seed-direct-connection.test.ts
+++ b/server/tests/seed-direct-connection.test.ts
@@ -1,0 +1,99 @@
+import { HocuspocusProvider } from "@hocuspocus/provider";
+import { expect } from "chai";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import sinon from "sinon";
+import WebSocket from "ws";
+import * as Y from "yjs";
+import { loadConfig } from "../src/config.js";
+import { demoPages } from "../src/demo-content.js";
+import { Project } from "../src/schema/app-schema.js";
+import { startServer } from "../src/server.js";
+
+// @ts-ignore
+global.WebSocket = WebSocket;
+
+// Regression coverage for the @hocuspocus/server 3.x -> 4.x upgrade.
+// 4.x changed DirectConnection.transact() to run its callback inside a single
+// Yjs transaction. yjs-orderedtree relies on its observeDeep handler firing
+// between successive tree mutations to refresh its internal computedMap, so
+// batching addPage/addNode (createNode + setNodeOrderToEnd) into one transaction
+// left freshly created nodes missing from that map and made every seed throw
+// "Cannot read properties of undefined (reading 'parent')". The demo and seed
+// routers now apply tree mutations directly on the live document, restoring the
+// 3.x behaviour. This exercises the real openDirectConnection path end-to-end —
+// the existing seed-api-validation test stubs openDirectConnection, so it never
+// caught this.
+describe("Seed via Hocuspocus direct connection (4.x regression)", () => {
+    let httpServer: any;
+    let provider: HocuspocusProvider | undefined;
+    let port: number;
+    let shutdown: () => Promise<void>;
+    let dbDir: string;
+
+    beforeEach(async () => {
+        dbDir = fs.mkdtempSync(path.join(os.tmpdir(), "seed-direct-"));
+        const config = loadConfig({ PORT: "0", LOG_LEVEL: "silent", DATABASE_PATH: dbDir });
+        const res = await startServer(config, undefined, {
+            checkContainerAccess: sinon.stub().resolves(true),
+            verifyIdTokenCached: sinon.stub().resolves({ uid: "test-uid" } as any),
+        });
+        httpServer = res.server;
+        shutdown = res.shutdown;
+
+        await new Promise<void>(resolve => {
+            if (httpServer.listening) resolve();
+            else httpServer.on("listening", resolve);
+        });
+        port = (httpServer.address() as any).port;
+        // Allow SQLite persistence to initialize.
+        await new Promise(r => setTimeout(r, 300));
+    });
+
+    afterEach(async () => {
+        provider?.destroy();
+        provider = undefined;
+        if (shutdown) await shutdown();
+        sinon.restore();
+        await fs.remove(dbDir);
+    });
+
+    it("seeds the demo project without YTree errors and a client syncs the populated tree", async () => {
+        const res = await fetch(`http://127.0.0.1:${port}/api/seed-demo`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ force: true }),
+        });
+        expect(res.status).to.equal(200);
+        const body = await res.json() as { success: boolean; reset: boolean; };
+        expect(body.success).to.equal(true);
+        expect(body.reset).to.equal(true);
+
+        // A client connecting to the public demo room must sync the populated
+        // tree, with one top-level page per template entry in order.
+        provider = new HocuspocusProvider({
+            url: `ws://127.0.0.1:${port}/projects/demo?token=1`,
+            name: "projects/demo",
+            document: new Y.Doc(),
+            token: "1",
+        });
+
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error("Timed out waiting for sync")), 8000);
+            provider!.on("synced", () => {
+                clearTimeout(timeout);
+                resolve();
+            });
+        });
+
+        const project = Project.fromDoc(provider.document);
+        const items = project.items;
+        const pageTitles: string[] = [];
+        for (let i = 0; i < items.length; i++) {
+            const page = items.at(i);
+            if (page) pageTitles.push(page.text);
+        }
+        expect(pageTitles).to.deep.equal(demoPages.map(p => p.title));
+    });
+});


### PR DESCRIPTION
## What

Bumps `@hocuspocus/server` from **3.4.4** to **4.1.0** in `/server`, aligning it with the already-4.1.0 `@hocuspocus/extension-logger`, `@hocuspocus/extension-sqlite`, and `@hocuspocus/provider` packages.

## Breaking change handled

4.x moved WebSocket handling to `crossws`. `handleConnection()` no longer attaches its own `message`/`close` listeners to the socket — it now returns a `ClientConnection` whose `handleMessage()` / `handleClose()` the integration must call.

The `request` argument is typed `Request` now, but at runtime the library only reads `.url` (via a helper that still handles Node-style path URLs) and passes `.headers` straight through to hooks without calling `.get()`, so the existing Node `IncomingMessage` keeps working.

## Changes in `server/src/server.ts`

- Capture the `ClientConnection` returned by `handleConnection`, then forward each `ws` `message` to `clientConnection.handleMessage(...)` and the `close` event to `clientConnection.handleClose(...)`. All existing custom upgrade logic (rate limiting, CORS, socket caps, room validation, message-size enforcement, connection counters) is preserved unchanged.
- Added a `toUint8Array` helper to normalize `ws` payloads (Buffer / ArrayBuffer / Buffer[]) into the `Uint8Array` that `handleMessage` expects.

## Verification

- `npm run build` — clean (0 TypeScript errors).
- Ran the WebSocket Mocha tests: **7 passing** — `hocuspocus-server` (no-token / invalid-token / no-access / **load-a-document full sync round-trip**) and `connection-limits` (message-size close, per-room cap, per-IP cap). Both the happy-path sync and message-size enforcement exercise the new forwarding code.
- 2 failures remain in `hocuspocus-auth-bypass.test.ts` (an uncaught "WebSocket was closed before the connection was established" from the provider's auto-reconnect during teardown). Confirmed **pre-existing** by reverting to 3.4.4 + original code and reproducing the identical failures. These tests are not run by any CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session ID: 7181887975195285342
https://jules.google.com/session/7181887975195285342