### PR TITLE
test(server): fix this.ensureApp(...).auth is not a function warning

### DIFF
--- a/server/tests/firebase-init.test.ts
+++ b/server/tests/firebase-init.test.ts
@@ -31,10 +31,10 @@ describe("firebase-init Secret Manager loading bypass", () => {
         sinon.stub(admin, "app").returns({
             delete: deleteAppStub,
             auth: () => ({
-                getUserByEmail: sinon.stub().rejects({ code: 'auth/user-not-found' }),
-                createUser: sinon.stub().resolves({ uid: 'test-uid', email: 'test@example.com' }),
-                setCustomUserClaims: sinon.stub().resolves()
-            })
+                getUserByEmail: sinon.stub().rejects({ code: "auth/user-not-found" }),
+                createUser: sinon.stub().resolves({ uid: "test-uid", email: "test@example.com" }),
+                setCustomUserClaims: sinon.stub().resolves(),
+            }),
         } as any);
         sinon.stub(admin, "apps").get(() => []);
 

--- a/server/tests/firebase-init.test.ts
+++ b/server/tests/firebase-init.test.ts
@@ -28,7 +28,14 @@ describe("firebase-init Secret Manager loading bypass", () => {
         initializeAppStub = sinon.stub(admin, "initializeApp");
         certStub = sinon.stub(admin.credential, "cert").returns({} as any);
         deleteAppStub = sinon.stub().resolves();
-        sinon.stub(admin, "app").returns({ delete: deleteAppStub } as any);
+        sinon.stub(admin, "app").returns({
+            delete: deleteAppStub,
+            auth: () => ({
+                getUserByEmail: sinon.stub().rejects({ code: 'auth/user-not-found' }),
+                createUser: sinon.stub().resolves({ uid: 'test-uid', email: 'test@example.com' }),
+                setCustomUserClaims: sinon.stub().resolves()
+            })
+        } as any);
         sinon.stub(admin, "apps").get(() => []);
 
         // By default, make it look like non-emulator environment to trigger Secret Manager load checks


### PR DESCRIPTION
[Issues]
A console warning `Failed to setup test user: this.ensureApp(...).auth is not a function` was occurring when running `npm run test` in the `server` directory. This happens because the test stubs `admin.app` to return an object with only a `delete` method, which is missing the `auth` method internally expected by `admin.auth()`.

[Changes]
Modified the `admin.app` stub in `server/tests/firebase-init.test.ts` to include the `auth` method with dummy functionality (`getUserByEmail`, `createUser`, `setCustomUserClaims`).

[Verification Results]
Ran `npm run test` in the `server` directory. The test suite passed successfully without outputting the console warning.

---
*PR created automatically by Jules for task [11533145965474254263](https://jules.google.com/task/11533145965474254263) started by @kitamura-tetsuo*