### PR TITLE
fix: track active page by ID to prevent routing loss on title edits

### DIFF
--- a/client/src/routes/[project]/[page]/+page.svelte
+++ b/client/src/routes/[project]/[page]/+page.svelte
@@ -294,9 +294,19 @@
         } catch {}
 
         // Monitor route parameter changes
+        let lastRoutePj: string | undefined;
+        let lastRoutePg: string | undefined;
         const unsub = page.subscribe(($p) => {
             const pj = $p.params?.project ?? projectName;
             const pg = $p.params?.page ?? pageName;
+
+            // if route changed, reset activePageId
+            if (lastRoutePj !== undefined && (lastRoutePj !== pj || lastRoutePg !== pg)) {
+                activePageId = undefined; // reset active id on route change
+            }
+            lastRoutePj = pj;
+            lastRoutePg = pg;
+
             scheduleLoadIfNeeded({ project: pj, page: pg });
         });
         onDestroy(unsub);

--- a/client/src/routes/[project]/[page]/+page.svelte
+++ b/client/src/routes/[project]/[page]/+page.svelte
@@ -37,6 +37,7 @@
     let isLoading = $state(true);
     let isAuthenticated = $state(false);
     let pageNotFound = $state(false);
+    let activePageId = $state<string | undefined>(undefined);
 
     let isSearchPanelVisible = $state(false); // Search panel visibility state
 
@@ -147,6 +148,10 @@
 
             // Helper to find page by name
             const findPage = () => {
+                if (activePageId && project) {
+                    const item = project.findPage(activePageId);
+                    if (item) return item as unknown as import("../../../schema/app-schema").Item;
+                }
                 const items = project?.items;
                 if (items) {
                     const len = items.length ?? 0;
@@ -213,6 +218,7 @@
             // 5. Set current page and hydration
             if (targetPage) {
                 store.currentPage = targetPage;
+            activePageId = targetPage.id;
 
                 // Wait for page list store update (optional)
                 if (!store.pages) {
@@ -392,6 +398,7 @@ let resetEpochCache = $state(0);
             resetEpochCache = store.resetEpoch;
             // nullify immediately to disconnect old tree node references
             store.currentPage = undefined;
+            activePageId = undefined;
             // The tree was rebuilt, we must force a remount and reload page logic
             if (projectName && pageName && !isLoading) {
                 setTimeout(() => {

--- a/client/src/routes/demo/[page]/+page.svelte
+++ b/client/src/routes/demo/[page]/+page.svelte
@@ -22,8 +22,13 @@
     let isSearchPanelVisible = $state(false);
     let isResetting = $state(false);
     let resetDone = $state(false);
+    let activePageId = $state<string | undefined>(undefined);
 
     function findPage(name: string): Item | undefined {
+        if (activePageId && store.project) {
+            const item = store.project.findPage(activePageId);
+            if (item) return item as unknown as Item;
+        }
         const items = store.project?.items;
         if (!items) return undefined;
         const len = items.length || 0;
@@ -107,6 +112,7 @@
             }
 
             store.currentPage = targetPage;
+            activePageId = targetPage.id;
         } catch (err) {
             console.error("Failed to load demo page:", err);
             error = err instanceof Error ? err.message : "An error occurred while loading the demo page.";
@@ -150,6 +156,7 @@ let resetEpochCache = $state(0);
             resetEpochCache = store.resetEpoch;
             // nullify immediately to disconnect old tree node references
             store.currentPage = undefined;
+            activePageId = undefined;
             // The tree was rebuilt, we must force a remount and reload page logic
             if (pageName && !isLoading) {
                 setTimeout(() => {
@@ -167,6 +174,7 @@ let resetEpochCache = $state(0);
             const name = $p.params?.page ?? "";
             if (!name || name === lastLoaded) return;
             lastLoaded = name;
+            activePageId = undefined; // reset active id on route change
             loadDemoPage(name);
         });
         return () => unsub();
@@ -178,6 +186,7 @@ let resetEpochCache = $state(0);
             yjsStore.yjsClient = undefined;
             store.project = undefined;
             store.currentPage = undefined;
+            activePageId = undefined;
         } catch {}
     });
 </script>

--- a/client/src/routes/demo/[page]/+page.svelte
+++ b/client/src/routes/demo/[page]/+page.svelte
@@ -171,10 +171,12 @@ let resetEpochCache = $state(0);
         // Follow route parameter changes (e.g. internal links between demo pages)
         let lastLoaded: string | undefined;
         const unsub = page.subscribe(($p) => {
-            const name = $p.params?.page ?? "";
+            const name = $p.params?.page ?? pageName;
             if (!name || name === lastLoaded) return;
+            if (lastLoaded !== undefined && lastLoaded !== name) {
+                activePageId = undefined; // reset active id on route change
+            }
             lastLoaded = name;
-            activePageId = undefined; // reset active id on route change
             loadDemoPage(name);
         });
         return () => unsub();


### PR DESCRIPTION
[Issues]
* Editing the root title of a page (e.g. the "Demo" text inside the `/demo/Demo` route) modifies the actual item text string. When Svelte reactive updates trigger the `findPage` resolution logic, it attempts to string-match the old URL parameter with the new modified text content, which fails. This causes the app to erroneously show a "Page not found" fallback, interrupting the user workflow.

[Changes]
* Introduce an `activePageId` reactive state variable in both `client/src/routes/[project]/[page]/+page.svelte` and `client/src/routes/demo/[page]/+page.svelte`.
* Once the page is initially loaded via string matching, its `id` is cached to `activePageId`.
* On subsequent reactively triggered calls to `findPage` or `loadProjectAndPage`, it will first attempt to lookup the page securely via the underlying static ID.
* Ensure the `activePageId` is cleared upon route URL parameter changes so that navigating away resolves correctly.

[Verification Results]
* Wrote and executed a Playwright script mimicking the user reproducing issue (modifying the title of the Demo page, and hitting Enter/Tab keys) which completed successfully without timeout, confirming the component did not disappear.
* Validated with standard test suite (`cd client && npm run test:unit`) and the entire suite passes without regressions.
* Lint passing and client bundle built successfully (`cd client && npm run build`).

---
*PR created automatically by Jules for task [9619950489123329793](https://jules.google.com/task/9619950489123329793) started by @kitamura-tetsuo*