### PR TITLE
chore: ignore generated paraglide files from ESLint validation

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -20,6 +20,7 @@ export default ts.config(
             ".svelte-kit/types/**/*",
             ".svelte-kit/output/**/*",
             "playwright-report/**/*",
+            "src/lib/paraglide/**/*",
         ],
     },
     {


### PR DESCRIPTION
[Issues]
- The codebase contained multiple ESLint warnings about unused `eslint-disable` directives in the auto-generated Paraglide localization files (`client/src/lib/paraglide/`).
- Previously recorded issue `issue.md` pointing to Demo Page Loading errors was already correctly resolved by `connectProjectDoc` containing the necessary guards. `server/src/demo-api.ts` was confirmed to be safe and functionally working via local testing, making code health an appropriate task.

[Changes]
- Added `src/lib/paraglide/**/*` to the `ignores` array in `client/eslint.config.js` to correctly skip linting for generated localization files.
- (Deleted intermediate exploratory `.eslintignore` script as client uses ESLint flat configuration format).

[Verification Results]
- `npm run lint` in the `client` directory completes successfully and ignores the previously warned paraglide generated files (resolving 17 out of 742 prior total warnings).
- `npm run build` completed successfully.
- `npm run test:unit` completed successfully.

---
*PR created automatically by Jules for task [3135838529227122364](https://jules.google.com/task/3135838529227122364) started by @kitamura-tetsuo*