### PR TITLE
fix(server): resolve TS5011 build error introduced by TypeScript 6 upgrade

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2020",
         "module": "Node16",
         "outDir": "./dist",
+        "rootDir": "./src",
         "strict": true,
         "esModuleInterop": true,
         "skipLibCheck": true,


### PR DESCRIPTION
[Issues]
- The Dependabot PR #3069 updating TypeScript from `5.9.3` to `6.0.3` inside `/server` failed in CI.
- The `tsc` build step generated a `TS5011: The common source directory of 'tsconfig.json' is './src'. The 'rootDir' setting must be explicitly set to this or another path` error. This occurs because TS 6.0 enforces strict `rootDir` declarations when multiple input paths are included (e.g. `src/**/*` and `types/**/*.d.ts`).

[Changes]
- Added `"rootDir": "./src"` inside `compilerOptions` of `/server/tsconfig.json`.

[Verification Results]
- `cd server && npm run build` successfully finishes and generates the `dist` directory.
- `cd server && npm run test` passes all tests.

---
*PR created automatically by Jules for task [10644438512345606653](https://jules.google.com/task/10644438512345606653) started by @kitamura-tetsuo*