### PR TITLE
refactor: ignore generated paraglide code in ESLint config

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -21,6 +21,8 @@ export default ts.config(
             ".svelte-kit/output/**/*",
             "playwright-report/**/*",
             "src/lib/paraglide/**/*",
+            "src/paraglide/**/*",
+            "src/paraglide./src/lib/paraglide/**/*",
         ],
     },
     {


### PR DESCRIPTION
[Issues]
ESLint flat configuration was running validation rules against automatically generated `.js` files in the `src/paraglide` directory. This incorrectly threw 'Unused eslint-disable directive' errors, causing noisy linting checks and CI pipelines.

[Changes]
Added `"src/paraglide/**/*"` and `"src/paraglide./src/lib/paraglide/**/*"` directly to the main `ignores` array within `client/eslint.config.js`.

[Verification Results]
Ran `npm run build`, `npm run test:unit`, and `npx eslint .` in the `client` directory. Verified that the `client` build succeeded, unit tests passed, and all 7 false positive parsing/linting errors originally present in the codebase have been completely eliminated.

---
*PR created automatically by Jules for task [12817626975544182697](https://jules.google.com/task/12817626975544182697) started by @kitamura-tetsuo*