### PR TITLE
Fix server crash and client loading hang when seeding demo document

### DIFF
--- a/server/src/demo-api.ts
+++ b/server/src/demo-api.ts
@@ -63,12 +63,6 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                 if (shouldReset) {
                     logger.info({ event: "seed_demo_resetting", lastReset, templateVersion, now, force });
 
-                    // Initialize the Project wrapper outside the transaction.
-                    // If the document is completely empty, this safely initializes the
-                    // YTree "root" marker in its own transaction, allowing yjs-orderedtree
-                    // to compute its internal state before we perform bulk operations.
-                    const project = Project.fromDoc(doc as unknown as Y.Doc);
-
                     await directConnection.transact((document: any) => {
                         const ydoc = document as unknown as Y.Doc;
 
@@ -88,6 +82,9 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                         meta.set("lastReset", now);
                         meta.set("templateVersion", DEMO_TEMPLATE_VERSION);
                     });
+
+                    // Initialize Project *after* the clear transaction so it has a clean slate.
+                    const project = Project.fromDoc(doc as unknown as Y.Doc);
 
                     // Rebuild the template directly in the live document.
                     // This is done sequentially outside the transaction because

--- a/server/src/demo-api.ts
+++ b/server/src/demo-api.ts
@@ -63,6 +63,12 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                 if (shouldReset) {
                     logger.info({ event: "seed_demo_resetting", lastReset, templateVersion, now, force });
 
+                    // Initialize the Project wrapper outside the transaction.
+                    // If the document is completely empty, this safely initializes the
+                    // YTree "root" marker in its own transaction, allowing yjs-orderedtree
+                    // to compute its internal state before we perform bulk operations.
+                    const project = Project.fromDoc(doc as unknown as Y.Doc);
+
                     await directConnection.transact((document: any) => {
                         const ydoc = document as unknown as Y.Doc;
 
@@ -81,15 +87,13 @@ export function createDemoRouter(hocuspocus: HocuspocusInstance) {
                         meta.set("title", DEMO_PROJECT_TITLE);
                         meta.set("lastReset", now);
                         meta.set("templateVersion", DEMO_TEMPLATE_VERSION);
-
-                        // Rebuild the template directly in the live document.
-                        // The orderedTree map is empty at this point, so
-                        // Project.fromDoc re-initializes the YTree as a
-                        // sequential write of this client (see demo-content.ts
-                        // for why applying a fresh doc's update is unsafe).
-                        const project = Project.fromDoc(ydoc);
-                        populateDemoProject(project, "seed-server");
                     });
+
+                    // Rebuild the template directly in the live document.
+                    // This is done sequentially outside the transaction because
+                    // yjs-orderedtree relies on synchronous observeDeep callbacks
+                    // which are suspended during a transaction.
+                    populateDemoProject(project, "seed-server");
                 } else {
                     logger.info({ event: "seed_demo_no_reset_needed", lastReset, templateVersion, now });
                 }


### PR DESCRIPTION
**Issues:**
The Public Demo page (`/demo`) failed to load for anonymous users and remained stuck displaying the "Loading Demo..." indicator due to repeated connection failures with the underlying WebSocket. The issue originated on the server during the demo document seeding process. The seeding logic was wrapped entirely in a single Yjs `transact` block. `yjs-orderedtree` relies on `observeDeep` callbacks to synchronously update its internal state (`computedMap`) upon node creation, but Yjs suspends these callbacks inside a transaction, causing a `TypeError` that crashed the server operation and prevented the client from syncing.

**Changes:**
1. Modified `server/src/demo-api.ts` to initialize `Project.fromDoc(doc)` outside the `transact` block.
2. Moved the `populateDemoProject(project, "seed-server")` call outside the `transact` block so `yjs-orderedtree` can safely write nodes sequentially, allowing its `observeDeep` callbacks to fire properly.
3. Kept the document map clearing logic inside the `transact` block to ensure atomic deletion.

**Verification Results:**
- Local unit tests in `server` and `client` pass.
- Client builds successfully.
- Manually verified via local scripts that initializing and inserting nodes outside the transaction prevents the crash and correctly populates the YTree structure.

---
*PR created automatically by Jules for task [8840376894638356545](https://jules.google.com/task/8840376894638356545) started by @kitamura-tetsuo*