### PR TITLE
chore: disable no-restricted-globals in CMD-0001.spec.ts

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -213,4 +213,10 @@ export default ts.config(
             "no-restricted-globals": "off", // Allow internal store access in helpers
         },
     },
+    {
+        files: ["e2e/new/CMD-0001.spec.ts"],
+        rules: {
+            "no-restricted-globals": "off",
+        },
+    },
 );


### PR DESCRIPTION
**Issues**
- ESLint was raising dozens of `no-restricted-globals` warnings in `client/e2e/new/CMD-0001.spec.ts` because Playwright E2E tests often need to interact with `window` and global stores (like `generalStore`) via `page.evaluate()` to check internal application state.
- Attempting to suppress these warnings with inline directives caused formatting issues and churn within the test file, polluting the code and disrupting automated linters.

**Changes**
- Modified `client/eslint.config.js` to explicitly disable the `no-restricted-globals` rule for the specific file `e2e/new/CMD-0001.spec.ts`, satisfying the requirement to use targeted overrides rather than global downgrades when fixing structural lint issues is unfeasible.

**Verification Results**
- Executed `cd client && npx eslint e2e/new/CMD-0001.spec.ts`, which now correctly passes with zero warnings.
- Executed the full client unit test suite (`npm run test:unit`) and the client build (`npm run build`), which all passed successfully, ensuring no regressions were introduced.

---
*PR created automatically by Jules for task [11634394872515475709](https://jules.google.com/task/11634394872515475709) started by @kitamura-tetsuo*